### PR TITLE
Group and order the things in the sidebar a bit better

### DIFF
--- a/tests-web/www/css/main.css
+++ b/tests-web/www/css/main.css
@@ -2,7 +2,7 @@
 
 /* Variables */
 body {
-    --pad: 1rem;
+  --pad: 1rem;
 }
 
 /* Full screen app layout */
@@ -10,49 +10,50 @@ body {
   display: flex;
   flex-flow: row nowrap;
   align-items: stretch;
-
 }
 
- menu {
-     padding: var(--pad);
-     margin: 0;
+body > aside {
+  padding: var(--pad);
+  margin: 0;
 
-     display: flex;
-     flex-flow: column nowrap;
- }
+  display: flex;
+  flex-flow: column nowrap;
+  row-gap: var(--pad);
+  column-gap: calc(var(--pad) * 2);
+}
 
 @media (orientation: landscape) {
-    body { flex-direction: row }
-    menu { flex-direction: column }
-    menu {
-        width: 300px;
-    }
+  body { flex-direction: row }
+  body > aside { flex-direction: column }
+  body > aside {
+    max-width: 23rem;
+  }
 }
 
 @media (orientation: portrait) {
-    body { flex-direction: column }
-    menu { flex-direction: row }
+  body { flex-direction: column }
+  body > aside { flex-direction: row }
 
-    menu {
-        height: 250px;
-    }
- }
+  body > aside {
+    max-height: 13rem;
+  }
+}
 
 
 #test-list {
-    list-style: none;
-    padding: 0;
+  list-style: none;
+  padding: 0;
 }
 
 #road-network > svg {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 #map {
-    flex-grow: 1;
+  flex-grow: 1;
 
-    cursor: crosshair;
+  cursor: crosshair;
 }
 
 /* Theming */

--- a/tests-web/www/index.html
+++ b/tests-web/www/index.html
@@ -28,16 +28,27 @@
     </script>
   </head>
   <body>
-    <menu>
-      <h1>StreetExplorer</h1>
-      <a href="https://github.com/a-b-street/osm2streets" target="_blank"
-        >About</a
-      >
-      <button type="button" id="import-view">Import current view</button>
-      <button type="button" id="settings">Settings</button>
-      <ul id="test-list" />
-      <ul id="view-controls" />
-    </menu>
+    <aside>
+      <header>
+        <h1>StreetExplorer</h1>
+        <p>
+          Understanding OSM streets and intersections with
+          <a href="https://github.com/a-b-street/osm2streets" target="_blank">osm2streets</a>.
+        </p>
+      </header>
+      <button type="button" id="settings">Processing Options</button>
+      <fieldset>
+        <legend>
+          <select id="test-list">
+            <option value="">No test case</option>
+            <option value="dynamic" hidden>Custom imported area</option>
+          </select>
+        </legend>
+        <div id="view-controls">
+          <button type="button" id="import-view">import current view</button>
+        </div>
+      </fieldset>
+    </aside>
     <section id="road-network"></section>
     <div id="map"></div>
   </body>

--- a/tests-web/www/js/main.js
+++ b/tests-web/www/js/main.js
@@ -55,16 +55,18 @@ export class StreetExplorer {
 
     // Wire up the import button
     const importButton = document.getElementById("import-view");
-    importButton.onclick = async () => {
-      if (app.map.getZoom() < 15) {
-        window.alert("Zoom in more to import");
-        return;
-      }
+    if (importButton) {
+      importButton.onclick = async () => {
+        if (app.map.getZoom() < 15) {
+          window.alert("Zoom in more to import");
+          return;
+        }
 
-      await app.setCurrentTest((app) =>
-        TestCase.importCurrentView(app, importButton)
-      );
-    };
+        await app.setCurrentTest((app) =>
+          TestCase.importCurrentView(app, importButton)
+        );
+      };
+    }
 
     // Wire up the settings button
     const settingsButton = document.getElementById("settings");
@@ -87,6 +89,7 @@ export class StreetExplorer {
     this.currentTest = await testMaker(this);
     if (this.currentTest) {
       this.map.fitBounds(this.currentTest.bounds, { animate: false });
+      document.getElementById("test-list").value = this.currentTest.name || "dynamic";
       this.currentTest.renderControls(document.getElementById("view-controls"));
     }
   }
@@ -171,22 +174,17 @@ class TestCase {
   renderControls(container) {
     container.innerHTML = "";
     if (this.name) {
-      const title = container.appendChild(document.createElement("b"));
-      title.innerText = `Currently showing ${this.name}`;
-
       const button = container.appendChild(document.createElement("button"));
       button.type = "button";
-      button.innerHTML = "Reimport";
+      button.innerHTML = "Generate Details";
       button.onclick = () => {
         // First remove all existing groups except for the original one
         this.app.layers.removeGroups((name) => name != "built-in test case");
         // Then disable the original group. Seeing dueling geometry isn't a good default.
         this.app.layers.getGroup("built-in test case").setEnabled(false);
 
-        importOSM("Reimport", this.app, this.osmXML, this.drivingSide, false);
+        importOSM("Details", this.app, this.osmXML, this.drivingSide, false);
       };
-    } else {
-      container.innerHTML = `<b>Custom imported view</b>`;
     }
 
     const button = container.appendChild(document.createElement("button"));

--- a/tests-web/www/js/tests.js
+++ b/tests-web/www/js/tests.js
@@ -23,13 +23,20 @@ export function loadTests() {
     "tempe_split",
   ];
 
-  // Add all of the test cases to the list.
+  // Add all the test cases to the list.
   const listNode = window.document.getElementById("test-list");
   for (const t of testNames) {
-    const li = listNode.appendChild(window.document.createElement("li"));
-    const a = li.appendChild(window.document.createElement("a"));
+    const a = listNode.appendChild(window.document.createElement("option"));
     // Here we encode the test name in the URL to be read elsewhere.
-    a.href = "?test=" + t;
+    a.value = t;
     a.innerHTML = t;
+  }
+
+  listNode.onchange = (ev) => {
+    const val = ev.currentTarget.value;
+    const q = new URLSearchParams(location.search);
+    if (val) q.set("test", val);
+    else q.delete("test")
+    location.search = q.toString();
   }
 }


### PR DESCRIPTION
The test list has become a dropdown that doubles as the "current test case" title, and the test specific controls have been put in a box.

The import options could go in their own (collapsible) box in the sidebar, next.

![No test case](https://user-images.githubusercontent.com/3784591/188316031-9ef41e7b-067b-45b8-aaae-9e4f140dac04.png)

![custom area](https://user-images.githubusercontent.com/3784591/188316066-4d3550f9-9222-4c6d-a3eb-dede3aff60cd.png)

![test case loaded](https://user-images.githubusercontent.com/3784591/188315871-0e233798-980e-465f-adec-2036ab60b9c4.png)
