### PR TITLE
Use a unique port for StreetExplorer dev server

### DIFF
--- a/street-explorer/serve_locally.sh
+++ b/street-explorer/serve_locally.sh
@@ -3,4 +3,4 @@ set -e # exit on failure
 set -x # print commands as they are run
 
 wasm-pack build --dev --target web ../osm2streets-js
-python3 -m http.server --directory www/
+python3 -m http.server --directory www/ 8112

--- a/street-explorer/serve_locally.sh
+++ b/street-explorer/serve_locally.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+set -e # exit on failure
+set -x # print commands as they are run
 
-wasm-pack build --dev --target web ../osm2streets-js && python3 -m http.server --directory www/
+wasm-pack build --dev --target web ../osm2streets-js
+python3 -m http.server --directory www/


### PR DESCRIPTION
When developing locally using localhost, it's annoying when multiple projects share the `localhost:8000` host. You can't run the dev server for multiple projects at the same time, and even when you do switch, the browser cache etc. is full of details from the other project.

I like to randomly assign a unique port to each of my projects, so let's use 8112 for this project (inspired by JOSM using 8111).

This PR also adds `set -x` because `wasm-pack` stalled for a whole 4 minutes before printing anything out at all, and the extra context helps demystify situations like that. (I was actually running the osm2lanes editor and it might have been a network issue, I'm not sure.)