### PR TITLE
Fix subtract underflow crash when calculating backwards lane counts

### DIFF
--- a/osm2streets/src/lanes/classic.rs
+++ b/osm2streets/src/lanes/classic.rs
@@ -107,7 +107,12 @@ pub fn get_lane_specs_ltr(tags: &Tags, cfg: &MapConfig) -> Vec<LaneSpec> {
     {
         n
     } else if let Some(n) = tags.get("lanes").and_then(|num| num.parse::<usize>().ok()) {
-        let base = n - num_driving_fwd;
+        let base = if n > num_driving_fwd {
+            n - num_driving_fwd
+        } else {
+            0
+        };
+
         if oneway {
             base
         } else {


### PR DESCRIPTION
Fixes crash when value of `lanes:forward` is greater than value of `lanes`. This _should_ not happen but has been spotted on live OSM data. This will at least let us handle the situation more gracefully.

Fixes #102 