### PR TITLE
Fix the jank in the SmoothWheelZoom plugin

### DIFF
--- a/street-explorer/www/js/deps/SmoothWheelZoom.js
+++ b/street-explorer/www/js/deps/SmoothWheelZoom.js
@@ -36,7 +36,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
         this._wheelMousePosition = map.mouseEventToContainerPoint(e);
         this._centerPoint = map.getSize()._divideBy(2);
         this._startLatLng = map.containerPointToLatLng(this._centerPoint);
-        this._wheelStartLatLng = map.containerPointToLatLng(this._wheelMousePosition);
+        this._wheelMouseLatLng = map.containerPointToLatLng(this._wheelMousePosition);
         this._startZoom = map.getZoom();
         this._moved = false;
         this._zooming = true;
@@ -59,6 +59,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
             this._goalZoom = map._limitZoom(this._goalZoom);
         }
         this._wheelMousePosition = this._map.mouseEventToContainerPoint(e);
+        this._wheelMouseLatLng = map.containerPointToLatLng(this._wheelMousePosition);
 
         clearTimeout(this._timeoutId);
         this._timeoutId = setTimeout(this._onWheelEnd.bind(this), 200);
@@ -89,7 +90,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
         if (map.options.smoothWheelZoom === 'center') {
             this._center = this._startLatLng;
         } else {
-            this._center = map.unproject(map.project(this._wheelStartLatLng, this._zoom).subtract(delta), this._zoom);
+            this._center = map.unproject(map.project(this._wheelMouseLatLng, this._zoom).subtract(delta), this._zoom);
         }
 
         if (!this._moved) {

--- a/street-explorer/www/js/main.js
+++ b/street-explorer/www/js/main.js
@@ -273,10 +273,11 @@ function setupLeafletMap(mapContainer) {
   const map = L.map(mapContainer, {
     layers: [osm],
     maxZoom: 21,
+    zoomSnap: 0,
+    zoomDelta: 0.5,
     scrollWheelZoom: false,
     smoothWheelZoom: true,
     smoothSensitivity: 1,
-    wheelPxPerZoomLevel: 120,
   }).setView([40.0, 10.0], 4);
 
   new GeoSearch.GeoSearchControl({


### PR DESCRIPTION
This PR fixes the jankiness in the plugin that was introduced in #110, and re-introduces the zoomSnap and zoomDelta settings which are still needed for other zooming methods. It is an alternative to #113.

`zoomSnap` is set to 0 to disable snapping altogether, which is a great win for touch-screen pinch zooming.

Zooming with a scroll wheel and track pad scrolling both feel great to me!