### PR TITLE
Expose a setting to import raw sidewalk/footway data and stop making …

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -10,6 +10,7 @@ pub struct ImportOptions {
     debug_each_step: bool,
     dual_carriageway_experiment: bool,
     cycletrack_snapping_experiment: bool,
+    inferred_sidewalks: bool,
 }
 
 #[wasm_bindgen]
@@ -28,15 +29,14 @@ impl JsStreetNetwork {
             .into_serde()
             .map_err(|err| JsValue::from_str(&err.to_string()))?;
 
+        let mut options = import_streets::Options::default_for_side(input.driving_side);
+        options.map_config.inferred_sidewalks = input.inferred_sidewalks;
+
         let clip_pts = None;
         let mut timer = Timer::throwaway();
-        let mut street_network = import_streets::osm_to_street_network(
-            osm_xml_input,
-            clip_pts,
-            import_streets::Options::default_for_side(input.driving_side),
-            &mut timer,
-        )
-        .map_err(|err| JsValue::from_str(&err.to_string()))?;
+        let mut street_network =
+            import_streets::osm_to_street_network(osm_xml_input, clip_pts, options, &mut timer)
+                .map_err(|err| JsValue::from_str(&err.to_string()))?;
         let mut transformations = Transformation::standard_for_clipped_areas();
         if input.dual_carriageway_experiment {
             // Merging short roads tries to touch "bridges," making debugging harder

--- a/tests-web/www/js/controls.js
+++ b/tests-web/www/js/controls.js
@@ -33,6 +33,14 @@ const SettingsControl = L.Control.extend({
         this.options.app.importSettings.cycletrackSnappingExperiment = checked;
       }
     );
+    const checkbox4 = makeCheckbox(
+      "inferredSidewalks",
+      "Infer sidewalks on roads. If false, import separate footways\n",
+      this.options.app.importSettings.inferredSidewalks,
+      (checked) => {
+        this.options.app.importSettings.inferredSidewalks = checked;
+      }
+    );
 
     // TODO Ask Overpass instead of making the user choose this
     const drivingSideLabel = document.createTextNode(
@@ -71,6 +79,7 @@ const SettingsControl = L.Control.extend({
       checkbox1,
       checkbox2,
       checkbox3,
+      checkbox4,
       drivingSideLabel,
       drivingSide1,
       drivingSide1Label,

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -33,6 +33,7 @@ export class StreetExplorer {
       dualCarriagewayExperiment: false,
       cycletrackSnappingExperiment: false,
       drivingSideForNewImports: "Right",
+      inferredSidewalks: true,
     };
     this.layers = makeLayerControl(this).addTo(this.map);
     this.settingsControl = null;
@@ -204,6 +205,7 @@ function importOSM(groupName, app, osmXML, drivingSide, addOSMLayer) {
       dual_carriageway_experiment: app.importSettings.dualCarriagewayExperiment,
       cycletrack_snapping_experiment:
         app.importSettings.cycletrackSnappingExperiment,
+      inferred_sidewalks: app.importSettings.inferredSidewalks,
     });
     var group = new LayerGroup(groupName, app.map);
     if (addOSMLayer) {


### PR DESCRIPTION
…inferences.

#81 
![Screenshot from 2022-08-21 14-55-25](https://user-images.githubusercontent.com/1664407/185791947-217abd87-50ac-4088-bbb9-ec18b6d0c2b0.png)

There's loads of work to make detailed sidewalks show up reasonably. Start by just exposing a setting in the browser app to enable this experiment.