### PR TITLE
Make interactive debugging even better

### DIFF
--- a/street_network/src/transform/mod.rs
+++ b/street_network/src/transform/mod.rs
@@ -149,16 +149,14 @@ impl StreetNetwork {
         transformations: Vec<Transformation>,
         timer: &mut Timer,
     ) {
-        self.debug_steps
-            .borrow_mut()
-            .push(self.copy_for_debugging("original"));
+        self.start_debug_step("original");
 
         timer.start("simplify StreetNetwork");
         for transformation in transformations {
             transformation.apply(self, timer);
-            self.debug_steps
-                .borrow_mut()
-                .push(self.copy_for_debugging(transformation.name()));
+            // Do this after, so any internal debug steps done by the transformation itself show up
+            // first
+            self.start_debug_step(transformation.name());
         }
         timer.stop("simplify StreetNetwork");
     }

--- a/street_network/src/transform/separate_cycletracks.rs
+++ b/street_network/src/transform/separate_cycletracks.rs
@@ -6,6 +6,7 @@ use crate::{osm, BufferType, Direction, LaneSpec, LaneType, OriginalRoad, Street
 /// "snap") them into the main road, inserting a buffer lane to represent the physical division.
 pub fn snap_cycleways(streets: &mut StreetNetwork) {
     for cycleway in find_cycleways(streets) {
+        streets.maybe_start_debug_step(format!("snap cycleway {}", cycleway.debug_idx));
         cycleway.debug(streets);
         snap(streets, cycleway);
     }

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -220,22 +220,19 @@ function importOSM(groupName, app, osmXML, drivingSide, addOSMLayer) {
     for (const step of network.getDebugSteps()) {
       i++;
       var group = new LayerGroup(`Step ${i}: ${step.getLabel()}`, app.map);
-      group.addLayer(
-        "Geometry",
+      group.addLazyLayer("Geometry", () =>
         makePlainGeoJsonLayer(step.getNetwork().toGeojsonPlain())
       );
-      group.addLayer(
-        "Lane polygons",
+      group.addLazyLayer("Lane polygons", () =>
         makeLanePolygonLayer(step.getNetwork().toLanePolygonsGeojson())
       );
-      group.addLayer(
-        "Lane markings",
+      group.addLazyLayer("Lane markings", () =>
         makeLaneMarkingsLayer(step.getNetwork().toLaneMarkingsGeojson())
       );
 
       const debugGeojson = step.toDebugGeojson();
       if (debugGeojson) {
-        group.addLayer("Debug", makeDebugLayer(debugGeojson));
+        group.addLazyLayer("Debug", () => makeDebugLayer(debugGeojson));
       }
       debugGroups.push(group);
     }


### PR DESCRIPTION
Within a transformation, we can now start a new debug step and label stuff whenever we want. Since the separate cycletrack experiment works on one road segment at a time, this is a nice granularity to show it working step-by-step. Here's it wreaking havoc in Taipei:

https://user-images.githubusercontent.com/1664407/184541561-6a3198ff-de9b-442f-bd67-61ea69b6b0ca.mp4

I can't understate how much better of a debug experience this is than I've ever had before. I have high confidence about making rapid progress on these complex transformations because of this.

Also made the JS layer lazily evaluate layers, or else there's a heavy penalty as we emit more debug steps.