### PR TITLE
Add two new GeoJSON layers to render more lane detail. #24

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -57,10 +57,17 @@ impl JsStreetNetwork {
         self.inner.to_geojson(&mut Timer::throwaway()).unwrap()
     }
 
-    #[wasm_bindgen(js_name = toGeojsonDetailed)]
-    pub fn to_geojson_detailed(&self) -> String {
+    #[wasm_bindgen(js_name = toLanePolygonsGeojson)]
+    pub fn to_lane_polygons_geojson(&self) -> String {
         self.inner
-            .to_detailed_geojson(&mut Timer::throwaway())
+            .to_lane_polygons_geojson(&mut Timer::throwaway())
+            .unwrap()
+    }
+
+    #[wasm_bindgen(js_name = toLaneMarkingsGeojson)]
+    pub fn to_lane_markings_geojson(&self) -> String {
+        self.inner
+            .to_lane_markings_geojson(&mut Timer::throwaway())
             .unwrap()
     }
 

--- a/street_network/src/lib.rs
+++ b/street_network/src/lib.rs
@@ -501,6 +501,30 @@ impl RawRoad {
             self.osm_tags.get(osm::OSM_WAY_ID).unwrap()
         )
     }
+
+    pub fn total_width(&self) -> Distance {
+        self.lane_specs_ltr.iter().map(|l| l.width).sum()
+    }
+
+    /// Returns one PolyLine representing the center of each lane in this road. Pass in
+    /// `road_center` generated from `InitialMap` (trimmed from the intersection) or from
+    /// `osm_center_points`. The result also faces the same direction as the road.
+    pub fn get_lane_center_lines(&self, road_center: &PolyLine) -> Vec<PolyLine> {
+        let total_width = self.total_width();
+
+        let mut width_so_far = Distance::ZERO;
+        let mut output = Vec::new();
+        for lane in &self.lane_specs_ltr {
+            width_so_far += lane.width / 2.0;
+            output.push(
+                road_center
+                    .shift_from_center(total_width, width_so_far)
+                    .unwrap_or_else(|_| road_center.clone()),
+            );
+            width_so_far += lane.width / 2.0;
+        }
+        output
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/tests-web/www/js/layers.js
+++ b/tests-web/www/js/layers.js
@@ -1,49 +1,70 @@
 export const makePlainGeoJsonLayer = (text) => {
-  return new L.geoJSON(JSON.parse(text), { style: styleGeoJson });
-};
+  const intersectionColours = {
+    undefined: "#666", // for default tarmac
+    Connection: "#666",
+    MultiConnection: "#669",
+    Merge: "#969",
+    Crossing: "#966",
+    Terminus: "#999",
+    MapEdge: "#696",
+  };
 
-const intersectionColours = {
-  undefined: "#666", // for default tarmac
-  Connection: "#666",
-  MultiConnection: "#669",
-  Merge: "#969",
-  Crossing: "#966",
-  Terminus: "#999",
-  MapEdge: "#696",
-};
-
-const styleGeoJson = (feature) => {
-  if (feature.geometry.type === "Polygon") {
-    return {
-      color: intersectionColours[feature.properties?.complexity],
-      weight: 1,
-      fillOpacity: 0.7,
-    };
-  }
-  return { color: "#f55" };
-};
-
-export const makeDetailedGeoJsonLayer = (text) => {
   return new L.geoJSON(JSON.parse(text), {
     style: function (feature) {
-      switch (feature.properties.type) {
-        case "road polygon":
-          return {
-            fill: true,
-            fillColor: "black",
-            fillOpacity: 0.9,
-            stroke: false,
-          };
-        case "intersection polygon":
-          return {
-            fill: true,
-            fillColor: "grey",
-            fillOpacity: 0.9,
-            stroke: false,
-          };
-        case "lane separator":
-          return { color: "white", dashArray: "4" };
+      if (feature.geometry.type === "Polygon") {
+        return {
+          color: intersectionColours[feature.properties?.complexity],
+          weight: 1,
+          fillOpacity: 0.7,
+        };
       }
+      return { color: "#f55" };
+    },
+  });
+};
+
+export const makeLanePolygonLayer = (text) => {
+  // These could change per locale
+  const colors = {
+    Driving: "black",
+    Parking: "#333333",
+    Sidewalk: "#CCCCCC",
+    Shoulder: "#CCCCCC",
+    Biking: "#0F7D4B",
+    Bus: "#BE4A4C",
+    SharedLeftTurn: "black",
+    Construction: "#FF6D00",
+    LightRail: "#844204",
+    // Skip Buffer -- those need different icons depending on the type
+  };
+
+  return new L.geoJSON(JSON.parse(text), {
+    style: function (feature) {
+      return {
+        fill: true,
+        fillColor: colors[feature.properties.type] || "red",
+        fillOpacity: 0.9,
+        stroke: false,
+      };
+    },
+  });
+};
+
+export const makeLaneMarkingsLayer = (text) => {
+  // These could change per locale
+  const colors = {
+    "center line": "yellow",
+    "lane separator": "white",
+  };
+
+  return new L.geoJSON(JSON.parse(text), {
+    style: function (feature) {
+      return {
+        fill: true,
+        fillColor: colors[feature.properties.type],
+        fillOpacity: 0.9,
+        stroke: false,
+      };
     },
   });
 };

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -9,7 +9,8 @@ import { loadTests } from "./tests.js";
 import {
   makeOsmLayer,
   makePlainGeoJsonLayer,
-  makeDetailedGeoJsonLayer,
+  makeLanePolygonLayer,
+  makeLaneMarkingsLayer,
   makeDotLayer,
   makeDebugLayer,
 } from "./layers.js";
@@ -154,8 +155,14 @@ class TestCase {
       layers.push(app.addLayer("Geometry", rawMapLayer));
       layers.push(
         app.addLayer(
-          "Detailed geometry",
-          makeDetailedGeoJsonLayer(network.toGeojsonDetailed())
+          "Lane polygons",
+          makeLanePolygonLayer(network.toLanePolygonsGeojson())
+        )
+      );
+      layers.push(
+        app.addLayer(
+          "Lane markings",
+          makeLaneMarkingsLayer(network.toLaneMarkingsGeojson())
         )
       );
       layers.push(app.addLayer("OSM", makeOsmLayer(osmInput)));
@@ -249,8 +256,14 @@ class TestCase {
       );
       this.layers.push(
         this.app.addLayer(
-          "Detailed geometry (reimport)",
-          makeDetailedGeoJsonLayer(network.toGeojsonDetailed())
+          "Lane polygons (reimport)",
+          makeLanePolygonLayer(network.toLanePolygonsGeojson())
+        )
+      );
+      this.layers.push(
+        this.app.addLayer(
+          "Lane markings (reimport)",
+          makeLaneMarkingsLayer(network.toLaneMarkingsGeojson())
         )
       );
       /*this.layers.push(


### PR DESCRIPTION
- one with a polygon per lane, so we can use color to distinguish
  parking/bus/bike/driving lanes
- another with dashed lines showing the road center line and separators
  between lanes

![Screenshot from 2022-08-09 10-46-33](https://user-images.githubusercontent.com/1664407/183619066-9785856e-30cd-457d-b381-dfaefe19b574.png)
![Screenshot from 2022-08-09 10-48-47](https://user-images.githubusercontent.com/1664407/183619129-67c61f0e-b6fd-4bb7-9d03-d559ff28203a.png)

I've chosen to do things in a simple way with GeoJSON and hardcoding some styling about dashed lines in the Rust layer for the moment, but this isn't ideal at all. I'd also like to add arrows for direction and bike/bus/parking icons spaced along some lanes. SVG is looking like an attractive option -- we could ideally return something saying to place some parking icon at a certain position and angle, and let the JS caller or others swap in icons or interpret the styling appropriately.