### PR TITLE
Add src_i and dst_i fields to Road, as a step towards opaque IDs. Change

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -48,6 +48,9 @@ impl JsStreetNetwork {
             transformations.push(Transformation::SnapCycleways);
             transformations.push(Transformation::TrimDeadendCycleways);
             transformations.push(Transformation::CollapseDegenerateIntersections);
+            // TODO Indeed it'd be much nicer to recalculate this as the above transformations
+            // modify things
+            transformations.push(Transformation::GenerateIntersectionGeometry);
         }
         if input.debug_each_step {
             street_network.apply_transformations_stepwise_debugging(transformations, &mut timer);

--- a/osm2streets/src/geometry/algorithm.rs
+++ b/osm2streets/src/geometry/algorithm.rs
@@ -215,7 +215,7 @@ fn generalized_trim_back(
             }
         }
 
-        let new_center = if r1.i2 == i {
+        let new_center = if roads[r1].dst_i == i {
             shortest_center
         } else {
             shortest_center.reversed()
@@ -562,7 +562,7 @@ fn on_off_ramp(
         roads.get_mut(&thin.id).unwrap().center_pts = trimmed_thin;
 
         // Trim the thick extra ends at the intersection
-        let extra = if thick_id.i2 == results.intersection_id {
+        let extra = if roads[&thick_id].dst_i == results.intersection_id {
             roads[&thick_id]
                 .center_pts
                 .get_slice_starting_at(trimmed_thick.last_pt())?

--- a/osm2streets/src/geometry/mod.rs
+++ b/osm2streets/src/geometry/mod.rs
@@ -24,6 +24,8 @@ pub use algorithm::intersection_polygon;
 #[derive(Clone)]
 pub struct InputRoad {
     pub id: OriginalRoad,
+    pub src_i: osm::NodeID,
+    pub dst_i: osm::NodeID,
     /// The true center of the road, including sidewalks. The input is untrimmed when called on the
     /// first endpoint, then trimmed on that one side when called on th second endpoint.
     pub center_pts: PolyLine,

--- a/osm2streets/src/ids.rs
+++ b/osm2streets/src/ids.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::osm::{NodeID, WayID};
+use crate::Road;
 
 /// Refers to a road segment between two nodes, using OSM IDs. Note OSM IDs are not stable over
 /// time.
@@ -37,14 +38,6 @@ impl OriginalRoad {
         }
     }
 
-    /// Prints the OriginalRoad in a way that can be copied to Rust code.
-    pub fn as_string_code(&self) -> String {
-        format!(
-            "OriginalRoad::new({}, ({}, {}))",
-            self.osm_way_id.0, self.i1.0, self.i2.0
-        )
-    }
-
     pub fn has_common_endpoint(&self, other: OriginalRoad) -> bool {
         if self.i1 == other.i1 || self.i1 == other.i2 {
             return true;
@@ -65,14 +58,32 @@ impl OriginalRoad {
         }
         panic!("{:?} and {:?} have no common_endpt", self, other);
     }
+}
+
+/// It's sometimes useful to track both a road's ID and endpoints together. Use this sparingly.
+#[derive(Clone)]
+pub struct RoadWithEndpoints {
+    pub road: OriginalRoad,
+    pub src_i: NodeID,
+    pub dst_i: NodeID,
+}
+
+impl RoadWithEndpoints {
+    pub fn new(road: &Road) -> Self {
+        Self {
+            road: road.id,
+            src_i: road.src_i,
+            dst_i: road.dst_i,
+        }
+    }
 
     pub fn other_side(&self, i: NodeID) -> NodeID {
-        if self.i1 == i {
-            self.i2
-        } else if self.i2 == i {
-            self.i1
+        if self.src_i == i {
+            self.dst_i
+        } else if self.dst_i == i {
+            self.src_i
         } else {
-            panic!("{} doesn't have {} on either side", self, i);
+            panic!("{} doesn't have {} on either side", self.road, i);
         }
     }
 }

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -13,8 +13,8 @@ use abstutil::{deserialize_btreemap, serialize_btreemap};
 use geom::{GPSBounds, PolyLine, Polygon, Pt2D};
 
 pub use self::geometry::{intersection_polygon, InputRoad};
-pub use self::ids::OriginalRoad;
 pub(crate) use self::ids::RoadWithEndpoints;
+pub use self::ids::{CommonEndpoint, OriginalRoad};
 pub use self::intersection::Intersection;
 pub use self::lanes::{
     get_lane_specs_ltr, BufferType, Direction, LaneSpec, LaneType, NORMAL_LANE_THICKNESS,

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -86,7 +86,7 @@ impl StreetNetwork {
     }
 
     pub fn insert_road(&mut self, road: Road) {
-        let endpts = vec![road.src_i, road.dst_i];
+        let endpts = road.endpoints();
         let id = road.id;
         self.roads.insert(road.id, road);
         for i in endpts {
@@ -98,11 +98,7 @@ impl StreetNetwork {
     }
 
     pub fn remove_road(&mut self, id: OriginalRoad) -> Road {
-        let endpts = {
-            let r = &self.roads[&id];
-            vec![r.src_i, r.dst_i]
-        };
-        for i in endpts {
+        for i in self.roads[&id].endpoints() {
             self.intersections
                 .get_mut(&i)
                 .unwrap()

--- a/osm2streets/src/pathfinding.rs
+++ b/osm2streets/src/pathfinding.rs
@@ -11,10 +11,10 @@ impl StreetNetwork {
     /// through intersections.
     pub fn path_dist_to(&self, from: osm::NodeID, to: osm::NodeID) -> Option<Distance> {
         let mut graph = DiGraphMap::new();
-        for (id, r) in &self.roads {
-            graph.add_edge(id.i1, id.i2, id);
+        for r in self.roads.values() {
+            graph.add_edge(r.src_i, r.dst_i, r.id);
             if r.oneway_for_driving().is_none() {
-                graph.add_edge(id.i2, id.i1, id);
+                graph.add_edge(r.dst_i, r.src_i, r.id);
             }
         }
         petgraph::algo::dijkstra(&graph, from, Some(to), |(_, _, r)| {
@@ -33,7 +33,7 @@ impl StreetNetwork {
         lane_types: &[LaneType],
     ) -> Option<Vec<(OriginalRoad, Direction)>> {
         let mut graph = DiGraphMap::new();
-        for (id, r) in &self.roads {
+        for r in self.roads.values() {
             let mut fwd = false;
             let mut back = false;
             for lane in &r.lane_specs_ltr {
@@ -46,10 +46,10 @@ impl StreetNetwork {
                 }
             }
             if fwd {
-                graph.add_edge(id.i1, id.i2, (*id, Direction::Fwd));
+                graph.add_edge(r.src_i, r.dst_i, (r.id, Direction::Fwd));
             }
             if back {
-                graph.add_edge(id.i2, id.i1, (*id, Direction::Back));
+                graph.add_edge(r.dst_i, r.src_i, (r.id, Direction::Back));
             }
         }
         let (_, path) = petgraph::algo::astar(

--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -25,16 +25,16 @@ impl StreetNetwork {
         let mut pairs = Vec::new();
 
         // Add a polygon per road
-        for (id, road) in &self.roads {
+        for road in self.roads.values() {
             pairs.push((
                 road.trimmed_center_line
                     .make_polygons(2.0 * road.total_width() / 2.0)
                     .to_geojson(Some(&self.gps_bounds)),
                 make_props(&[
                     ("type", "road".into()),
-                    ("osm_way_id", id.osm_way_id.0.into()),
-                    ("src_i", id.i1.0.into()),
-                    ("dst_i", id.i2.0.into()),
+                    ("osm_way_id", road.id.osm_way_id.0.into()),
+                    ("src_i", road.src_i.0.into()),
+                    ("dst_i", road.dst_i.0.into()),
                 ]),
             ));
         }
@@ -272,7 +272,7 @@ impl StreetNetwork {
                 .iter()
                 .map(|r| {
                     let road = &self.roads[r];
-                    let first_road_segment = if road.id.i1 == *i {
+                    let first_road_segment = if road.src_i == *i {
                         road.trimmed_center_line.first_line()
                     } else {
                         road.trimmed_center_line.last_line().reversed()

--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -231,11 +231,11 @@ impl StreetNetwork {
 
         for (i, intersection) in &self.intersections {
             for (idx, r) in intersection.roads.iter().enumerate() {
-                let pl = &self.roads[r].trimmed_center_line;
-                let pt = if r.i1 == *i {
-                    pl.first_pt()
+                let road = &self.roads[r];
+                let pt = if road.src_i == *i {
+                    road.trimmed_center_line.first_pt()
                 } else {
-                    pl.last_pt()
+                    road.trimmed_center_line.last_pt()
                 };
                 pairs.push((
                     pt.to_geojson(Some(&self.gps_bounds)),

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -5,8 +5,8 @@ use abstutil::Tags;
 use geom::{Angle, Distance, PolyLine, Pt2D};
 
 use crate::{
-    get_lane_specs_ltr, osm, CrossingType, Direction, InputRoad, LaneSpec, LaneType, MapConfig,
-    OriginalRoad, RestrictionType, RoadWithEndpoints,
+    get_lane_specs_ltr, osm, CommonEndpoint, CrossingType, Direction, InputRoad, LaneSpec,
+    LaneType, MapConfig, OriginalRoad, RestrictionType, RoadWithEndpoints,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -238,5 +238,9 @@ impl Road {
 
     pub fn other_side(&self, i: osm::NodeID) -> osm::NodeID {
         RoadWithEndpoints::new(self).other_side(i)
+    }
+
+    pub fn common_endpoint(&self, other: &Road) -> CommonEndpoint {
+        CommonEndpoint::new((self.src_i, self.dst_i), (other.src_i, other.dst_i))
     }
 }

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -11,8 +11,9 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Road {
-    /// This determines the orientation of the road -- what intersection it points at.
     pub id: OriginalRoad,
+    pub src_i: osm::NodeID,
+    pub dst_i: osm::NodeID,
     /// This represents the original OSM geometry. No transformation has happened, besides slightly
     /// smoothing the polyline.
     pub untrimmed_center_line: PolyLine,
@@ -42,6 +43,8 @@ pub struct Road {
 impl Road {
     pub fn new(
         id: OriginalRoad,
+        src_i: osm::NodeID,
+        dst_i: osm::NodeID,
         untrimmed_center_line: PolyLine,
         osm_tags: Tags,
         config: &MapConfig,
@@ -49,6 +52,8 @@ impl Road {
         let lane_specs_ltr = get_lane_specs_ltr(&osm_tags, config);
         Self {
             id,
+            src_i,
+            dst_i,
             untrimmed_center_line,
             trimmed_center_line: PolyLine::dummy(),
             osm_tags,
@@ -219,6 +224,8 @@ impl Road {
     pub(crate) fn to_input_road(&self) -> InputRoad {
         InputRoad {
             id: self.id,
+            src_i: self.src_i,
+            dst_i: self.dst_i,
             center_pts: self.trimmed_center_line.clone(),
             half_width: self.total_width() / 2.0,
             osm_tags: self.osm_tags.clone(),

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -6,7 +6,7 @@ use geom::{Angle, Distance, PolyLine, Pt2D};
 
 use crate::{
     get_lane_specs_ltr, osm, CrossingType, Direction, InputRoad, LaneSpec, LaneType, MapConfig,
-    OriginalRoad, RestrictionType,
+    OriginalRoad, RestrictionType, RoadWithEndpoints,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -234,5 +234,9 @@ impl Road {
             half_width: self.total_width() / 2.0,
             osm_tags: self.osm_tags.clone(),
         }
+    }
+
+    pub fn other_side(&self, i: osm::NodeID) -> osm::NodeID {
+        RoadWithEndpoints::new(self).other_side(i)
     }
 }

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -221,6 +221,10 @@ impl Road {
         Ok((left, right))
     }
 
+    pub fn endpoints(&self) -> Vec<osm::NodeID> {
+        vec![self.src_i, self.dst_i]
+    }
+
     pub(crate) fn to_input_road(&self) -> InputRoad {
         InputRoad {
             id: self.id,

--- a/osm2streets/src/transform/classify_intersections.rs
+++ b/osm2streets/src/transform/classify_intersections.rs
@@ -118,7 +118,7 @@ pub fn guess_complexity(
 
 fn can_drive_out_of(road: &Road, which_end: NodeID) -> bool {
     if let Some(driving_dir) = road.oneway_for_driving() {
-        let required_dir = if road.id.i2 == which_end {
+        let required_dir = if road.dst_i == which_end {
             Direction::Fwd
         } else {
             Direction::Back
@@ -130,7 +130,7 @@ fn can_drive_out_of(road: &Road, which_end: NodeID) -> bool {
 
 fn can_drive_into(road: &Road, which_end: NodeID) -> bool {
     if let Some(driving_dir) = road.oneway_for_driving() {
-        let required_dir = if road.id.i1 == which_end {
+        let required_dir = if road.src_i == which_end {
             Direction::Fwd
         } else {
             Direction::Back

--- a/osm2streets/src/transform/collapse_intersections.rs
+++ b/osm2streets/src/transform/collapse_intersections.rs
@@ -145,13 +145,9 @@ pub fn collapse_intersection(streets: &mut StreetNetwork, i: NodeID) {
 
     // Skip loops; they break. Easiest way to detect is see how many total vertices we've got.
     {
-        let road1 = &streets.roads[&r1];
-        let road2 = &streets.roads[&r2];
         let mut endpts = BTreeSet::new();
-        endpts.insert(road1.src_i);
-        endpts.insert(road1.dst_i);
-        endpts.insert(road2.src_i);
-        endpts.insert(road2.dst_i);
+        endpts.extend(streets.roads[&r1].endpoints());
+        endpts.extend(streets.roads[&r2].endpoints());
         if endpts.len() != 3 {
             info!("Not collapsing degenerate {i}, because it's a loop");
             return;

--- a/osm2streets/src/transform/collapse_intersections.rs
+++ b/osm2streets/src/transform/collapse_intersections.rs
@@ -230,8 +230,8 @@ const SHORT_THRESHOLD: Distance = Distance::const_meters(30.0);
 pub fn trim_deadends(streets: &mut StreetNetwork) {
     let mut remove_roads = BTreeSet::new();
     let mut remove_intersections = BTreeSet::new();
-    for (id, i) in &streets.intersections {
-        let roads = streets.roads_per_intersection(*id);
+    for i in streets.intersections.values() {
+        let roads = streets.roads_per_intersection(i.id);
         if roads.len() != 1 || i.control == ControlType::Border {
             continue;
         }
@@ -240,7 +240,7 @@ pub fn trim_deadends(streets: &mut StreetNetwork) {
             && (road.is_cycleway() || road.osm_tags.is(osm::HIGHWAY, "service"))
         {
             remove_roads.insert(roads[0].id);
-            remove_intersections.insert(*id);
+            remove_intersections.insert(i.id);
         }
     }
 

--- a/osm2streets/src/transform/find_short_roads.rs
+++ b/osm2streets/src/transform/find_short_roads.rs
@@ -116,7 +116,7 @@ impl StreetNetwork {
                 continue;
             }
 
-            for i in [road.src_i, road.dst_i] {
+            for i in road.endpoints() {
                 let connections = self.roads_per_intersection(i);
                 if connections.len() != 3 {
                     continue 'ROAD;

--- a/osm2streets/src/transform/intersection_geometry.rs
+++ b/osm2streets/src/transform/intersection_geometry.rs
@@ -39,7 +39,7 @@ pub fn generate(streets: &mut StreetNetwork, timer: &mut Timer) {
                 if let Some(r) = i.roads.iter().next() {
                     // Don't trim lines back at all
                     let road = &streets.roads[r];
-                    let pt = if r.i1 == i.id {
+                    let pt = if road.src_i == i.id {
                         road.trimmed_center_line.first_pt()
                     } else {
                         road.trimmed_center_line.last_pt()
@@ -82,7 +82,7 @@ fn fix_borders(streets: &mut StreetNetwork) {
         if road.trimmed_center_line.length() >= min_len {
             continue;
         }
-        if r.i2 == i.id {
+        if road.dst_i == i.id {
             road.trimmed_center_line = road.trimmed_center_line.extend_to_length(min_len);
         } else {
             road.trimmed_center_line = road

--- a/osm2streets/src/transform/remove_disconnected.rs
+++ b/osm2streets/src/transform/remove_disconnected.rs
@@ -49,7 +49,7 @@ pub fn remove_disconnected_roads(streets: &mut StreetNetwork) {
     for p in partitions.iter().skip(1) {
         for id in p {
             info!("Removing {} because it's disconnected from most roads", id);
-            streets.remove_road(id);
+            streets.remove_road(*id);
             next_roads.remove(id.i1, *id);
             next_roads.remove(id.i2, *id);
         }
@@ -57,7 +57,7 @@ pub fn remove_disconnected_roads(streets: &mut StreetNetwork) {
 
     // Also remove cul-de-sacs here. TODO Support them properly, but for now, they mess up parking
     // hint matching (loop PolyLine) and pathfinding later.
-    streets.retain_roads(|id, _| id.i1 != id.i2);
+    streets.retain_roads(|r| r.src_i != r.dst_i);
 
     // Remove intersections without any roads
     streets

--- a/osm2streets/src/transform/snappy.rs
+++ b/osm2streets/src/transform/snappy.rs
@@ -52,7 +52,7 @@ pub fn snap_cycleways(streets: &mut StreetNetwork) {
         snapped_ids.push(cycleway_id);
 
         // Remove the separate cycleway
-        let deleted_cycleway = streets.remove_road(&cycleway_id);
+        let deleted_cycleway = streets.remove_road(cycleway_id);
 
         // Add it as an attribute to the roads instead
         for (road_id, dir) in roads {

--- a/osm2streets/src/transform/snappy.rs
+++ b/osm2streets/src/transform/snappy.rs
@@ -96,7 +96,7 @@ pub fn snap_cycleways(streets: &mut StreetNetwork) {
         //
         // Do all of these in one batch after snapping everything. Otherwise, some cycleway IDs
         // totally disappear.
-        for i in [r.i1, r.i2] {
+        for i in streets.roads[&r].endpoints() {
             if streets.roads_per_intersection(i).len() == 2 {
                 crate::transform::collapse_intersections::collapse_intersection(streets, i);
             }

--- a/streets_reader/src/clip.rs
+++ b/streets_reader/src/clip.rs
@@ -11,7 +11,7 @@ pub fn clip_map(streets: &mut StreetNetwork, timer: &mut Timer) -> Result<()> {
     let boundary_ring = boundary_polygon.get_outer_ring();
 
     // First, just remove roads that both start and end outside the boundary polygon.
-    streets.retain_roads(|_, r| {
+    streets.retain_roads(|r| {
         let first_in = boundary_polygon.contains_pt(r.untrimmed_center_line.first_pt());
         let last_in = boundary_polygon.contains_pt(r.untrimmed_center_line.last_pt());
         let light_rail_ok = if r.is_light_rail() {
@@ -54,7 +54,7 @@ pub fn clip_map(streets: &mut StreetNetwork, timer: &mut Timer) -> Result<()> {
 
         if intersection.roads.len() > 1 {
             for r in intersection.roads.clone() {
-                let mut road = streets.remove_road(&r);
+                let mut road = streets.remove_road(r);
 
                 let mut copy = streets.intersections[&id].clone();
                 copy.roads.clear();
@@ -70,10 +70,12 @@ pub fn clip_map(streets: &mut StreetNetwork, timer: &mut Timer) -> Result<()> {
                 }
                 assert_ne!(r, fixed_road_id);
                 road.id = fixed_road_id;
+                road.src_i = fixed_road_id.i1;
+                road.dst_i = fixed_road_id.i2;
                 copy.id = new_id;
 
                 streets.intersections.insert(new_id, copy);
-                streets.insert_road(fixed_road_id, road);
+                streets.insert_road(road);
             }
 
             assert!(streets.intersections[&id].roads.is_empty());

--- a/streets_reader/src/clip.rs
+++ b/streets_reader/src/clip.rs
@@ -101,7 +101,7 @@ pub fn clip_map(streets: &mut StreetNetwork, timer: &mut Timer) -> Result<()> {
             continue;
         }
 
-        if r.i1 == *i {
+        if road.src_i == *i {
             // Starting out-of-bounds
             let border_pt = border_pts[0];
             if let Some(pl) = road.untrimmed_center_line.get_slice_starting_at(border_pt) {

--- a/streets_reader/src/lib.rs
+++ b/streets_reader/src/lib.rs
@@ -116,7 +116,7 @@ pub fn osm_to_street_network(
 
     // Need to do a first pass of removing cul-de-sacs here, or we wind up with loop PolyLines when
     // doing the parking hint matching.
-    streets.retain_roads(|r, _| r.i1 != r.i2);
+    streets.retain_roads(|r| r.src_i != r.dst_i);
 
     use_barrier_nodes(
         &mut streets,

--- a/streets_reader/src/split_ways.rs
+++ b/streets_reader/src/split_ways.rs
@@ -132,7 +132,7 @@ pub fn split_up_roads(
                 let untrimmed_center_line = simplify_linestring(std::mem::take(&mut pts));
                 match PolyLine::new(untrimmed_center_line) {
                     Ok(pl) => {
-                        streets.insert_road(id, Road::new(id, pl, tags, &streets.config));
+                        streets.insert_road(Road::new(id, id.i1, id.i2, pl, tags, &streets.config));
                     }
                     Err(err) => {
                         error!("Skipping {id}: {err}");


### PR DESCRIPTION
some callers to prefer these to using OriginalRoad.

I started a few attempts to cutover to opaque IDs and store OSM IDs separately, but it's a brutally hard refactor. This is an intermediate step that starts changing some code to figure out road direction by looking at the `Road` struct instead of its ID. Not all callers converted over yet, but it's a decent chunk. Tests pass.

About naming: what I might do just for the refactor is make everything use `src_i` and `dst_i` fields on `Road`, so it's easy to grep code for `i1` and `i2` and see places left to convert. Once the cutover is done, I'm not too opinionated about how we call these, as long as it's consistent.