### PR TITLE
Start detecting a certain pattern of dual carriageways, labelling the

### DIFF
--- a/street_network/src/lib.rs
+++ b/street_network/src/lib.rs
@@ -136,6 +136,16 @@ impl OriginalRoad {
         }
         panic!("{:?} and {:?} have no common_endpt", self, other);
     }
+
+    pub fn other_side(&self, i: osm::NodeID) -> osm::NodeID {
+        if self.i1 == i {
+            self.i2
+        } else if self.i2 == i {
+            self.i1
+        } else {
+            panic!("{} doesn't have {} on either side", self, i);
+        }
+    }
 }
 
 impl StreetNetwork {

--- a/street_network/src/transform/dual_carriageways.rs
+++ b/street_network/src/transform/dual_carriageways.rs
@@ -1,55 +1,350 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+use geom::Distance;
 
 use crate::{osm, OriginalRoad, StreetNetwork};
 
-/// Does this road go between two divided one-ways? Ideally they're tagged explicitly
-/// (https://wiki.openstreetmap.org/wiki/Tag:dual_carriageway%3Dyes), but we can also apply simple
-/// heuristics to guess this.
-#[allow(unused)]
-pub fn connects_dual_carriageway(streets: &StreetNetwork, id: &OriginalRoad) -> bool {
-    let connectors_angle = streets.roads[id].angle();
-    // There are false positives like https://www.openstreetmap.org/way/4636259 when we're looking
-    // at a segment along a marked dual carriageway. Filter out by requiring the intersecting dual
-    // carriageways to differ by a minimum angle.
-    let within_degrees = 10.0;
-
-    let mut i1_dual_carriageway = false;
-    let mut oneway_names_i1: BTreeSet<String> = BTreeSet::new();
-    for r in streets.roads_per_intersection(id.i1) {
-        let road = &streets.roads[&r];
-        if r == *id || connectors_angle.approx_eq(road.angle(), within_degrees) {
-            continue;
-        }
-        if road.osm_tags.is("dual_carriageway", "yes") {
-            i1_dual_carriageway = true;
-        }
-        if road.oneway_for_driving().is_some() {
-            if let Some(name) = road.osm_tags.get(osm::NAME) {
-                oneway_names_i1.insert(name.to_string());
+pub fn merge(streets: &mut StreetNetwork) {
+    for i in streets.intersections.keys() {
+        // Progressively detect more stuff. Display the most detail possible.
+        if let Some(mc) = MultiConnection::new(streets, *i) {
+            // TODO Ignore opposite direction of one we've already found?
+            if let Some(dc1) = DualCarriagewayPt1::new(streets, &mc) {
+                if let Some(dc2) = DualCarriagewayPt2::new(streets, &dc1) {
+                    dc2.debug(streets);
+                } else {
+                    dc1.debug(streets);
+                }
+            } else {
+                mc.debug(streets);
             }
+
+            // TODO Just work on one right now
+            break;
+        }
+    }
+}
+
+// TODO We should do this in classify_intersections.rs?
+// Step 1: just find where dual carriageways start or end
+struct MultiConnection {
+    i: osm::NodeID,
+    side1: OriginalRoad,
+    side2: OriginalRoad,
+    road_name: String,
+}
+
+impl MultiConnection {
+    fn new(streets: &StreetNetwork, i: osm::NodeID) -> Option<Self> {
+        let roads = streets.roads_per_intersection(i);
+        if roads.len() < 3 {
+            return None;
+        }
+
+        // First group roads by name.
+        let mut roads_by_name: BTreeMap<String, Vec<OriginalRoad>> = BTreeMap::new();
+        for r in roads {
+            let road = &streets.roads[&r];
+            // Skip unnamed roads for now
+            if let Some(name) = road.osm_tags.get(osm::NAME) {
+                roads_by_name
+                    .entry(name.clone())
+                    .or_insert_with(Vec::new)
+                    .push(r);
+            }
+        }
+
+        // Look for a group of 3. Two should be one-way for driving, the other shouldn't.
+        for (road_name, groups) in roads_by_name {
+            if groups.len() != 3 {
+                continue;
+            }
+            let mut oneway_roads = Vec::new();
+            let mut bidi_roads = Vec::new();
+            for r in groups {
+                if streets.roads[&r].oneway_for_driving().is_some() {
+                    oneway_roads.push(r);
+                } else {
+                    bidi_roads.push(r);
+                }
+            }
+
+            if oneway_roads.len() != 2 || bidi_roads.len() != 1 {
+                continue;
+            }
+
+            // Preserving notes about old detection:
+            // - look for dual_carriageway=yes tag, but since it's rarely there, maybe just use as an "opt
+            //   in" technique
+            // - make sure the 2 oneway roads are within 10 degrees of the bidi road?
+            // - The two one-ways should point at each other
+            // - Maybe one intersection could be a MultiConnection for two roads? For now just take one.
+
+            return Some(Self {
+                i,
+                side1: oneway_roads.remove(0),
+                side2: oneway_roads.remove(0),
+                road_name,
+            });
+        }
+
+        None
+    }
+
+    fn debug(&self, streets: &StreetNetwork) {
+        streets.debug_intersection(self.i, "join/split that isnt DC");
+        streets.debug_road(self.side1, "side1 of failed DC");
+        streets.debug_road(self.side2, "side2 of failed DC");
+    }
+}
+
+// Step 2: trace both sequences of one-ways between the intersections where a dual carriageway
+// splits/rejoins
+struct DualCarriagewayPt1 {
+    road_name: String,
+    i1: osm::NodeID,
+    i2: osm::NodeID,
+    // side1 points from i1 to i2
+    side1: Vec<OriginalRoad>,
+    // side2 points from i2 to i1
+    side2: Vec<OriginalRoad>,
+}
+
+impl DualCarriagewayPt1 {
+    fn new(streets: &StreetNetwork, mc: &MultiConnection) -> Option<Self> {
+        let (side1, i2_v1) = Self::trace_side(streets, &mc.side1, mc.i, &mc.road_name)?;
+        let (side2, i2_v2) = Self::trace_side(streets, &mc.side2, mc.i, &mc.road_name)?;
+
+        // TODO Something very odd has happened. Make a new copy of the map for debugging and label
+        // the strangeness.
+        if i2_v1 != i2_v2 {
+            return None;
+        }
+
+        let mut side1 = Self::orient_oneways(side1)?;
+        let mut side2 = Self::orient_oneways(side2)?;
+
+        // Which one goes from i1->i2?
+        let i1 = mc.i;
+        let i2 = i2_v1;
+        for swap in [false, true] {
+            if swap {
+                std::mem::swap(&mut side1, &mut side2);
+            }
+            let side1_endpts = (side1[0].i1, side1.last().as_ref().unwrap().i2);
+            let side2_endpts = (side2[0].i1, side2.last().as_ref().unwrap().i2);
+
+            if side1_endpts == (i1, i2) {
+                if side2_endpts != (i2, i1) {
+                    // Why doesn't the other side point the opposite way?
+                    return None;
+                }
+                return Some(Self {
+                    road_name: mc.road_name.clone(),
+                    i1,
+                    i2,
+                    side1,
+                    side2,
+                });
+            }
+        }
+        None
+    }
+
+    fn debug(&self, streets: &StreetNetwork) {
+        streets.debug_intersection(self.i1, format!("start of {}", self.road_name));
+        streets.debug_intersection(self.i2, "end");
+        for (idx, r) in self.side1.iter().enumerate() {
+            streets.debug_road(*r, format!("side1, {}", idx));
+        }
+        for (idx, r) in self.side2.iter().enumerate() {
+            streets.debug_road(*r, format!("side2, {}", idx));
         }
     }
 
-    let mut i2_dual_carriageway = false;
-    let mut oneway_names_i2: BTreeSet<String> = BTreeSet::new();
-    for r in streets.roads_per_intersection(id.i2) {
-        let road = &streets.roads[&r];
-        if r == *id || connectors_angle.approx_eq(road.angle(), within_degrees) {
-            continue;
-        }
-        if road.osm_tags.is("dual_carriageway", "yes") {
-            i2_dual_carriageway = true;
-        }
-        if road.oneway_for_driving().is_some() {
-            if let Some(name) = road.osm_tags.get(osm::NAME) {
-                oneway_names_i2.insert(name.to_string());
+    // Chase a one-way while the road name stays the same. Also returns the last intersection
+    // found, where the one-ways end.
+    fn trace_side(
+        streets: &StreetNetwork,
+        start: &OriginalRoad,
+        join: osm::NodeID,
+        road_name: &str,
+    ) -> Option<(Vec<OriginalRoad>, osm::NodeID)> {
+        let mut sequence = vec![start.clone()];
+
+        let mut current = start.clone();
+        let mut last_i = join;
+        'LOOP: loop {
+            let other_side = current.other_side(last_i);
+            for r in streets.roads_per_intersection(other_side) {
+                // TODO Helper method to just find roads originating at other_side and pointing
+                // away (or towards) something?
+                if r == current {
+                    continue;
+                }
+                let road = &streets.roads[&r];
+                if road.osm_tags.is(osm::NAME, road_name) {
+                    if road.oneway_for_driving().is_some() {
+                        current = r.clone();
+                        sequence.push(r);
+                        last_i = other_side;
+                        continue 'LOOP;
+                    }
+                    // We found the bidirectional piece. Assume it's the other end.
+                    return Some((sequence, other_side));
+                }
             }
+            // We didn't find a next step?
+            return None;
         }
     }
 
-    (i1_dual_carriageway && i2_dual_carriageway)
-        || oneway_names_i1
-            .intersection(&oneway_names_i2)
-            .next()
-            .is_some()
+    // The input should already be ordered so that the first road points at the second, or reversed
+    // relative to the way the one-ways are defined. Flip the order if needed.
+    fn orient_oneways(mut seq: Vec<OriginalRoad>) -> Option<Vec<OriginalRoad>> {
+        for reverse in [false, true] {
+            if reverse {
+                seq.reverse();
+            }
+            if seq.windows(2).all(|pair| pair[0].i2 == pair[1].i1) {
+                return Some(seq);
+            }
+        }
+        // The input was broken somehow
+        return None;
+    }
+}
+
+// Step 3: find "branch" roads that lead away from either side, and "bridge" roads linking the two
+// sides
+struct DualCarriagewayPt2 {
+    road_name: String,
+    i1: osm::NodeID,
+    i2: osm::NodeID,
+    // side1 points from i1 to i2
+    side1: Vec<OriginalRoad>,
+    // side2 points from i2 to i1
+    side2: Vec<OriginalRoad>,
+
+    // The branches also track the linear untrimmed distance from the beginning of the side
+    side1_branches: Vec<(OriginalRoad, Distance)>,
+    side2_branches: Vec<(OriginalRoad, Distance)>,
+    // The linear untrimmed distance is relative to side1 (i1 -> i2). Only bridges consisting of a
+    // single OriginalRoad are detected; no multi-step ones yet.
+    bridges: Vec<(OriginalRoad, Distance)>,
+
+    side1_length: Distance,
+    side2_length: Distance,
+}
+
+impl DualCarriagewayPt2 {
+    fn new(streets: &StreetNetwork, orig: &DualCarriagewayPt1) -> Option<Self> {
+        // Only calculate bridges relative to side1
+        let (side1_branches, bridges) = Self::find_branches_and_bridges(
+            streets,
+            &orig.side1,
+            Self::side_to_intersections(&orig.side2),
+        );
+        let (side2_branches, _) = Self::find_branches_and_bridges(
+            streets,
+            &orig.side2,
+            Self::side_to_intersections(&orig.side1),
+        );
+
+        Some(Self {
+            road_name: orig.road_name.clone(),
+            i1: orig.i1,
+            i2: orig.i2,
+            side1: orig.side1.clone(),
+            side2: orig.side2.clone(),
+
+            side1_branches,
+            side2_branches,
+            bridges,
+
+            side1_length: orig
+                .side1
+                .iter()
+                .map(|r| streets.roads[r].untrimmed_road_geometry().0.length())
+                .sum(),
+            side2_length: orig
+                .side2
+                .iter()
+                .map(|r| streets.roads[r].untrimmed_road_geometry().0.length())
+                .sum(),
+        })
+    }
+
+    fn side_to_intersections(side: &Vec<OriginalRoad>) -> BTreeSet<osm::NodeID> {
+        let mut set = BTreeSet::new();
+        for r in side {
+            set.insert(r.i1);
+            set.insert(r.i2);
+        }
+        set
+    }
+
+    // TODO The types are getting gross. Returns (branches, bridges).
+    fn find_branches_and_bridges(
+        streets: &StreetNetwork,
+        side: &Vec<OriginalRoad>,
+        other_side_intersections: BTreeSet<osm::NodeID>,
+    ) -> (Vec<(OriginalRoad, Distance)>, Vec<(OriginalRoad, Distance)>) {
+        let mut branches = Vec::new();
+        let mut bridges = Vec::new();
+        let mut dist = Distance::ZERO;
+
+        for pair in side.windows(2) {
+            dist += streets.roads[&pair[0]].untrimmed_road_geometry().0.length();
+            let i = pair[0].i2;
+            for r in streets.roads_per_intersection(i) {
+                if r == pair[0] || r == pair[1] {
+                    continue;
+                }
+                // It's a branch or a bridge. Is the intersection it connects to part of the other
+                // side or not?
+                if other_side_intersections.contains(&r.other_side(i)) {
+                    bridges.push((r, dist));
+                } else {
+                    branches.push((r, dist));
+                }
+            }
+        }
+
+        (branches, bridges)
+    }
+
+    fn debug(&self, streets: &StreetNetwork) {
+        streets.debug_intersection(self.i1, format!("start of {}", self.road_name));
+        streets.debug_intersection(self.i2, "end");
+        for (idx, r) in self.side1.iter().enumerate() {
+            if idx == 0 {
+                streets.debug_road(
+                    *r,
+                    format!("side1, {}, total length {}", idx, self.side1_length),
+                );
+            } else {
+                streets.debug_road(*r, format!("side1, {}", idx));
+            }
+        }
+        for (idx, r) in self.side2.iter().enumerate() {
+            if idx == 0 {
+                streets.debug_road(
+                    *r,
+                    format!("side2, {}, total length {}", idx, self.side2_length),
+                );
+            } else {
+                streets.debug_road(*r, format!("side2, {}", idx));
+            }
+        }
+        for (r, dist) in &self.side1_branches {
+            streets.debug_road(*r, format!("side1 branch, {dist} from i1"));
+        }
+        for (r, dist) in &self.side2_branches {
+            streets.debug_road(*r, format!("side2 branch, {dist} from i2"));
+        }
+        for (r, dist) in &self.bridges {
+            streets.debug_road(*r, format!("bridge, {dist} from i1"));
+        }
+    }
 }

--- a/street_network/src/transform/mod.rs
+++ b/street_network/src/transform/mod.rs
@@ -24,6 +24,7 @@ pub enum Transformation {
     CollapseDegenerateIntersections,
     CollapseSausageLinks,
     ShrinkOverlappingRoads,
+    MergeDualCarriageways,
 }
 
 impl Transformation {
@@ -82,6 +83,7 @@ impl Transformation {
             Transformation::CollapseDegenerateIntersections => "collapse degenerate intersections",
             Transformation::CollapseSausageLinks => "collapse sausage links",
             Transformation::ShrinkOverlappingRoads => "shrink overlapping roads",
+            Transformation::MergeDualCarriageways => "merge dual carriageways",
         }
     }
 
@@ -116,6 +118,9 @@ impl Transformation {
             }
             Transformation::ShrinkOverlappingRoads => {
                 shrink_roads::shrink(streets, timer);
+            }
+            Transformation::MergeDualCarriageways => {
+                dual_carriageways::merge(streets);
             }
         }
         timer.stop(self.name());

--- a/street_network/src/transform/sausage_links.rs
+++ b/street_network/src/transform/sausage_links.rs
@@ -8,11 +8,6 @@ use crate::{
 /// Collapse them into one road with a barrier in the middle.
 pub fn collapse_sausage_links(streets: &mut StreetNetwork) {
     for (id1, id2) in find_sausage_links(streets) {
-        // TODO Temporarily demonstrate debugging by labelling some things. Remove after checking
-        // in a transformation that actually needs this.
-        streets.debug_road(id1.clone(), "one side of sausage link");
-        streets.debug_intersection(id1.i2, "one endpoint of sausage link");
-
         fix(streets, id1, id2);
     }
 }

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -24,6 +24,7 @@ export class StreetExplorer {
     this.currentTest = null;
     this.importSettings = {
       debugEachStep: false,
+      dualCarriagewayExperiment: false,
     };
 
     // Add all tests to the sidebar
@@ -143,6 +144,8 @@ class TestCase {
       const network = new JsStreetNetwork(osmInput, {
         driving_side: drivingSide,
         debug_each_step: app.importSettings.debugEachStep,
+        dual_carriageway_experiment:
+          app.importSettings.dualCarriagewayExperiment,
       });
       const rawMapLayer = makePlainGeoJsonLayer(network.toGeojsonPlain());
       const bounds = rawMapLayer.getBounds();
@@ -235,6 +238,8 @@ class TestCase {
       const network = new JsStreetNetwork(this.osmXML, {
         driving_side: this.drivingSide,
         debug_each_step: this.app.importSettings.debugEachStep,
+        dual_carriageway_experiment:
+          app.importSettings.dualCarriagewayExperiment,
       });
       this.layers.push(
         this.app.addLayer(
@@ -319,19 +324,34 @@ const SettingsControl = L.Control.extend({
     position: "topleft",
   },
   onAdd: function (map) {
-    var checkbox = L.DomUtil.create("input");
-    checkbox.id = "debugEachStep";
-    checkbox.type = "checkbox";
+    var checkbox1 = L.DomUtil.create("input");
+    checkbox1.id = "debugEachStep";
+    checkbox1.type = "checkbox";
     if (this.options.app.importSettings.debugEachStep) {
-      checkbox.checked = true;
+      checkbox1.checked = true;
     }
-    checkbox.onclick = () => {
-      this.options.app.importSettings.debugEachStep = checkbox.checked;
+    checkbox1.onclick = () => {
+      this.options.app.importSettings.debugEachStep = checkbox1.checked;
     };
 
-    var label = L.DomUtil.create("label");
-    label.for = "debugEachStep";
-    label.innerText = "Debug each transformation step";
+    var label1 = L.DomUtil.create("label");
+    label1.for = "debugEachStep";
+    label1.innerText = "Debug each transformation step\n";
+
+    var checkbox2 = L.DomUtil.create("input");
+    checkbox2.id = "dualCarriagewayExperiment";
+    checkbox2.type = "checkbox";
+    if (this.options.app.importSettings.dualCarriagewayExperiment) {
+      checkbox2.checked = true;
+    }
+    checkbox2.onclick = () => {
+      this.options.app.importSettings.dualCarriagewayExperiment =
+        checkbox2.checked;
+    };
+
+    var label2 = L.DomUtil.create("label");
+    label2.for = "dualCarriagewayExperiment";
+    label2.innerText = "Enable dual carriageway experiment\n";
 
     const button = L.DomUtil.create("button");
     button.type = "button";
@@ -343,9 +363,9 @@ const SettingsControl = L.Control.extend({
 
     var group = L.DomUtil.create("div");
     group.style = "background: black; padding: 10px;";
-    group.appendChild(checkbox);
-    group.appendChild(label);
-    group.appendChild(button);
+    for (const x of [checkbox1, label1, checkbox2, label2, button]) {
+      group.appendChild(x);
+    }
 
     return group;
   },


### PR DESCRIPTION
parts for later transformation.

This is an experiment disabled by default; it doesn't yet even correctly
detect every test case.


https://user-images.githubusercontent.com/1664407/183421293-ce165d54-eb6a-48b4-8955-39354d883b62.mp4

Alright, this PR gets interesting. I added a new test case, `northgate_dual_carriageway`, that nicely exhibits lots of complexities of a dual carriageway (DC). This PR starts to pattern match it and label parts of the structure:

- the two intersections where the DC starts or ends. I believe this matches the concept of `MultiConnection`
- each side of the DC, expressed as a sequence of one-way roads pointing in a chain
- "bridge" roads leading between the two sides
- "branch" roads leading from one side to somewhere else

What I'll attempt to do next is to put all of the intersections on each side, the branches, and the bridges in a "linear" order, "zipping" the two sides together. There'll be some way to figure out which pairs of roads from both sides should get zipped together, with their lanes merged. Not sure how/if it'll work yet!

The detection in this PR isn't robust; it picks up one example in northgate, but doesn't even find all of the examples there. So it's disabled by default. I want to get one example working end-to-end, then make things more robust gradually.