### PR TITLE
Store IDs in roads and intersections

### DIFF
--- a/osm2streets/src/ids.rs
+++ b/osm2streets/src/ids.rs
@@ -1,0 +1,78 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::osm::{NodeID, WayID};
+
+/// Refers to a road segment between two nodes, using OSM IDs. Note OSM IDs are not stable over
+/// time.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OriginalRoad {
+    pub osm_way_id: WayID,
+    pub i1: NodeID,
+    pub i2: NodeID,
+}
+
+impl fmt::Display for OriginalRoad {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "OriginalRoad({} from {} to {}",
+            self.osm_way_id, self.i1, self.i2
+        )
+    }
+}
+impl fmt::Debug for OriginalRoad {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl OriginalRoad {
+    pub fn new(way: i64, (i1, i2): (i64, i64)) -> OriginalRoad {
+        OriginalRoad {
+            osm_way_id: WayID(way),
+            i1: NodeID(i1),
+            i2: NodeID(i2),
+        }
+    }
+
+    /// Prints the OriginalRoad in a way that can be copied to Rust code.
+    pub fn as_string_code(&self) -> String {
+        format!(
+            "OriginalRoad::new({}, ({}, {}))",
+            self.osm_way_id.0, self.i1.0, self.i2.0
+        )
+    }
+
+    pub fn has_common_endpoint(&self, other: OriginalRoad) -> bool {
+        if self.i1 == other.i1 || self.i1 == other.i2 {
+            return true;
+        }
+        if self.i2 == other.i1 || self.i2 == other.i2 {
+            return true;
+        }
+        false
+    }
+
+    // TODO Doesn't handle two roads between the same pair of intersections
+    pub fn common_endpt(&self, other: OriginalRoad) -> NodeID {
+        if self.i1 == other.i1 || self.i1 == other.i2 {
+            return self.i1;
+        }
+        if self.i2 == other.i1 || self.i2 == other.i2 {
+            return self.i2;
+        }
+        panic!("{:?} and {:?} have no common_endpt", self, other);
+    }
+
+    pub fn other_side(&self, i: NodeID) -> NodeID {
+        if self.i1 == i {
+            self.i2
+        } else if self.i2 == i {
+            self.i1
+        } else {
+            panic!("{} doesn't have {} on either side", self, i);
+        }
+    }
+}

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -82,6 +82,7 @@ impl StreetNetwork {
     }
 
     pub fn insert_road(&mut self, id: OriginalRoad, road: Road) {
+        assert_eq!(id, road.id);
         self.roads.insert(id, road);
         for i in [id.i1, id.i2] {
             self.intersections.get_mut(&i).unwrap().roads.push(id);
@@ -333,6 +334,8 @@ impl StreetNetwork {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Road {
+    /// This determines the orientation of the road -- what intersection it points at.
+    pub id: OriginalRoad,
     /// This represents the original OSM geometry. No transformation has happened, besides slightly
     /// smoothing the polyline.
     pub untrimmed_center_line: PolyLine,
@@ -357,9 +360,15 @@ pub struct Road {
 }
 
 impl Road {
-    pub fn new(untrimmed_center_line: PolyLine, osm_tags: Tags, config: &MapConfig) -> Self {
+    pub fn new(
+        id: OriginalRoad,
+        untrimmed_center_line: PolyLine,
+        osm_tags: Tags,
+        config: &MapConfig,
+    ) -> Self {
         let lane_specs_ltr = get_lane_specs_ltr(&osm_tags, config);
         Self {
+            id,
             untrimmed_center_line,
             osm_tags,
             turn_restrictions: Vec::new(),
@@ -537,6 +546,8 @@ pub enum CrossingType {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Intersection {
+    pub id: osm::NodeID,
+
     /// Represents the original place where OSM center-lines meet. This may be meaningless beyond
     /// StreetNetwork; roads and intersections get merged and deleted.
     pub point: Pt2D,
@@ -553,8 +564,14 @@ pub struct Intersection {
 }
 
 impl Intersection {
-    pub fn new(point: Pt2D, complexity: IntersectionComplexity, control: ControlType) -> Self {
+    pub fn new(
+        id: osm::NodeID,
+        point: Pt2D,
+        complexity: IntersectionComplexity,
+        control: ControlType,
+    ) -> Self {
         Self {
+            id,
             point,
             complexity,
             control,

--- a/osm2streets/src/transform/merge_short_road.rs
+++ b/osm2streets/src/transform/merge_short_road.rs
@@ -108,7 +108,7 @@ impl StreetNetwork {
         let mut new_to_old = BTreeMap::new();
         for r in self.roads_per_intersection(i2) {
             deleted.push(r);
-            let road = self.remove_road(&r);
+            let mut road = self.remove_road(&r);
             let mut new_id = r;
             if r.i1 == i2 {
                 new_id.i1 = i1;
@@ -116,6 +116,7 @@ impl StreetNetwork {
                 assert_eq!(r.i2, i2);
                 new_id.i2 = i1;
             }
+            road.id = new_id;
 
             if new_id.i1 == new_id.i2 {
                 // When merging many roads around some junction, we wind up with loops. We can

--- a/streets_reader/src/clip.rs
+++ b/streets_reader/src/clip.rs
@@ -54,7 +54,7 @@ pub fn clip_map(streets: &mut StreetNetwork, timer: &mut Timer) -> Result<()> {
 
         if intersection.roads.len() > 1 {
             for r in intersection.roads.clone() {
-                let road = streets.remove_road(&r);
+                let mut road = streets.remove_road(&r);
 
                 let mut copy = streets.intersections[&id].clone();
                 copy.roads.clear();
@@ -69,6 +69,7 @@ pub fn clip_map(streets: &mut StreetNetwork, timer: &mut Timer) -> Result<()> {
                     fixed_road_id.i2 = new_id;
                 }
                 assert_ne!(r, fixed_road_id);
+                road.id = fixed_road_id;
 
                 streets.intersections.insert(new_id, copy);
                 streets.insert_road(fixed_road_id, road);

--- a/streets_reader/src/split_ways.rs
+++ b/streets_reader/src/split_ways.rs
@@ -63,6 +63,7 @@ pub fn split_up_roads(
         streets.intersections.insert(
             *id,
             Intersection::new(
+                *id,
                 pt.to_pt2d(),
                 // Guess a safe generic complexity, specialise later.
                 IntersectionComplexity::Crossing,
@@ -81,6 +82,7 @@ pub fn split_up_roads(
         streets.intersections.insert(
             id,
             Intersection::new(
+                id,
                 point,
                 IntersectionComplexity::Crossing,
                 ControlType::StopSign,
@@ -128,7 +130,7 @@ pub fn split_up_roads(
                 let untrimmed_center_line = simplify_linestring(std::mem::take(&mut pts));
                 match PolyLine::new(untrimmed_center_line) {
                     Ok(pl) => {
-                        streets.insert_road(id, Road::new(pl, tags, &streets.config));
+                        streets.insert_road(id, Road::new(id, pl, tags, &streets.config));
                     }
                     Err(err) => {
                         error!("Skipping {id}: {err}");


### PR DESCRIPTION
This unblocks simpler code in the movements PR by storing the current IDs in each structure. I'm doing this separate from changing IDs to opaque, because that's going to be a much more complex refactor. This smaller step also forces us to find the places where currently we modify the ID of an existing road.