### PR TITLE
Switch from roxmltree to xmlparser.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,15 +746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
 
 [[package]]
-name = "roxmltree"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
 name = "rstar"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,7 +886,7 @@ dependencies = [
  "geom",
  "log",
  "osm2streets",
- "roxmltree",
+ "xmlparser",
 ]
 
 [[package]]
@@ -1111,6 +1102,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xmlparser"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"

--- a/streets_reader/Cargo.toml
+++ b/streets_reader/Cargo.toml
@@ -9,5 +9,5 @@ abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = "1.0.38"
 geom = { git = "https://github.com/a-b-street/abstreet" }
 log = "0.4.14"
-roxmltree = { version = "0.14.0", features=["std"] }
 osm2streets = { path = "../osm2streets" }
+xmlparser = "0.13.5"

--- a/streets_reader/src/osm_reader/reader.rs
+++ b/streets_reader/src/osm_reader/reader.rs
@@ -1,6 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::iter::Peekable;
 
 use anyhow::Result;
+use xmlparser::Token;
 
 use abstutil::{prettyprint_usize, Tags, Timer};
 use geom::{GPSBounds, LonLat, Pt2D};
@@ -8,7 +10,8 @@ use osm2streets::osm::{NodeID, OsmID, RelationID, WayID};
 
 // References to missing objects are just filtered out.
 // Per https://wiki.openstreetmap.org/wiki/OSM_XML#Certainties_and_Uncertainties, we assume
-// elements come in order: nodes, ways, then relations.
+// elements come in order: nodes, ways, then relations. We assume ways reference nodes and
+// relations reference members before defining their own tags.
 //
 // TODO Filter out visible=false
 // TODO NodeID, WayID, RelationID are nice. Plumb forward through map_model.
@@ -41,10 +44,6 @@ pub struct Relation {
 }
 
 pub fn read(raw_string: &str, input_gps_bounds: &GPSBounds, timer: &mut Timer) -> Result<Document> {
-    timer.start("parse osm.xml");
-    let tree = roxmltree::Document::parse(raw_string)?;
-    timer.stop("parse osm.xml");
-
     let mut doc = Document {
         gps_bounds: input_gps_bounds.clone(),
         nodes: BTreeMap::new(),
@@ -52,24 +51,28 @@ pub fn read(raw_string: &str, input_gps_bounds: &GPSBounds, timer: &mut Timer) -
         relations: BTreeMap::new(),
     };
 
+    // We use the lower-level xmlparser instead of roxmltree to reduce peak memory usage in large
+    // files.
+    let mut reader = ElementReader {
+        tokenizer: xmlparser::Tokenizer::from(raw_string),
+    }
+    .peekable();
+
     timer.start("scrape objects");
-    for obj in tree.descendants() {
-        if !obj.is_element() {
-            continue;
-        }
-        match obj.tag_name().name() {
+    while let Some(obj) = reader.next() {
+        match obj.name {
             "bounds" => {
                 // If we weren't provided with GPSBounds, use this.
                 if doc.gps_bounds != GPSBounds::new() {
                     continue;
                 }
                 doc.gps_bounds.update(LonLat::new(
-                    obj.attribute("minlon").unwrap().parse::<f64>().unwrap(),
-                    obj.attribute("minlat").unwrap().parse::<f64>().unwrap(),
+                    obj.attribute("minlon").parse::<f64>().unwrap(),
+                    obj.attribute("minlat").parse::<f64>().unwrap(),
                 ));
                 doc.gps_bounds.update(LonLat::new(
-                    obj.attribute("maxlon").unwrap().parse::<f64>().unwrap(),
-                    obj.attribute("maxlat").unwrap().parse::<f64>().unwrap(),
+                    obj.attribute("maxlon").parse::<f64>().unwrap(),
+                    obj.attribute("maxlat").parse::<f64>().unwrap(),
                 ));
             }
             "node" => {
@@ -78,84 +81,84 @@ pub fn read(raw_string: &str, input_gps_bounds: &GPSBounds, timer: &mut Timer) -
                         "No clipping polygon provided and the .osm is missing a <bounds> element, \
                          so figuring out the bounds manually."
                     );
-                    doc.gps_bounds = scrape_bounds(&tree);
+                    doc.gps_bounds = scrape_bounds(raw_string);
                 }
 
-                let id = NodeID(obj.attribute("id").unwrap().parse::<i64>().unwrap());
+                let id = NodeID(obj.attribute("id").parse::<i64>().unwrap());
                 if doc.nodes.contains_key(&id) {
                     bail!("Duplicate {}, your .osm is corrupt", id);
                 }
                 let pt = LonLat::new(
-                    obj.attribute("lon").unwrap().parse::<f64>().unwrap(),
-                    obj.attribute("lat").unwrap().parse::<f64>().unwrap(),
+                    obj.attribute("lon").parse::<f64>().unwrap(),
+                    obj.attribute("lat").parse::<f64>().unwrap(),
                 )
                 .to_pt(&doc.gps_bounds);
-                let tags = read_tags(obj);
+                let tags = read_tags(&mut reader);
                 doc.nodes.insert(id, Node { pt, tags });
             }
             "way" => {
-                let id = WayID(obj.attribute("id").unwrap().parse::<i64>().unwrap());
+                let id = WayID(obj.attribute("id").parse::<i64>().unwrap());
                 if doc.ways.contains_key(&id) {
                     bail!("Duplicate {}, your .osm is corrupt", id);
                 }
-                let tags = read_tags(obj);
 
                 let mut nodes = Vec::new();
                 let mut pts = Vec::new();
-                for child in obj.children() {
-                    if child.tag_name().name() == "nd" {
-                        let n = NodeID(child.attribute("ref").unwrap().parse::<i64>().unwrap());
-                        // Just skip missing nodes
-                        if let Some(node) = doc.nodes.get(&n) {
-                            nodes.push(n);
-                            pts.push(node.pt);
-                        }
+                while reader.peek().map(|x| x.name == "nd").unwrap_or(false) {
+                    let node_ref = reader.next().unwrap();
+                    let n = NodeID(node_ref.attribute("ref").parse::<i64>().unwrap());
+                    // Just skip missing nodes
+                    if let Some(node) = doc.nodes.get(&n) {
+                        nodes.push(n);
+                        pts.push(node.pt);
                     }
                 }
+
+                // We assume <nd>'s come before <tag>'s
+                let tags = read_tags(&mut reader);
+
                 if !nodes.is_empty() {
                     doc.ways.insert(id, Way { nodes, pts, tags });
                 }
             }
             "relation" => {
-                let id = RelationID(obj.attribute("id").unwrap().parse::<i64>().unwrap());
+                let id = RelationID(obj.attribute("id").parse::<i64>().unwrap());
                 if doc.relations.contains_key(&id) {
                     bail!("Duplicate {}, your .osm is corrupt", id);
                 }
-                let tags = read_tags(obj);
                 let mut members = Vec::new();
-                for child in obj.children() {
-                    if child.tag_name().name() == "member" {
-                        let member = match child.attribute("type").unwrap() {
-                            "node" => {
-                                let n =
-                                    NodeID(child.attribute("ref").unwrap().parse::<i64>().unwrap());
-                                if !doc.nodes.contains_key(&n) {
-                                    continue;
-                                }
-                                OsmID::Node(n)
+                while reader.peek().map(|x| x.name == "member").unwrap_or(false) {
+                    let child = reader.next().unwrap();
+                    let member = match child.attribute("type") {
+                        "node" => {
+                            let n = NodeID(child.attribute("ref").parse::<i64>().unwrap());
+                            if !doc.nodes.contains_key(&n) {
+                                continue;
                             }
-                            "way" => {
-                                let w =
-                                    WayID(child.attribute("ref").unwrap().parse::<i64>().unwrap());
-                                if !doc.ways.contains_key(&w) {
-                                    continue;
-                                }
-                                OsmID::Way(w)
+                            OsmID::Node(n)
+                        }
+                        "way" => {
+                            let w = WayID(child.attribute("ref").parse::<i64>().unwrap());
+                            if !doc.ways.contains_key(&w) {
+                                continue;
                             }
-                            "relation" => {
-                                let r = RelationID(
-                                    child.attribute("ref").unwrap().parse::<i64>().unwrap(),
-                                );
-                                if !doc.relations.contains_key(&r) {
-                                    continue;
-                                }
-                                OsmID::Relation(r)
+                            OsmID::Way(w)
+                        }
+                        "relation" => {
+                            let r = RelationID(child.attribute("ref").parse::<i64>().unwrap());
+                            if !doc.relations.contains_key(&r) {
+                                continue;
                             }
-                            _ => continue,
-                        };
-                        members.push((child.attribute("role").unwrap().to_string(), member));
-                    }
+                            OsmID::Relation(r)
+                        }
+                        _ => continue,
+                    };
+                    members.push((child.attribute("role").to_string(), member));
                 }
+
+                // We assume <nd>'s come before <tag>'s
+                let tags = read_tags(&mut reader);
+
                 doc.relations.insert(id, Relation { tags, members });
             }
             _ => {}
@@ -172,30 +175,128 @@ pub fn read(raw_string: &str, input_gps_bounds: &GPSBounds, timer: &mut Timer) -
     Ok(doc)
 }
 
-fn read_tags(obj: roxmltree::Node) -> Tags {
+fn read_tags(reader: &mut Peekable<ElementReader>) -> Tags {
     let mut tags = Tags::empty();
-    for child in obj.children() {
-        if child.tag_name().name() == "tag" {
-            let key = child.attribute("k").unwrap();
-            // Filter out really useless data
-            if key.starts_with("tiger:") || key.starts_with("old_name:") {
-                continue;
-            }
-            tags.insert(key, child.attribute("v").unwrap());
+
+    while reader.peek().map(|x| x.name == "tag").unwrap_or(false) {
+        let obj = reader.next().unwrap();
+        let key = obj.attribute("k");
+        let value = obj.attribute("v");
+        // Filter out really useless data
+        if key.starts_with("tiger:") || key.starts_with("old_name:") {
+            continue;
         }
+        tags.insert(key, unescape(value).unwrap());
     }
+
     tags
 }
 
-fn scrape_bounds(doc: &roxmltree::Document) -> GPSBounds {
+fn scrape_bounds(raw_string: &str) -> GPSBounds {
     let mut b = GPSBounds::new();
-    for obj in doc.descendants() {
-        if obj.is_element() && obj.tag_name().name() == "node" {
+    for obj in (ElementReader {
+        tokenizer: xmlparser::Tokenizer::from(raw_string),
+    }) {
+        if obj.name == "node" {
             b.update(LonLat::new(
-                obj.attribute("lon").unwrap().parse::<f64>().unwrap(),
-                obj.attribute("lat").unwrap().parse::<f64>().unwrap(),
+                obj.attribute("lon").parse::<f64>().unwrap(),
+                obj.attribute("lat").parse::<f64>().unwrap(),
             ));
         }
     }
     b
+}
+
+// Reads one element with attributes at a time. Ignores/flattens nested elements.
+struct ElementReader<'a> {
+    tokenizer: xmlparser::Tokenizer<'a>,
+}
+
+struct Element<'a> {
+    name: &'a str,
+    attributes: HashMap<&'a str, &'a str>,
+}
+
+impl<'a> Element<'a> {
+    fn attribute(&self, key: &str) -> &str {
+        self.attributes.get(key).unwrap()
+    }
+}
+
+impl<'a> Iterator for ElementReader<'a> {
+    type Item = Element<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut name: Option<&'a str> = None;
+        let mut attributes = HashMap::new();
+        loop {
+            match self.tokenizer.next()?.unwrap() {
+                Token::ElementStart { local, .. } => {
+                    assert!(name.is_none());
+                    assert!(attributes.is_empty());
+                    name = Some(local.as_str());
+                }
+                Token::Attribute { local, value, .. } => {
+                    assert!(name.is_some());
+                    attributes.insert(local.as_str(), value.as_str());
+                }
+                Token::ElementEnd { .. } => {
+                    if name.is_none() {
+                        assert!(attributes.is_empty());
+                        continue;
+                    }
+
+                    return Some(Element {
+                        name: name.unwrap(),
+                        attributes,
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// Copied from https://github.com/Florob/RustyXML, Apache licensed. Unescapes all valid XML
+// entities in a string.
+fn unescape(input: &str) -> Result<String> {
+    let mut result = String::with_capacity(input.len());
+
+    let mut it = input.split('&');
+
+    // Push everything before the first '&'
+    if let Some(sub) = it.next() {
+        result.push_str(sub);
+    }
+
+    for sub in it {
+        match sub.find(';') {
+            Some(idx) => {
+                let ent = &sub[..idx];
+                match ent {
+                    "quot" => result.push('"'),
+                    "apos" => result.push('\''),
+                    "gt" => result.push('>'),
+                    "lt" => result.push('<'),
+                    "amp" => result.push('&'),
+                    ent => {
+                        let val = if ent.starts_with("#x") {
+                            u32::from_str_radix(&ent[2..], 16).ok()
+                        } else if ent.starts_with('#') {
+                            u32::from_str_radix(&ent[1..], 10).ok()
+                        } else {
+                            None
+                        };
+                        match val.and_then(char::from_u32) {
+                            Some(c) => result.push(c),
+                            None => bail!("&{};", ent),
+                        }
+                    }
+                }
+                result.push_str(&sub[idx + 1..]);
+            }
+            None => bail!("&".to_owned() + sub),
+        }
+    }
+    Ok(result)
 }


### PR DESCRIPTION
This improves peak memory use and runtime, at the cost of slightly more complex code.

Specifically, a 1.1GB OSM file of Greater London used to OOM on my laptop: https://github.com/RazrFalcon/roxmltree/issues/18#issuecomment-1293630601
With this change, it fits in memory just fine. Additionally, one test of a larger input (200MB XML) went from 4.5s to 3.5s to create a `Document`.