### PR TITLE
A few refactors

### DIFF
--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -1,0 +1,57 @@
+use std::collections::BTreeMap;
+
+use geom::{Distance, Polygon, Pt2D};
+use serde::{Deserialize, Serialize};
+
+use crate::{osm, ConflictType, ControlType, IntersectionComplexity, Movement, OriginalRoad};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Intersection {
+    pub id: osm::NodeID,
+
+    /// Represents the original place where OSM center-lines meet. This may be meaningless beyond
+    /// StreetNetwork; roads and intersections get merged and deleted.
+    pub point: Pt2D,
+    /// This will be a placeholder until `Transformation::GenerateIntersectionGeometry` runs.
+    pub polygon: Polygon,
+    pub complexity: IntersectionComplexity,
+    pub conflict_level: ConflictType,
+    pub control: ControlType,
+    pub elevation: Distance,
+
+    /// All roads connected to this intersection. They may be incoming or outgoing relative to this
+    /// intersection. They're ordered clockwise aroundd the intersection.
+    pub roads: Vec<OriginalRoad>,
+    pub movements: Vec<Movement>,
+
+    // true if src_i matches this intersection (or the deleted/consolidated one, whatever)
+    pub trim_roads_for_merging: BTreeMap<(osm::WayID, bool), Pt2D>,
+}
+
+impl Intersection {
+    pub fn new(
+        id: osm::NodeID,
+        point: Pt2D,
+        complexity: IntersectionComplexity,
+        conflict_level: ConflictType,
+        control: ControlType,
+    ) -> Self {
+        Self {
+            id,
+            point,
+            polygon: Polygon::dummy(),
+            complexity,
+            conflict_level,
+            control,
+            // Filled out later
+            roads: Vec::new(),
+            movements: Vec::new(),
+            elevation: Distance::ZERO,
+            trim_roads_for_merging: BTreeMap::new(),
+        }
+    }
+
+    pub fn is_border(&self) -> bool {
+        self.control == ControlType::Border
+    }
+}

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -9,8 +9,8 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use abstutil::{deserialize_btreemap, serialize_btreemap, Tags};
-use geom::{Angle, Distance, GPSBounds, PolyLine, Polygon, Pt2D};
+use abstutil::{deserialize_btreemap, serialize_btreemap};
+use geom::{Distance, GPSBounds, PolyLine, Polygon, Pt2D};
 
 pub use self::geometry::{intersection_polygon, InputRoad};
 pub use self::ids::OriginalRoad;
@@ -18,6 +18,7 @@ pub use self::lanes::{
     get_lane_specs_ltr, BufferType, Direction, LaneSpec, LaneType, NORMAL_LANE_THICKNESS,
     SIDEWALK_THICKNESS,
 };
+pub use self::road::Road;
 pub use self::transform::Transformation;
 pub use self::types::{
     ConflictType, ControlType, DrivingSide, IntersectionComplexity, MapConfig, Movement,
@@ -31,6 +32,7 @@ mod lanes;
 pub mod osm;
 mod pathfinding;
 mod render;
+mod road;
 mod transform;
 mod types;
 
@@ -325,223 +327,6 @@ impl StreetNetwork {
             .min_by_key(|(_, i)| i.point.dist_to(pt))
             .map(|(id, _)| *id)
             .unwrap()
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Road {
-    /// This determines the orientation of the road -- what intersection it points at.
-    pub id: OriginalRoad,
-    /// This represents the original OSM geometry. No transformation has happened, besides slightly
-    /// smoothing the polyline.
-    pub untrimmed_center_line: PolyLine,
-    /// The physical center of the road, including sidewalks. This won't actually be trimmed until
-    /// `Transformation::GenerateIntersectionGeometry` runs.
-    pub trimmed_center_line: PolyLine,
-    pub osm_tags: Tags,
-    pub turn_restrictions: Vec<(RestrictionType, OriginalRoad)>,
-    /// (via, to). For turn restrictions where 'via' is an entire road. Only BanTurns.
-    pub complicated_turn_restrictions: Vec<(OriginalRoad, OriginalRoad)>,
-    pub percent_incline: f64,
-    /// Is there a tagged crosswalk near each end of the road?
-    pub crosswalk_forward: bool,
-    pub crosswalk_backward: bool,
-    // TODO Preserving these two across transformations (especially merging dual carriageways!)
-    // could be really hard. It might be better to split the road into two pieces to match the more
-    // often used OSM style.
-    /// Barrier nodes along this road's original center line.
-    pub barrier_nodes: Vec<Pt2D>,
-    /// Crossing nodes along this road's original center line.
-    pub crossing_nodes: Vec<(Pt2D, CrossingType)>,
-
-    /// Derived from osm_tags. Not automatically updated.
-    pub lane_specs_ltr: Vec<LaneSpec>,
-}
-
-impl Road {
-    pub fn new(
-        id: OriginalRoad,
-        untrimmed_center_line: PolyLine,
-        osm_tags: Tags,
-        config: &MapConfig,
-    ) -> Self {
-        let lane_specs_ltr = get_lane_specs_ltr(&osm_tags, config);
-        Self {
-            id,
-            untrimmed_center_line,
-            trimmed_center_line: PolyLine::dummy(),
-            osm_tags,
-            turn_restrictions: Vec::new(),
-            complicated_turn_restrictions: Vec::new(),
-            percent_incline: 0.0,
-            // Start assuming there's a crosswalk everywhere, and maybe filter it down
-            // later
-            crosswalk_forward: true,
-            crosswalk_backward: true,
-            barrier_nodes: Vec::new(),
-            crossing_nodes: Vec::new(),
-
-            lane_specs_ltr,
-        }
-    }
-
-    // TODO For the moment, treating all rail things as light rail
-    pub fn is_light_rail(&self) -> bool {
-        self.osm_tags.is_any("railway", vec!["light_rail", "rail"])
-    }
-
-    pub fn is_footway(&self) -> bool {
-        self.osm_tags.is_any(
-            osm::HIGHWAY,
-            vec![
-                // TODO cycleway in here is weird, reconsider. is_footway is only used in one
-                // disabled transformation right now.
-                "cycleway",
-                "footway",
-                "path",
-                "pedestrian",
-                "steps",
-                "track",
-            ],
-        )
-    }
-
-    pub fn is_service(&self) -> bool {
-        self.osm_tags.is(osm::HIGHWAY, "service")
-    }
-
-    pub fn is_cycleway(&self) -> bool {
-        // Don't repeat the logic looking at the tags, just see what lanes we'll create
-        let mut bike = false;
-        for spec in &self.lane_specs_ltr {
-            if spec.lt == LaneType::Biking {
-                bike = true;
-            } else if spec.lt != LaneType::Shoulder {
-                return false;
-            }
-        }
-        bike
-    }
-
-    pub fn is_driveable(&self) -> bool {
-        self.lane_specs_ltr
-            .iter()
-            .any(|spec| spec.lt == LaneType::Driving)
-    }
-
-    pub fn oneway_for_driving(&self) -> Option<Direction> {
-        LaneSpec::oneway_for_driving(&self.lane_specs_ltr)
-    }
-
-    /// Points from first to last point. Undefined for loops.
-    pub fn angle(&self) -> Angle {
-        self.untrimmed_center_line
-            .first_pt()
-            .angle_to(self.untrimmed_center_line.last_pt())
-    }
-
-    /// The length of the original OSM center line, before any trimming away from intersections
-    pub fn untrimmed_length(&self) -> Distance {
-        self.untrimmed_center_line.length()
-    }
-
-    pub fn get_zorder(&self) -> isize {
-        if let Some(layer) = self.osm_tags.get("layer") {
-            match layer.parse::<f64>() {
-                // Just drop .5 for now
-                Ok(l) => l as isize,
-                Err(_) => {
-                    warn!("Weird layer={} on {}", layer, self.osm_url());
-                    0
-                }
-            }
-        } else {
-            0
-        }
-    }
-
-    /// Returns the corrected (but untrimmed) center and total width for a road
-    pub fn untrimmed_road_geometry(&self) -> (PolyLine, Distance) {
-        let mut total_width = Distance::ZERO;
-        let mut sidewalk_right = None;
-        let mut sidewalk_left = None;
-        for l in &self.lane_specs_ltr {
-            total_width += l.width;
-            if l.lt.is_walkable() {
-                if l.dir == Direction::Back {
-                    sidewalk_left = Some(l.width);
-                } else {
-                    sidewalk_right = Some(l.width);
-                }
-            }
-        }
-
-        // If there's a sidewalk on only one side, adjust the true center of the road.
-        // TODO I don't remember the rationale for doing this in the first place. What if there's a
-        // shoulder and a sidewalk of different widths? We don't do anything then
-        let mut true_center = self.untrimmed_center_line.clone();
-        match (sidewalk_right, sidewalk_left) {
-            (Some(w), None) => {
-                true_center = true_center.must_shift_right(w / 2.0);
-            }
-            (None, Some(w)) => {
-                true_center = true_center.must_shift_right(w / 2.0);
-            }
-            _ => {}
-        }
-
-        (true_center, total_width)
-    }
-
-    pub fn osm_url(&self) -> String {
-        // Since we don't store an OriginalRoad (since we may need to update it during
-        // transformations), this may be convenient
-        format!(
-            "http://openstreetmap.org/way/{}",
-            self.osm_tags.get(osm::OSM_WAY_ID).unwrap()
-        )
-    }
-
-    pub fn total_width(&self) -> Distance {
-        self.lane_specs_ltr.iter().map(|l| l.width).sum()
-    }
-
-    /// Returns one PolyLine representing the center of each lane in this road. This must be called
-    /// after `Transformation::GenerateIntersectionGeometry` is run. The result also faces the same
-    /// direction as the road.
-    pub(crate) fn get_lane_center_lines(&self) -> Vec<PolyLine> {
-        let total_width = self.total_width();
-
-        let mut width_so_far = Distance::ZERO;
-        let mut output = Vec::new();
-        for lane in &self.lane_specs_ltr {
-            width_so_far += lane.width / 2.0;
-            output.push(
-                self.trimmed_center_line
-                    .shift_from_center(total_width, width_so_far)
-                    .unwrap_or_else(|_| self.trimmed_center_line.clone()),
-            );
-            width_so_far += lane.width / 2.0;
-        }
-        output
-    }
-
-    /// Returns the untrimmed left and right side of the road, oriented in the same direction of
-    /// the road
-    pub fn get_untrimmed_sides(&self) -> Result<(PolyLine, PolyLine)> {
-        let (center, total_width) = self.untrimmed_road_geometry();
-        let left = center.shift_from_center(total_width, -total_width / 2.0)?;
-        let right = center.shift_from_center(total_width, total_width / 2.0)?;
-        Ok((left, right))
-    }
-
-    pub(crate) fn to_input_road(&self) -> InputRoad {
-        InputRoad {
-            id: self.id,
-            center_pts: self.trimmed_center_line.clone(),
-            half_width: self.total_width() / 2.0,
-            osm_tags: self.osm_tags.clone(),
-        }
     }
 }
 

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -1,0 +1,227 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use abstutil::Tags;
+use geom::{Angle, Distance, PolyLine, Pt2D};
+
+use crate::{
+    get_lane_specs_ltr, osm, CrossingType, Direction, InputRoad, LaneSpec, LaneType, MapConfig,
+    OriginalRoad, RestrictionType,
+};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Road {
+    /// This determines the orientation of the road -- what intersection it points at.
+    pub id: OriginalRoad,
+    /// This represents the original OSM geometry. No transformation has happened, besides slightly
+    /// smoothing the polyline.
+    pub untrimmed_center_line: PolyLine,
+    /// The physical center of the road, including sidewalks. This won't actually be trimmed until
+    /// `Transformation::GenerateIntersectionGeometry` runs.
+    pub trimmed_center_line: PolyLine,
+    pub osm_tags: Tags,
+    pub turn_restrictions: Vec<(RestrictionType, OriginalRoad)>,
+    /// (via, to). For turn restrictions where 'via' is an entire road. Only BanTurns.
+    pub complicated_turn_restrictions: Vec<(OriginalRoad, OriginalRoad)>,
+    pub percent_incline: f64,
+    /// Is there a tagged crosswalk near each end of the road?
+    pub crosswalk_forward: bool,
+    pub crosswalk_backward: bool,
+    // TODO Preserving these two across transformations (especially merging dual carriageways!)
+    // could be really hard. It might be better to split the road into two pieces to match the more
+    // often used OSM style.
+    /// Barrier nodes along this road's original center line.
+    pub barrier_nodes: Vec<Pt2D>,
+    /// Crossing nodes along this road's original center line.
+    pub crossing_nodes: Vec<(Pt2D, CrossingType)>,
+
+    /// Derived from osm_tags. Not automatically updated.
+    pub lane_specs_ltr: Vec<LaneSpec>,
+}
+
+impl Road {
+    pub fn new(
+        id: OriginalRoad,
+        untrimmed_center_line: PolyLine,
+        osm_tags: Tags,
+        config: &MapConfig,
+    ) -> Self {
+        let lane_specs_ltr = get_lane_specs_ltr(&osm_tags, config);
+        Self {
+            id,
+            untrimmed_center_line,
+            trimmed_center_line: PolyLine::dummy(),
+            osm_tags,
+            turn_restrictions: Vec::new(),
+            complicated_turn_restrictions: Vec::new(),
+            percent_incline: 0.0,
+            // Start assuming there's a crosswalk everywhere, and maybe filter it down
+            // later
+            crosswalk_forward: true,
+            crosswalk_backward: true,
+            barrier_nodes: Vec::new(),
+            crossing_nodes: Vec::new(),
+
+            lane_specs_ltr,
+        }
+    }
+
+    // TODO For the moment, treating all rail things as light rail
+    pub fn is_light_rail(&self) -> bool {
+        self.osm_tags.is_any("railway", vec!["light_rail", "rail"])
+    }
+
+    pub fn is_footway(&self) -> bool {
+        self.osm_tags.is_any(
+            osm::HIGHWAY,
+            vec![
+                // TODO cycleway in here is weird, reconsider. is_footway is only used in one
+                // disabled transformation right now.
+                "cycleway",
+                "footway",
+                "path",
+                "pedestrian",
+                "steps",
+                "track",
+            ],
+        )
+    }
+
+    pub fn is_service(&self) -> bool {
+        self.osm_tags.is(osm::HIGHWAY, "service")
+    }
+
+    pub fn is_cycleway(&self) -> bool {
+        // Don't repeat the logic looking at the tags, just see what lanes we'll create
+        let mut bike = false;
+        for spec in &self.lane_specs_ltr {
+            if spec.lt == LaneType::Biking {
+                bike = true;
+            } else if spec.lt != LaneType::Shoulder {
+                return false;
+            }
+        }
+        bike
+    }
+
+    pub fn is_driveable(&self) -> bool {
+        self.lane_specs_ltr
+            .iter()
+            .any(|spec| spec.lt == LaneType::Driving)
+    }
+
+    pub fn oneway_for_driving(&self) -> Option<Direction> {
+        LaneSpec::oneway_for_driving(&self.lane_specs_ltr)
+    }
+
+    /// Points from first to last point. Undefined for loops.
+    pub fn angle(&self) -> Angle {
+        self.untrimmed_center_line
+            .first_pt()
+            .angle_to(self.untrimmed_center_line.last_pt())
+    }
+
+    /// The length of the original OSM center line, before any trimming away from intersections
+    pub fn untrimmed_length(&self) -> Distance {
+        self.untrimmed_center_line.length()
+    }
+
+    pub fn get_zorder(&self) -> isize {
+        if let Some(layer) = self.osm_tags.get("layer") {
+            match layer.parse::<f64>() {
+                // Just drop .5 for now
+                Ok(l) => l as isize,
+                Err(_) => {
+                    warn!("Weird layer={} on {}", layer, self.osm_url());
+                    0
+                }
+            }
+        } else {
+            0
+        }
+    }
+
+    /// Returns the corrected (but untrimmed) center and total width for a road
+    pub fn untrimmed_road_geometry(&self) -> (PolyLine, Distance) {
+        let mut total_width = Distance::ZERO;
+        let mut sidewalk_right = None;
+        let mut sidewalk_left = None;
+        for l in &self.lane_specs_ltr {
+            total_width += l.width;
+            if l.lt.is_walkable() {
+                if l.dir == Direction::Back {
+                    sidewalk_left = Some(l.width);
+                } else {
+                    sidewalk_right = Some(l.width);
+                }
+            }
+        }
+
+        // If there's a sidewalk on only one side, adjust the true center of the road.
+        // TODO I don't remember the rationale for doing this in the first place. What if there's a
+        // shoulder and a sidewalk of different widths? We don't do anything then
+        let mut true_center = self.untrimmed_center_line.clone();
+        match (sidewalk_right, sidewalk_left) {
+            (Some(w), None) => {
+                true_center = true_center.must_shift_right(w / 2.0);
+            }
+            (None, Some(w)) => {
+                true_center = true_center.must_shift_right(w / 2.0);
+            }
+            _ => {}
+        }
+
+        (true_center, total_width)
+    }
+
+    pub fn osm_url(&self) -> String {
+        // Since we don't store an OriginalRoad (since we may need to update it during
+        // transformations), this may be convenient
+        format!(
+            "http://openstreetmap.org/way/{}",
+            self.osm_tags.get(osm::OSM_WAY_ID).unwrap()
+        )
+    }
+
+    pub fn total_width(&self) -> Distance {
+        self.lane_specs_ltr.iter().map(|l| l.width).sum()
+    }
+
+    /// Returns one PolyLine representing the center of each lane in this road. This must be called
+    /// after `Transformation::GenerateIntersectionGeometry` is run. The result also faces the same
+    /// direction as the road.
+    pub(crate) fn get_lane_center_lines(&self) -> Vec<PolyLine> {
+        let total_width = self.total_width();
+
+        let mut width_so_far = Distance::ZERO;
+        let mut output = Vec::new();
+        for lane in &self.lane_specs_ltr {
+            width_so_far += lane.width / 2.0;
+            output.push(
+                self.trimmed_center_line
+                    .shift_from_center(total_width, width_so_far)
+                    .unwrap_or_else(|_| self.trimmed_center_line.clone()),
+            );
+            width_so_far += lane.width / 2.0;
+        }
+        output
+    }
+
+    /// Returns the untrimmed left and right side of the road, oriented in the same direction of
+    /// the road
+    pub fn get_untrimmed_sides(&self) -> Result<(PolyLine, PolyLine)> {
+        let (center, total_width) = self.untrimmed_road_geometry();
+        let left = center.shift_from_center(total_width, -total_width / 2.0)?;
+        let right = center.shift_from_center(total_width, total_width / 2.0)?;
+        Ok((left, right))
+    }
+
+    pub(crate) fn to_input_road(&self) -> InputRoad {
+        InputRoad {
+            id: self.id,
+            center_pts: self.trimmed_center_line.clone(),
+            half_width: self.total_width() / 2.0,
+            osm_tags: self.osm_tags.clone(),
+        }
+    }
+}

--- a/osm2streets/src/transform/classify_intersections.rs
+++ b/osm2streets/src/transform/classify_intersections.rs
@@ -35,8 +35,7 @@ pub fn guess_complexity(
 ) -> (IntersectionComplexity, ConflictType, Vec<Movement>) {
     let roads: Vec<_> = streets
         .roads_per_intersection(*intersection_id)
-        .iter()
-        .map(|id| &streets.roads[id])
+        .into_iter()
         .filter(|road| road.is_driveable())
         .collect();
 

--- a/osm2streets/src/transform/collapse_intersections.rs
+++ b/osm2streets/src/transform/collapse_intersections.rs
@@ -17,7 +17,7 @@ pub fn collapse(streets: &mut StreetNetwork) {
         if roads.len() != 2 {
             continue;
         }
-        match should_collapse(&streets.roads[&roads[0]], &streets.roads[&roads[1]]) {
+        match should_collapse(roads[0], roads[1]) {
             Ok(()) => {
                 merge.push(*id);
             }
@@ -131,7 +131,7 @@ fn should_collapse(road1: &Road, road2: &Road) -> Result<()> {
 }
 
 pub fn collapse_intersection(streets: &mut StreetNetwork, i: NodeID) {
-    let roads = streets.roads_per_intersection(i);
+    let roads = streets.intersections[&i].roads.clone();
     assert_eq!(roads.len(), 2);
     let mut r1 = roads[0];
     let mut r2 = roads[1];
@@ -233,11 +233,11 @@ pub fn trim_deadends(streets: &mut StreetNetwork) {
         if roads.len() != 1 || i.control == ControlType::Border {
             continue;
         }
-        let road = &streets.roads[&roads[0]];
+        let road = &roads[0];
         if road.untrimmed_length() < SHORT_THRESHOLD
             && (road.is_cycleway() || road.osm_tags.is(osm::HIGHWAY, "service"))
         {
-            remove_roads.insert(roads[0]);
+            remove_roads.insert(roads[0].id);
             remove_intersections.insert(*id);
         }
     }

--- a/osm2streets/src/transform/collapse_intersections.rs
+++ b/osm2streets/src/transform/collapse_intersections.rs
@@ -246,7 +246,7 @@ pub fn trim_deadends(streets: &mut StreetNetwork) {
         streets.remove_road(&r);
     }
     for i in remove_intersections {
-        streets.delete_intersection(i);
+        streets.remove_intersection(i);
     }
 
     // It's possible we need to do this in a fixed-point until there are no changes, but meh.

--- a/osm2streets/src/transform/sausage_links.rs
+++ b/osm2streets/src/transform/sausage_links.rs
@@ -25,8 +25,8 @@ fn find_sausage_links(streets: &StreetNetwork) -> BTreeSet<(OriginalRoad, Origin
         }
         // Find roads that lead between the two endpoints
         let mut common_roads: BTreeSet<OriginalRoad> =
-            into_set(streets.roads_per_intersection(id1.i1))
-                .intersection(&into_set(streets.roads_per_intersection(id1.i2)))
+            into_set(streets.intersections[&id1.i1].roads.clone())
+                .intersection(&into_set(streets.intersections[&id1.i2].roads.clone()))
                 .cloned()
                 .collect();
         // Normally it's just this one road

--- a/osm2streets/src/transform/separate_cycletracks.rs
+++ b/osm2streets/src/transform/separate_cycletracks.rs
@@ -57,10 +57,9 @@ fn find_cycleways(streets: &StreetNetwork) -> Vec<Cycleway> {
             let mut main_road_endpoints = Vec::new();
             for i in [cycleway_id.i1, cycleway_id.i2] {
                 let mut candidates = Vec::new();
-                for r in streets.roads_per_intersection(i) {
-                    let road = &streets.roads[&r];
+                for road in streets.roads_per_intersection(i) {
                     if road.untrimmed_length() < SHORT_ROAD_THRESHOLD {
-                        candidates.push(r);
+                        candidates.push(road.id);
                     }
                 }
                 if candidates.len() == 1 {

--- a/streets_reader/src/split_ways.rs
+++ b/streets_reader/src/split_ways.rs
@@ -156,7 +156,7 @@ pub fn split_up_roads(
         if !streets.intersections.contains_key(&via_osm) {
             continue;
         }
-        let roads = streets.roads_per_intersection(via_osm);
+        let roads = &streets.intersections[&via_osm].roads;
         // If some of the roads are missing, they were likely filtered out -- usually service
         // roads.
         if let (Some(from), Some(to)) = (
@@ -195,15 +195,15 @@ pub fn split_up_roads(
         }
         let via = via_candidates[0];
 
-        let maybe_from = streets
-            .roads_per_intersection(via.i1)
-            .into_iter()
-            .chain(streets.roads_per_intersection(via.i2).into_iter())
+        let maybe_from = streets.intersections[&via.i1]
+            .roads
+            .iter()
+            .chain(&streets.intersections[&via.i2].roads)
             .find(|r| r.osm_way_id == from_osm);
-        let maybe_to = streets
-            .roads_per_intersection(via.i1)
-            .into_iter()
-            .chain(streets.roads_per_intersection(via.i2).into_iter())
+        let maybe_to = streets.intersections[&via.i1]
+            .roads
+            .iter()
+            .chain(&streets.intersections[&via.i2].roads)
             .find(|r| r.osm_way_id == to_osm);
         match (maybe_from, maybe_to) {
             (Some(from), Some(to)) => {
@@ -223,7 +223,7 @@ pub fn split_up_roads(
             .get_mut(&from)
             .unwrap()
             .complicated_turn_restrictions
-            .push((via, to));
+            .push((via, *to));
     }
 
     timer.start("match traffic signals to intersections");


### PR DESCRIPTION
Viewing commits individually may be easier.

1) `roads_per_intersection` returns `Vec<&Road>`. It's more convenient for some callers. The others can just lookup the `Vec<OriginalRoad>` themselves.
2) Move `Road` and its impl into a module, just because there's enough methods there to feel like a bit more organization is nice.
3) Remove some of the methods used by the `RawMap` editor. They're for interactively dragging intersections around. I think it's noisy / irrelevant to have these methods in this repo; they don't yet batch mutations or recalculate derived things in any nice way. If we want to support this kind of operation on a streetnetwork "properly", we can bring the code back and think through it again.

The big refactor coming after this is switching to opaque IDs