### PR TITLE
Draw arrows showing the direction of lanes. #24

### DIFF
--- a/tests-web/www/js/layers.js
+++ b/tests-web/www/js/layers.js
@@ -55,6 +55,7 @@ export const makeLaneMarkingsLayer = (text) => {
   const colors = {
     "center line": "yellow",
     "lane separator": "white",
+    "lane arrow": "white",
   };
 
   return new L.geoJSON(JSON.parse(text), {


### PR DESCRIPTION
![Screenshot from 2022-08-11 08-59-51](https://user-images.githubusercontent.com/1664407/184089512-4dd35fb1-434a-4a17-9d44-1ef2c45481a7.png)

Like the rest of the lane marking, it's likely too low-level to prescribe specific arrow polygons in the geojson, but this moves us forward quickly. I need this to make sure a WIP transformation is preserving directions correctly!