### PR TITLE
Start rendering sidewalk corners.

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -89,6 +89,11 @@ impl JsStreetNetwork {
         self.inner.to_lane_markings_geojson().unwrap()
     }
 
+    #[wasm_bindgen(js_name = toIntersectionMarkingsGeojson)]
+    pub fn to_intersection_markings_geojson(&self) -> String {
+        self.inner.to_intersection_markings_geojson().unwrap()
+    }
+
     #[wasm_bindgen(js_name = toGraphviz)]
     pub fn to_graphviz(&self) -> String {
         // TODO Should we make the caller do the clone? Is that weird from JS?

--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -24,7 +24,7 @@ pub struct Intersection {
     pub elevation: Distance,
 
     /// All roads connected to this intersection. They may be incoming or outgoing relative to this
-    /// intersection. They're ordered clockwise aroundd the intersection.
+    /// intersection. They're ordered clockwise around the intersection.
     pub roads: Vec<RoadID>,
     pub movements: Vec<Movement>,
 

--- a/street-explorer/www/js/layers.js
+++ b/street-explorer/www/js/layers.js
@@ -143,6 +143,24 @@ export const makeLaneMarkingsLayer = (text) => {
   });
 };
 
+export const makeIntersectionMarkingsLayer = (text) => {
+  // These could change per locale
+  const colors = {
+    "sidewalk corner": "#CCCCCC",
+  };
+
+  return new L.geoJSON(JSON.parse(text), {
+    style: function (feature) {
+      return {
+        fill: true,
+        fillColor: colors[feature.properties.type],
+        fillOpacity: 0.9,
+        stroke: false,
+      };
+    },
+  });
+};
+
 export const makeOsmLayer = (text) => {
   return new L.OSM.DataLayer(
     new DOMParser().parseFromString(text, "application/xml"),

--- a/street-explorer/www/js/main.js
+++ b/street-explorer/www/js/main.js
@@ -11,6 +11,7 @@ import {
   makeDotLayer,
   makeLaneMarkingsLayer,
   makeLanePolygonLayer,
+  makeIntersectionMarkingsLayer,
   makeOsmLayer,
   makePlainGeoJsonLayer,
 } from "./layers.js";
@@ -203,6 +204,10 @@ function importOSM(groupName, app, osmXML, addOSMLayer) {
     group.addLayer(
       "Lane markings",
       makeLaneMarkingsLayer(network.toLaneMarkingsGeojson())
+    );
+    group.addLayer(
+      "Intersection markings",
+      makeIntersectionMarkingsLayer(network.toIntersectionMarkingsGeojson())
     );
     group.addLazyLayer("Debug road ordering", () =>
       makeDebugLayer(network.debugClockwiseOrderingGeojson())


### PR DESCRIPTION
#24. As a break from refactoring, something to start improving the visual output. When two sidewalks (or shoulders) meet up, we can extend the pavement into the intersection a bit and show how they join.

I started with the logic in A/B Street, but rewrote it from scratch to be simpler. A/B Street splits the problem into two steps -- generate a polyline representing the turning movement between sidewalk endpoints, then later render it. https://github.com/a-b-street/abstreet/blob/dfae1b54d56bd0e40d482e4120c985ec943c1f19/map_model/src/make/walking_turns.rs#L211 is part 1, and https://github.com/a-b-street/abstreet/blob/dfae1b54d56bd0e40d482e4120c985ec943c1f19/map_gui/src/render/intersection.rs#L307 is part 2. This is much more complex than this PR. One reason is that we insist on creating the turning movement even if the geometry is weird, and so the rendering has to handle weird geometry. In this PR since we're just rendering (for now), I've chosen to skip situations that don't match perfectly.

Some sample results, showing both good and bad:
![Screenshot from 2022-11-25 14-21-10](https://user-images.githubusercontent.com/1664407/204004308-e1391bac-63a1-4684-a4b9-da4a1d0f7061.png)
![Screenshot from 2022-11-25 14-21-01](https://user-images.githubusercontent.com/1664407/204004310-4b0fb9d5-f886-4f18-bb2c-d2d2ac9fa3ef.png)
![Screenshot from 2022-11-25 14-21-44](https://user-images.githubusercontent.com/1664407/204004390-e91cac82-5208-497f-88c0-7728dac4564c.png)

This is of course preliminary, but hopefully a starting point to working on things like this, and figuring out how our estimation of where the pavement extends can affect vehicle movements around the corners.