### PR TITLE
Optionally show intermediate transformation steps and debug data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "abstutil"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/abstreet#fb39e716889b903cf6b57490b2e048bcba3bf262"
+source = "git+https://github.com/a-b-street/abstreet#e51ebb970a4c8dbe9cf03198933451fcd338e497"
 dependencies = [
  "anyhow",
  "bincode",
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/abstreet#fb39e716889b903cf6b57490b2e048bcba3bf262"
+source = "git+https://github.com/a-b-street/abstreet#e51ebb970a4c8dbe9cf03198933451fcd338e497"
 dependencies = [
  "aabb-quadtree",
  "abstutil",

--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 #[derive(Serialize, Deserialize)]
 pub struct ImportOptions {
     driving_side: street_network::DrivingSide,
+    debug_each_step: bool,
 }
 
 #[wasm_bindgen]

--- a/street_network/src/render.rs
+++ b/street_network/src/render.rs
@@ -6,7 +6,7 @@ use abstutil::Timer;
 use anyhow::Result;
 use geom::Distance;
 
-use crate::StreetNetwork;
+use crate::{DebugStreets, StreetNetwork};
 
 impl StreetNetwork {
     /// Saves the plain GeoJSON rendering to a file.
@@ -118,6 +118,30 @@ impl StreetNetwork {
         let obj = geom::geometries_with_properties_to_geojson(pairs);
         let output = serde_json::to_string_pretty(&obj)?;
         Ok(output)
+    }
+}
+
+impl DebugStreets {
+    /// None if there's nothing labelled
+    pub fn to_debug_geojson(&self) -> Option<String> {
+        let mut pairs = Vec::new();
+        for (pt, label) in &self.points {
+            pairs.push((
+                pt.to_geojson(Some(&self.streets.gps_bounds)),
+                make_props(&[("label", label.to_string().into())]),
+            ));
+        }
+        for (pl, label) in &self.polylines {
+            pairs.push((
+                pl.to_geojson(Some(&self.streets.gps_bounds)),
+                make_props(&[("label", label.to_string().into())]),
+            ));
+        }
+        if pairs.is_empty() {
+            return None;
+        }
+        let obj = geom::geometries_with_properties_to_geojson(pairs);
+        Some(serde_json::to_string_pretty(&obj).unwrap())
     }
 }
 

--- a/street_network/src/transform/mod.rs
+++ b/street_network/src/transform/mod.rs
@@ -135,22 +135,24 @@ impl StreetNetwork {
         timer.stop("simplify StreetNetwork");
     }
 
-    /// Apply a sequence of transformations, but also return a copy of the `StreetNetwork` before
-    /// each step.
+    /// Apply a sequence of transformations, but also save a copy of the `StreetNetwork` before
+    /// each step. Some steps may also internally add debugging info.
     pub fn apply_transformations_stepwise_debugging(
         &mut self,
         transformations: Vec<Transformation>,
         timer: &mut Timer,
-    ) -> Vec<(String, Self)> {
-        let mut debug = vec![("original".to_string(), self.clone())];
+    ) {
+        self.debug_steps
+            .borrow_mut()
+            .push(self.copy_for_debugging("original"));
 
         timer.start("simplify StreetNetwork");
         for transformation in transformations {
             transformation.apply(self, timer);
-            debug.push((transformation.name().to_string(), self.clone()));
+            self.debug_steps
+                .borrow_mut()
+                .push(self.copy_for_debugging(transformation.name()));
         }
         timer.stop("simplify StreetNetwork");
-
-        debug
     }
 }

--- a/street_network/src/transform/sausage_links.rs
+++ b/street_network/src/transform/sausage_links.rs
@@ -8,6 +8,11 @@ use crate::{
 /// Collapse them into one road with a barrier in the middle.
 pub fn collapse_sausage_links(streets: &mut StreetNetwork) {
     for (id1, id2) in find_sausage_links(streets) {
+        // TODO Temporarily demonstrate debugging by labelling some things. Remove after checking
+        // in a transformation that actually needs this.
+        streets.debug_road(id1.clone(), "one side of sausage link");
+        streets.debug_intersection(id1.i2, "one endpoint of sausage link");
+
         fix(streets, id1, id2);
     }
 }

--- a/tests-web/www/js/layers.js
+++ b/tests-web/www/js/layers.js
@@ -77,6 +77,14 @@ export const makeDotLayer = async (text, { bounds }) => {
   });
 };
 
+export const makeDebugLayer = (text) => {
+  return new L.geoJSON(JSON.parse(text), {
+    onEachFeature: function (feature, layer) {
+      layer.bindTooltip(feature.properties.label, { permanent: true });
+    },
+  });
+};
+
 export const layerMakers = {
   json: makePlainGeoJsonLayer,
   osm: makeOsmLayer,

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -11,6 +11,7 @@ import {
   makePlainGeoJsonLayer,
   makeDetailedGeoJsonLayer,
   makeDotLayer,
+  makeDebugLayer,
 } from "./layers.js";
 import init, { JsStreetNetwork } from "./osm2streets-js/osm2streets_js.js";
 
@@ -162,6 +163,23 @@ class TestCase {
           await makeDotLayer(network.toGraphviz(), { bounds })
         )
       );*/
+      for (const step of network.getDebugSteps()) {
+        layers.push(
+          app.addLayer(
+            `${step.getLabel()}: geometry`,
+            makePlainGeoJsonLayer(step.getNetwork().toGeojsonPlain())
+          )
+        );
+        const debugGeojson = step.toDebugGeojson();
+        if (debugGeojson) {
+          layers.push(
+            app.addLayer(
+              `${step.getLabel()}: debug`,
+              makeDebugLayer(debugGeojson)
+            )
+          );
+        }
+      }
 
       return new TestCase(app, null, osmInput, drivingSide, layers, bounds);
     } catch (err) {
@@ -185,8 +203,11 @@ class TestCase {
       button.type = "button";
       button.innerHTML = "Reimport";
       button.onclick = async () => {
-        // It doesn't make sense to ever reimport twice; that would only add redundant layers
-        button.disabled = true;
+        // TODO Allow reimporting to happen multiple times, since
+        // transformation settings could change. This will add redundant
+        // layers right now. Once we have better layer management, we
+        // should be able to erase all of the layers from the previous
+        // reimport.
         await this.reimport();
       };
 
@@ -233,6 +254,23 @@ class TestCase {
           await makeDotLayer(network.toGraphviz(), { bounds: this.bounds })
         )
       );*/
+      for (const step of network.getDebugSteps()) {
+        this.layers.push(
+          this.app.addLayer(
+            `${step.getLabel()}: geometry`,
+            makePlainGeoJsonLayer(step.getNetwork().toGeojsonPlain())
+          )
+        );
+        const debugGeojson = step.toDebugGeojson();
+        if (debugGeojson) {
+          this.layers.push(
+            this.app.addLayer(
+              `${step.getLabel()}: debug`,
+              makeDebugLayer(debugGeojson)
+            )
+          );
+        }
+      }
     } catch (err) {
       window.alert(`Reimport failed: ${err}`);
     }

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -21,6 +21,9 @@ export class StreetExplorer {
     this.map = setupLeafletMap(mapContainer);
     this.layerControl = L.control.layers({}, {}).addTo(this.map);
     this.currentTest = null;
+    this.importSettings = {
+      debugEachStep: false,
+    };
 
     // Add all tests to the sidebar
     loadTests();
@@ -138,6 +141,7 @@ class TestCase {
 
       const network = new JsStreetNetwork(osmInput, {
         driving_side: drivingSide,
+        debug_each_step: app.importSettings.debugEachStep,
       });
       const rawMapLayer = makePlainGeoJsonLayer(network.toGeojsonPlain());
       const bounds = rawMapLayer.getBounds();
@@ -185,6 +189,15 @@ class TestCase {
         button.disabled = true;
         await this.reimport();
       };
+
+      const settings = container.appendChild(document.createElement("button"));
+      settings.id = "settingsButton";
+      settings.type = "button";
+      settings.innerHTML = "(Settings)";
+      settings.onclick = () => {
+        settings.disabled = true;
+        makeSettingsControl(app).addTo(app.map);
+      };
     } else {
       container.innerHTML = `<b>Custom imported view</b>`;
     }
@@ -200,6 +213,7 @@ class TestCase {
     try {
       const network = new JsStreetNetwork(this.osmXML, {
         driving_side: this.drivingSide,
+        debug_each_step: this.app.importSettings.debugEachStep,
       });
       this.layers.push(
         this.app.addLayer(
@@ -226,7 +240,13 @@ class TestCase {
 }
 
 function setupLeafletMap(mapContainer) {
-  const map = L.map(mapContainer, { maxZoom: 21 }).setView([40.0, 10.0], 4);
+  // Make it smoother to zoom farther into the map
+  const map = L.map(mapContainer, {
+    maxZoom: 21,
+    zoomSnap: 0.5,
+    zoomDelta: 0.5,
+    wheelPxPerZoomLevel: 120,
+  }).setView([40.0, 10.0], 4);
   L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
     maxNativeZoom: 18,
     maxZoom: 21,
@@ -250,4 +270,49 @@ const useMap = (map) => {
   map.loadLink = makeLinkHandler(map);
   map.openTest = makeOpenTest(map);
   console.info("New map created! File drops enabled.", container);
+};
+
+// TODO A Leaflet control isn't the right abstraction. We want a popup modal
+// that totally blocks the map and other things. Things like disabling
+// settingsButton to stop multiple of these controls is a total hack.
+const SettingsControl = L.Control.extend({
+  // TODO Centered would be great. https://github.com/Leaflet/Leaflet/issues/8358
+  options: {
+    position: "topleft",
+  },
+  onAdd: function (map) {
+    var checkbox = L.DomUtil.create("input");
+    checkbox.id = "debugEachStep";
+    checkbox.type = "checkbox";
+    if (this.options.app.importSettings.debugEachStep) {
+      checkbox.checked = true;
+    }
+    checkbox.onclick = () => {
+      this.options.app.importSettings.debugEachStep = checkbox.checked;
+    };
+
+    var label = L.DomUtil.create("label");
+    label.for = "debugEachStep";
+    label.innerText = "Debug each transformation step";
+
+    const button = L.DomUtil.create("button");
+    button.type = "button";
+    button.innerHTML = "Confirm";
+    button.onclick = () => {
+      this.remove();
+      document.getElementById("settingsButton").disabled = false;
+    };
+
+    var group = L.DomUtil.create("div");
+    group.style = "background: black; padding: 10px;";
+    group.appendChild(checkbox);
+    group.appendChild(label);
+    group.appendChild(button);
+
+    return group;
+  },
+});
+
+const makeSettingsControl = function (app) {
+  return new SettingsControl({ app: app });
 };


### PR DESCRIPTION

https://user-images.githubusercontent.com/1664407/183407689-c250bbc1-3cff-4f45-8f26-2f95160d7822.mp4

There's now a setting for imports. When enabled, we take a full copy of the `StreetNetwork` in between each transformation, and add it as a layer. Within transformations, we can also label points or lines for more explanation or debugging.

The way it works is a bit clunky, but usable. My next steps:

1) add the first part of a complicated dual carriageway algorithm, where I make extensive use of the debugging
2) work on some controls for managing all the layers. I think we want groups: original / built-in test data; the final reimport; each step of a transformation. For the last, arrow controls to scroll between them will be vital.