### PR TITLE
Use relative paths to load JS and to indicate the test name

### DIFF
--- a/tests-web/assets/js/main.js
+++ b/tests-web/assets/js/main.js
@@ -10,9 +10,11 @@ const useMap = (map) => {
     map.openTest = makeOpenTest(map)
     console.info("New map created! File drops enabled.", container);
 
-    const path = window.location.pathname.split('/');
-    if (path[1] === 't') {
-        const test = path[2];
+
+    // Here we read the test name from the URL.
+    const q = new URLSearchParams(window.location.search);
+    if (q.has('test')) {
+        const test = q.get('test');
         console.info("Loading test " + test + " from URL.");
         map.openTest(test);
     }

--- a/tests-web/assets/js/tests.js
+++ b/tests-web/assets/js/tests.js
@@ -2,7 +2,7 @@ import { makeOsmLayer, makeJsonLayer, makeDotLayer  } from './layers.js';
 
 /** Load and display all the files associated with a test case. */
 export const makeOpenTest = (map) => async (name) => {
-    const prefix = `/src/${name}/`;
+    const prefix = `src/${name}/`;
     const input = loadFile(prefix + 'input.osm');
     const rawMap = loadFile(prefix + 'raw_map.json');
     const network = loadFile(prefix + 'road_network.dot');
@@ -49,7 +49,8 @@ export const loadTests = async () => {
     for (const t of testNames) {
         const li = listNode.appendChild(window.document.createElement('li'));
         const a = li.appendChild(window.document.createElement('a'));
-        a.href = '/t/' + t;
+        // Here we encode the test name in the URL to be read elsewhere.
+        a.href = '?test=' + t;
         a.innerHTML = t;
     }
 }

--- a/tests-web/index.html
+++ b/tests-web/index.html
@@ -19,8 +19,8 @@
     <script src="https://unpkg.com/d3-graphviz@4.1.1/build/d3-graphviz.js" crossorigin></script>
 
     <link data-trunk rel="copy-dir" href="./assets/js" />
-    <script type="module" src="/js/leaflet-osm.js"></script>
-    <script type="module" src="/js/main.js"></script>
+    <script type="module" src="js/leaflet-osm.js"></script>
+    <script type="module" src="js/main.js"></script>
 
     <link data-trunk rel="copy-dir" href="../tests/src" />
 </head>


### PR DESCRIPTION
Hopefully closes #35

I have only tested via `trunk serve`, but I'll merge this in in order to test the version deployed to [github.io](https://a-b-street.github.io/osm2streets/)...