### PR TITLE
Detect a few MultiConnections

### DIFF
--- a/street_network/src/transform/classify_intersections.rs
+++ b/street_network/src/transform/classify_intersections.rs
@@ -1,6 +1,6 @@
 use crate::osm::NodeID;
 use crate::IntersectionComplexity::*;
-use crate::{Intersection, IntersectionComplexity, OriginalRoad, StreetNetwork};
+use crate::{Direction, Intersection, IntersectionComplexity, OriginalRoad, StreetNetwork};
 
 /// Determines the initial complexity of all intersections. Intersections marked "Crossing" are
 /// considered "unclassified" and will be updated with a guess, others will be left unchanged.
@@ -8,10 +8,7 @@ pub fn classify_intersections(streets: &mut StreetNetwork) {
     let mut changes: Vec<(NodeID, IntersectionComplexity)> = Vec::new();
     for (id, inter) in &streets.intersections {
         if let Crossing = inter.complexity {
-            changes.push((
-                *id,
-                guess_complexity(inter, streets.roads_per_intersection(*id)),
-            ));
+            changes.push((*id, guess_complexity(streets, id)));
         }
     }
 
@@ -23,7 +20,9 @@ pub fn classify_intersections(streets: &mut StreetNetwork) {
 /// Guesses the complexity of the intersection based on the connecting roads and their lanes.
 ///
 /// The existing complexity field is ignored, so be careful how you use the guessed value.
-fn guess_complexity(_inter: &Intersection, roads: Vec<OriginalRoad>) -> IntersectionComplexity {
+fn guess_complexity(streets: &StreetNetwork, id: &NodeID) -> IntersectionComplexity {
+    let roads = streets.roads_per_intersection(*id);
+
     // A terminus is characterised by a single connected road.
     if roads.len() == 1 {
         return Terminus;
@@ -34,8 +33,50 @@ fn guess_complexity(_inter: &Intersection, roads: Vec<OriginalRoad>) -> Intersec
         return Connection;
     }
 
-    // A MultiConnection is characterised by exactly two connected dividing lines (lines that
-    // separate traffic in different directions) and no traffic that crosses them.
+    // A MultiConnection is characterised by exactly one dividing line traveling through it (the
+    // line that separates traffic in different directions) and no traffic that crosses it.
+    if roads.len() == 3 {
+        let mut num_roads_in = 0;
+        let mut num_roads_out = 0;
+        let mut num_roads_inout = 0;
+        for or in roads {
+            let is_outward = or.i1 == *id;
+            let road = streets.roads.get(&or).unwrap();
+            match road.oneway_for_driving() {
+                Some(Direction::Fwd) => {
+                    if is_outward {
+                        num_roads_out += 1
+                    } else {
+                        num_roads_in += 1
+                    }
+                }
+
+                Some(Direction::Back) => {
+                    if is_outward {
+                        num_roads_in += 1
+                    } else {
+                        num_roads_out += 1
+                    }
+                }
+                None => num_roads_inout += 1,
+            }
+        }
+
+        if num_roads_inout == 0 {
+            // The simplest MultiConnect
+            return MultiConnection;
+        }
+
+        // detect the simple case of a single road splitting
+        if num_roads_inout == 1 {
+            // TODO Determine if it is possible to turn from the 'in' road to the 'out' road.
+            // If not, then we have a dual carriageway split.
+            if false {
+                return MultiConnection;
+            }
+        }
+    }
+
     // A Merge is characterised by an uninterrupted road (that would qualify as a Connection or
     // MultiConnection), with additional connected roads that yield.
     // TODO Combine roads into corridors and count them.

--- a/street_network/src/transform/classify_intersections.rs
+++ b/street_network/src/transform/classify_intersections.rs
@@ -20,8 +20,8 @@ pub fn classify_intersections(streets: &mut StreetNetwork) {
 /// Guesses the complexity of the intersection based on the connecting roads and their lanes.
 ///
 /// The existing complexity field is ignored, so be careful how you use the guessed value.
-fn guess_complexity(streets: &StreetNetwork, id: &NodeID) -> IntersectionComplexity {
-    let roads = streets.roads_per_intersection(*id);
+fn guess_complexity(streets: &StreetNetwork, intersection_id: &NodeID) -> IntersectionComplexity {
+    let roads = streets.roads_per_intersection(*intersection_id);
 
     // A terminus is characterised by a single connected road.
     if roads.len() == 1 {
@@ -39,9 +39,9 @@ fn guess_complexity(streets: &StreetNetwork, id: &NodeID) -> IntersectionComplex
         let mut num_roads_in = 0;
         let mut num_roads_out = 0;
         let mut num_roads_inout = 0;
-        for or in roads {
-            let is_outward = or.i1 == *id;
-            let road = streets.roads.get(&or).unwrap();
+        for road_id in roads {
+            let is_outward = road_id.i1 == *intersection_id;
+            let road = streets.roads.get(&road_id).unwrap();
             match road.oneway_for_driving() {
                 Some(Direction::Fwd) => {
                     if is_outward {

--- a/street_network/src/transform/classify_intersections.rs
+++ b/street_network/src/transform/classify_intersections.rs
@@ -1,6 +1,6 @@
 use crate::osm::NodeID;
 use crate::IntersectionComplexity::*;
-use crate::{Direction, Intersection, IntersectionComplexity, OriginalRoad, StreetNetwork};
+use crate::{Direction, IntersectionComplexity, StreetNetwork};
 
 /// Determines the initial complexity of all intersections. Intersections marked "Crossing" are
 /// considered "unclassified" and will be updated with a guess, others will be left unchanged.
@@ -36,8 +36,8 @@ fn guess_complexity(streets: &StreetNetwork, intersection_id: &NodeID) -> Inters
     // A MultiConnection is characterised by exactly one dividing line traveling through it (the
     // line that separates traffic in different directions) and no traffic that crosses it.
     if roads.len() == 3 {
-        let mut num_roads_in = 0;
-        let mut num_roads_out = 0;
+        let mut _num_roads_in = 0;
+        let mut _num_roads_out = 0;
         let mut num_roads_inout = 0;
         for road_id in roads {
             let is_outward = road_id.i1 == *intersection_id;
@@ -45,17 +45,17 @@ fn guess_complexity(streets: &StreetNetwork, intersection_id: &NodeID) -> Inters
             match road.oneway_for_driving() {
                 Some(Direction::Fwd) => {
                     if is_outward {
-                        num_roads_out += 1
+                        _num_roads_out += 1
                     } else {
-                        num_roads_in += 1
+                        _num_roads_in += 1
                     }
                 }
 
                 Some(Direction::Back) => {
                     if is_outward {
-                        num_roads_in += 1
+                        _num_roads_in += 1
                     } else {
-                        num_roads_out += 1
+                        _num_roads_out += 1
                     }
                 }
                 None => num_roads_inout += 1,

--- a/tests/src/arizona_highways/geometry.json
+++ b/tests/src/arizona_highways/geometry.json
@@ -4398,7 +4398,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/257973235",
         "osm_node_id": 257973235,
@@ -4439,7 +4439,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/257973558",
         "osm_node_id": 257973558,
@@ -4484,7 +4484,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/257973659",
         "osm_node_id": 257973659,
@@ -4931,7 +4931,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1950975867",
         "osm_node_id": 1950975867,
@@ -4972,7 +4972,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1950975883",
         "osm_node_id": 1950975883,
@@ -5091,7 +5091,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1950975926",
         "osm_node_id": 1950975926,
@@ -5357,7 +5357,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2391008592",
         "osm_node_id": 2391008592,
@@ -5619,7 +5619,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2454728514",
         "osm_node_id": 2454728514,
@@ -5697,7 +5697,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2457540680",
         "osm_node_id": 2457540680,
@@ -5738,7 +5738,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2457540684",
         "osm_node_id": 2457540684,
@@ -5779,7 +5779,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2457540685",
         "osm_node_id": 2457540685,
@@ -6032,7 +6032,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2457540697",
         "osm_node_id": 2457540697,
@@ -6073,7 +6073,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2457540699",
         "osm_node_id": 2457540699,
@@ -6114,7 +6114,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2457540707",
         "osm_node_id": 2457540707,
@@ -6393,7 +6393,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/4341085386",
         "osm_node_id": 4341085386,
@@ -6771,7 +6771,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/5134463770",
         "osm_node_id": 5134463770,

--- a/tests/src/borough_sausage_links/geometry.json
+++ b/tests/src/borough_sausage_links/geometry.json
@@ -3939,7 +3939,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2217412069",
         "osm_node_id": 2217412069,
@@ -3992,7 +3992,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/2217412073",
         "osm_node_id": 2217412073,

--- a/tests/src/cycleway_rejoin_road/geometry.json
+++ b/tests/src/cycleway_rejoin_road/geometry.json
@@ -7697,7 +7697,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/25504033",
         "osm_node_id": 25504033,

--- a/tests/src/i5_exit_ramp/geometry.json
+++ b/tests/src/i5_exit_ramp/geometry.json
@@ -2241,7 +2241,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/29484936",
         "osm_node_id": 29484936,
@@ -2467,7 +2467,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/29545445",
         "osm_node_id": 29545445,
@@ -3492,7 +3492,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1864943558",
         "osm_node_id": 1864943558,

--- a/tests/src/kingsway_junction/geometry.json
+++ b/tests/src/kingsway_junction/geometry.json
@@ -7201,7 +7201,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/31287525",
         "osm_node_id": 31287525,
@@ -7242,7 +7242,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/32025947",
         "osm_node_id": 32025947,
@@ -7373,7 +7373,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/32025961",
         "osm_node_id": 32025961,
@@ -7980,7 +7980,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/743548189",
         "osm_node_id": 743548189,
@@ -10090,7 +10090,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/2918379027",
         "osm_node_id": 2918379027,
@@ -10380,7 +10380,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2918472522",
         "osm_node_id": 2918472522,
@@ -11067,7 +11067,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/5405641445",
         "osm_node_id": 5405641445,
@@ -11149,7 +11149,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6137128080",
         "osm_node_id": 6137128080,
@@ -11243,7 +11243,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6137128391",
         "osm_node_id": 6137128391,
@@ -11665,7 +11665,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/7218399545",
         "osm_node_id": 7218399545,
@@ -11870,7 +11870,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/8672774809",
         "osm_node_id": 8672774809,

--- a/tests/src/leeds_cycleway/geometry.json
+++ b/tests/src/leeds_cycleway/geometry.json
@@ -30996,7 +30996,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/643907",
         "osm_node_id": 643907,
@@ -31041,7 +31041,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/643911",
         "osm_node_id": 643911,
@@ -31143,7 +31143,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/643945",
         "osm_node_id": 643945,
@@ -31184,7 +31184,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/643946",
         "osm_node_id": 643946,
@@ -31339,7 +31339,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/9791699",
         "osm_node_id": 9791699,
@@ -31810,7 +31810,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26109191",
         "osm_node_id": 26109191,
@@ -31900,7 +31900,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26298420",
         "osm_node_id": 26298420,
@@ -31945,7 +31945,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26298423",
         "osm_node_id": 26298423,
@@ -32226,7 +32226,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26298429",
         "osm_node_id": 26298429,
@@ -32275,7 +32275,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26298430",
         "osm_node_id": 26298430,
@@ -32513,7 +32513,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26300437",
         "osm_node_id": 26300437,
@@ -32828,7 +32828,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/26661432",
         "osm_node_id": 26661432,
@@ -35023,7 +35023,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/342579502",
         "osm_node_id": 342579502,
@@ -35444,7 +35444,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/342579576",
         "osm_node_id": 342579576,
@@ -35497,7 +35497,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/342579578",
         "osm_node_id": 342579578,
@@ -36455,7 +36455,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/370191920",
         "osm_node_id": 370191920,
@@ -36941,7 +36941,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/659971029",
         "osm_node_id": 659971029,
@@ -37477,7 +37477,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1022749752",
         "osm_node_id": 1022749752,
@@ -38331,7 +38331,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1591373171",
         "osm_node_id": 1591373171,
@@ -38441,7 +38441,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1591373192",
         "osm_node_id": 1591373192,
@@ -40449,7 +40449,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2014304918",
         "osm_node_id": 2014304918,
@@ -40776,7 +40776,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2377604550",
         "osm_node_id": 2377604550,
@@ -40899,7 +40899,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/3181227681",
         "osm_node_id": 3181227681,
@@ -42720,7 +42720,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/4540786888",
         "osm_node_id": 4540786888,
@@ -45177,7 +45177,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/5728993691",
         "osm_node_id": 5728993691,
@@ -47315,7 +47315,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6111971409",
         "osm_node_id": 6111971409,
@@ -47936,7 +47936,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6211583013",
         "osm_node_id": 6211583013,
@@ -50593,7 +50593,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6905250281",
         "osm_node_id": 6905250281,
@@ -53200,7 +53200,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/8273166694",
         "osm_node_id": 8273166694,

--- a/tests/src/northgate_dual_carriageway/geometry.json
+++ b/tests/src/northgate_dual_carriageway/geometry.json
@@ -7583,7 +7583,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/476254734",
         "osm_node_id": 476254734,
@@ -7681,7 +7681,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/476254742",
         "osm_node_id": 476254742,
@@ -8516,7 +8516,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/1968559734",
         "osm_node_id": 1968559734,
@@ -10189,7 +10189,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/4787774433",
         "osm_node_id": 4787774433,
@@ -11978,7 +11978,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/9322923125",
         "osm_node_id": 9322923125,
@@ -13425,7 +13425,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/9772983384",
         "osm_node_id": 9772983384,

--- a/tests/src/perth_peanut_roundabout/geometry.json
+++ b/tests/src/perth_peanut_roundabout/geometry.json
@@ -1755,7 +1755,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/61067223",
         "osm_node_id": 61067223,
@@ -2247,7 +2247,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/585206951",
         "osm_node_id": 585206951,
@@ -2292,7 +2292,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/585206952",
         "osm_node_id": 585206952,
@@ -2386,7 +2386,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/585206956",
         "osm_node_id": 585206956,
@@ -2435,7 +2435,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/585206957",
         "osm_node_id": 585206957,
@@ -2484,7 +2484,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/585206960",
         "osm_node_id": 585206960,
@@ -3021,7 +3021,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6257803111",
         "osm_node_id": 6257803111,
@@ -3074,7 +3074,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6257803113",
         "osm_node_id": 6257803113,

--- a/tests/src/roosevelt_cycletrack/geometry.json
+++ b/tests/src/roosevelt_cycletrack/geometry.json
@@ -5460,7 +5460,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/59711142",
         "osm_node_id": 59711142,

--- a/tests/src/seattle_slip_lane/geometry.json
+++ b/tests/src/seattle_slip_lane/geometry.json
@@ -1922,7 +1922,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/59711142",
         "osm_node_id": 59711142,

--- a/tests/src/service_road_loop/geometry.json
+++ b/tests/src/service_road_loop/geometry.json
@@ -2037,7 +2037,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6036958616",
         "osm_node_id": 6036958616,
@@ -2094,7 +2094,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/6036958633",
         "osm_node_id": 6036958633,

--- a/tests/src/st_georges_cycletrack/geometry.json
+++ b/tests/src/st_georges_cycletrack/geometry.json
@@ -6879,7 +6879,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/96619956",
         "osm_node_id": 96619956,
@@ -7064,7 +7064,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/264341506",
         "osm_node_id": 264341506,
@@ -8970,7 +8970,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/3874597627",
         "osm_node_id": 3874597627,
@@ -9412,7 +9412,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/4156273389",
         "osm_node_id": 4156273389,

--- a/tests/src/taipei/geometry.json
+++ b/tests/src/taipei/geometry.json
@@ -2614,7 +2614,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/656415898",
         "osm_node_id": 656415898,
@@ -3620,7 +3620,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/662161241",
         "osm_node_id": 662161241,
@@ -3739,7 +3739,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "TrafficSignal",
         "osm_link": "https://www.openstreetmap.org/node/662161891",
         "osm_node_id": 662161891,
@@ -3955,7 +3955,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/662161955",
         "osm_node_id": 662161955,
@@ -4106,7 +4106,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/662161980",
         "osm_node_id": 662161980,
@@ -4262,7 +4262,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2137955743",
         "osm_node_id": 2137955743,
@@ -4319,7 +4319,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2137955785",
         "osm_node_id": 2137955785,
@@ -4364,7 +4364,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2137955831",
         "osm_node_id": 2137955831,
@@ -4458,7 +4458,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "complexity": "Crossing",
+        "complexity": "MultiConnection",
         "control": "StopSign",
         "osm_link": "https://www.openstreetmap.org/node/2137955866",
         "osm_node_id": 2137955866,


### PR DESCRIPTION
This PR detects `MultiConnection`s made up of oneways (like a divided highway entrance or exit). It is a tiny improvement, itself, but mostly I want to talk about the approach.

The idea is to look at the entrances and exits of the intersection to see to what extent paths through the intersections conflict. Counting the number of roads pointing in and out seemed like an OK starting point, with additional heuristics added on top. But, it turns out classifying intersections first, in order to understand the intersection better in later transformations, falls down quickly. 

I am now thinking that the calculating the valid "movements" (as A/B Street calls them) should come first. Then the conflicts could be calculated (at the graph level, without geometry, just ordering), then the types of markings that must be present.