### PR TITLE
Create a new Leaflet layer control widget. It internally manages groups

### DIFF
--- a/tests-web/www/js/controls.js
+++ b/tests-web/www/js/controls.js
@@ -1,0 +1,197 @@
+// TODO A Leaflet control isn't the right abstraction. We want a popup modal
+// that totally blocks the map and other things. Things like disabling
+// settingsButton to stop multiple of these controls is a total hack.
+const SettingsControl = L.Control.extend({
+  // TODO Centered would be great. https://github.com/Leaflet/Leaflet/issues/8358
+  options: {
+    position: "topleft",
+  },
+  onAdd: function (map) {
+    const checkbox1 = makeCheckbox(
+      "debugEachStep",
+      "Debug each transformation step\n",
+      this.options.app.importSettings.debugEachStep,
+      (checked) => {
+        this.options.app.importSettings.debugEachStep = checked;
+      }
+    );
+    const checkbox2 = makeCheckbox(
+      "dualCarriagewayExperiment",
+      "Enable dual carriageway experiment\n",
+      this.options.app.importSettings.dualCarriagewayExperiment,
+      (checked) => {
+        this.options.app.importSettings.dualCarriagewayExperiment = checked;
+      }
+    );
+
+    const button = L.DomUtil.create("button");
+    button.type = "button";
+    button.innerHTML = "Confirm";
+    button.onclick = () => {
+      this.remove();
+      document.getElementById("settingsButton").disabled = false;
+    };
+
+    var group = makeDiv([checkbox1, checkbox2, button]);
+    group.style = "background: black; padding: 10px;";
+    L.DomEvent.disableClickPropagation(group);
+    return group;
+  },
+});
+
+export const makeSettingsControl = function (app) {
+  return new SettingsControl({ app: app });
+};
+
+export class LayerGroup {
+  constructor(name, map) {
+    this.name = name;
+    this.layers = [];
+    this.enabled = true;
+    this.map = map;
+  }
+
+  addLayer(name, layer, { enabled = true } = {}) {
+    this.layers.push({ name, enabled, layer });
+  }
+
+  // Doesn't re-render
+  setEnabled(enabled) {
+    this.enabled = enabled;
+    for (const layer of this.layers) {
+      layer.enabled = enabled;
+    }
+  }
+
+  renderControls() {
+    var members = [
+      makeCheckbox(
+        this.name,
+        `<u>${this.name}</u>`,
+        this.enabled,
+        (checked) => {
+          this.setEnabled(checked);
+
+          // Rerender
+          document.getElementById(this.name).replaceWith(this.renderControls());
+        }
+      ),
+    ];
+    for (const layer of this.layers) {
+      members.push(
+        makeCheckbox(
+          this.name + "_" + layer.name,
+          layer.name,
+          layer.enabled,
+          (checked) => {
+            layer.enabled = checked;
+            if (checked) {
+              this.map.addLayer(layer.layer);
+            } else {
+              this.map.removeLayer(layer.layer);
+            }
+          }
+        )
+      );
+
+      // This is maybe an odd time to sync this state
+      if (layer.enabled) {
+        this.map.addLayer(layer.layer);
+      } else {
+        this.map.removeLayer(layer.layer);
+      }
+    }
+    var div = makeDiv(members);
+    div.id = this.name;
+    return div;
+  }
+}
+
+// Manages a list of groups
+const LayerControl = L.Control.extend({
+  options: {
+    position: "bottomleft",
+  },
+  onAdd: function (map) {
+    return this.renderControls();
+  },
+
+  renderControls: function () {
+    var members = [];
+    for (const group of this.options.groups) {
+      members.push(group.renderControls());
+    }
+    var group = makeDiv(members);
+    group.style = "background: black; padding: 10px;";
+    L.DomEvent.disableClickPropagation(group);
+    return group;
+  },
+
+  getLayer: function (groupName, layerName) {
+    for (const group of this.options.groups) {
+      if (group.name == groupName) {
+        for (const layer of group.layers) {
+          if (layer.name == layerName) {
+            return layer.layer;
+          }
+        }
+      }
+    }
+
+    throw `Can't find group ${groupName} with layer ${layerName}`;
+  },
+
+  removeGroups: function (predicate) {
+    var keep = [];
+    for (const group of this.options.groups) {
+      if (predicate(group.name)) {
+        for (const layer of group.layers) {
+          group.map.removeLayer(layer.layer);
+        }
+      } else {
+        keep.push(group);
+      }
+    }
+    this.options.groups = keep;
+
+    L.DomUtil.empty(this.getContainer());
+    this.getContainer().appendChild(this.renderControls());
+  },
+
+  addGroup: function (group) {
+    this.options.groups.push(group);
+
+    L.DomUtil.empty(this.getContainer());
+    this.getContainer().appendChild(this.renderControls());
+  },
+});
+
+export const makeLayerControl = function (app) {
+  return new LayerControl({ app: app, groups: [] });
+};
+
+// Helpers
+
+function makeCheckbox(id, label, enabled, callback) {
+  var checkbox = L.DomUtil.create("input");
+  checkbox.id = id;
+  checkbox.type = "checkbox";
+  checkbox.checked = enabled;
+  checkbox.onclick = () => {
+    callback(checkbox.checked);
+  };
+
+  var labelElem = L.DomUtil.create("label");
+  labelElem.for = id;
+  labelElem.innerHTML = label;
+
+  return makeDiv([checkbox, labelElem]);
+}
+
+function makeDiv(members) {
+  var div = L.DomUtil.create("div");
+  for (const child of members) {
+    div.appendChild(child);
+  }
+  return div;
+}


### PR DESCRIPTION
of layers, which can be managed together. Use this to establish groups
for the pre-built test case layers, for reimported layers, and for each
step in a debugging sequence.


https://user-images.githubusercontent.com/1664407/183684304-7347720d-1120-46c5-8543-8b0cba6f65b0.mp4

Next up, I'm going to make all the debugging groups bundled together in their own special group and have controls for going back and forth. This'll start to get us to a nicer debugging experience / a way to tell the story of transformations.