### PR TITLE
Start a simple visual OSM tags editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "anyhow",
  "console_error_panic_hook",
  "experimental",
+ "geom",
  "instant",
  "osm2streets",
  "serde",

--- a/experimental/src/io.rs
+++ b/experimental/src/io.rs
@@ -26,7 +26,7 @@ use crate::units::{Direction, DrivingSide, Meters, Side, TrafficDirections};
 pub fn load_road_network(osm_path: String, timer: &mut Timer) -> Result<RoadNetwork> {
     let clip_pts = None;
 
-    let mut street_network = streets_reader::osm_to_street_network(
+    let (mut street_network, _) = streets_reader::osm_to_street_network(
         &std::fs::read_to_string(osm_path).unwrap(),
         clip_pts,
         MapConfig::default(),

--- a/osm2streets-js/Cargo.toml
+++ b/osm2streets-js/Cargo.toml
@@ -13,12 +13,13 @@ crate-type = ["cdylib", "rlib"]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = "1.0.38"
 console_error_panic_hook = "0.1.6"
-streets_reader = { path = "../streets_reader" }
+geom = { git = "https://github.com/a-b-street/abstreet" }
+experimental = { path = "../experimental" }
 # TODO Upstream this in abstutil crate. WASM is missing some runtime dep otherwise.
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
-serde = { version = "1", features = ["derive"] }
-experimental = { path = "../experimental" }
 osm2streets = { path = "../osm2streets" }
+serde = { version = "1", features = ["derive"] }
+streets_reader = { path = "../streets_reader" }
 wasm-bindgen = { version = "=0.2.81", features = [
     "serde-serialize",
 ] } # loosen after https://github.com/rustwasm/wasm-bindgen/issues/2774

--- a/street-explorer/www/js/lane_editor.js
+++ b/street-explorer/www/js/lane_editor.js
@@ -1,0 +1,102 @@
+import { downloadGeneratedFile } from "./files.js";
+import {
+  makeLaneMarkingsLayer,
+  lanePolygonStyle,
+  makePlainGeoJsonLayer,
+} from "./layers.js";
+import { setupLeafletMap } from "./leaflet.js";
+import init, { JsStreetNetwork } from "./osm2streets-js/osm2streets_js.js";
+
+await init();
+
+export class LaneEditor {
+  constructor(mapContainer) {
+    this.map = setupLeafletMap(mapContainer);
+    this.network = null;
+    this.layers = [];
+
+    // Wire up the import button
+    const importButton = document.getElementById("import-view");
+    importButton.onclick = async () => {
+      if (this.map.getZoom() < 15) {
+        window.alert("Zoom in more to import");
+        return;
+      }
+
+      await this.importView(importButton);
+    };
+  }
+
+  async importView(importButton) {
+    // Grab OSM XML from Overpass
+    // (Sadly toBBoxString doesn't seem to match the order for Overpass)
+    const b = app.map.getBounds();
+    const bbox = `${b.getSouth()},${b.getWest()},${b.getNorth()},${b.getEast()}`;
+    const query = `(nwr(${bbox}); node(w)->.x; <;); out meta;`;
+    const url = `https://overpass-api.de/api/interpreter?data=${query}`;
+    console.log(`Fetching from overpass: ${url}`);
+
+    importButton.innerText = "Downloading from Overpass...";
+    // Prevent this function from happening twice in a row. It could also maybe
+    // be nice to allow cancellation.
+    importButton.disabled = true;
+
+    try {
+      const resp = await fetch(url);
+      const osmXML = await resp.text();
+
+      importButton.innerText = "Importing OSM data...";
+
+      this.network = new JsStreetNetwork(osmXML, {
+        debug_each_step: false,
+        dual_carriageway_experiment: false,
+        cycletrack_snapping_experiment: false,
+        inferred_sidewalks: false,
+        osm2lanes: false,
+      });
+      this.rerenderAll();
+      const bounds = this.layers[0].getBounds();
+      this.map.fitBounds(bounds, { animate: false });
+    } catch (err) {
+      window.alert(`Import failed: ${err}`);
+    } finally {
+      // Make the button clickable again
+      importButton.innerText = "Import current view";
+      importButton.disabled = false;
+    }
+  }
+
+  rerenderAll() {
+    for (const layer of this.layers) {
+      layer.remove();
+    }
+    this.layers = [];
+
+    // Just show intersections from the plain layer
+    this.layers.push(
+      L.geoJSON(JSON.parse(this.network.toGeojsonPlain()), {
+        style: function (feature) {
+          if (feature.properties.type == "intersection") {
+            return {
+              color: "black",
+              fillOpacity: 0.7,
+            };
+          }
+          return { fill: false, stroke: false };
+        },
+      })
+    );
+    this.layers.push(
+      L.geoJSON(JSON.parse(this.network.toLanePolygonsGeojson()), {
+        style: lanePolygonStyle,
+      })
+    );
+    this.layers.push(
+      makeLaneMarkingsLayer(this.network.toLaneMarkingsGeojson())
+    );
+
+    for (const layer of this.layers) {
+      layer.addTo(this.map);
+    }
+  }
+}

--- a/street-explorer/www/js/lane_editor.js
+++ b/street-explorer/www/js/lane_editor.js
@@ -15,6 +15,7 @@ export class LaneEditor {
     this.network = null;
     this.layers = [];
     this.currentWay = null;
+    this.currentWaysLayer = null;
 
     // Wire up the import button
     const importButton = document.getElementById("import-view");
@@ -117,6 +118,17 @@ export class LaneEditor {
 
   editWay(id) {
     this.currentWay = id;
+    if (this.currentWaysLayer) {
+      this.currentWaysLayer.remove();
+    }
+    this.currentWaysLayer = L.geoJSON(
+      JSON.parse(this.network.getGeometryForWay(id)),
+      {
+        style: (feature) => {
+          return { stroke: false, fill: true, color: "red", opacity: 0.5 };
+        },
+      }
+    ).addTo(this.map);
 
     var html = `<table><tbody id="tags-table">`;
 

--- a/street-explorer/www/js/lane_editor.js
+++ b/street-explorer/www/js/lane_editor.js
@@ -72,10 +72,10 @@ export class LaneEditor {
     }
     this.layers = [];
 
-    // Just show intersections from the plain layer
     this.layers.push(
       L.geoJSON(JSON.parse(this.network.toGeojsonPlain()), {
-        style: function (feature) {
+        // Just show intersections from the plain layer
+        style: (feature) => {
           if (feature.properties.type == "intersection") {
             return {
               color: "black",
@@ -89,6 +89,20 @@ export class LaneEditor {
     this.layers.push(
       L.geoJSON(JSON.parse(this.network.toLanePolygonsGeojson()), {
         style: lanePolygonStyle,
+        // Make lanes clickable
+        onEachFeature: (feature, layer) => {
+          layer.on({
+            click: (ev) => {
+              if (feature.properties.osm_way_ids.length != 1) {
+                window.alert(
+                  "This road doesn't match up with one OSM way; you can't edit it"
+                );
+              } else {
+                this.editWay(feature.properties.osm_way_ids[0]);
+              }
+            },
+          });
+        },
       })
     );
     this.layers.push(
@@ -98,5 +112,24 @@ export class LaneEditor {
     for (const layer of this.layers) {
       layer.addTo(this.map);
     }
+  }
+
+  editWay(id) {
+    var html = "<table>";
+
+    const tags = JSON.parse(this.network.getOsmTagsForWay(BigInt(id)));
+    for (let key in tags) {
+      const value = tags[key];
+      html += `<tr>`;
+      html += `<td><input type="text" value="${key}"></td>`;
+      html += `<td><input type="text" value="${value}"></td>`;
+      html += `<td><button type="button">Delete</button></td>`;
+      html += `</tr>`;
+    }
+    html += `</table>`;
+    // TODO Add new tag
+
+    const div = document.getElementById("tags");
+    div.innerHTML = html;
   }
 }

--- a/street-explorer/www/js/layers.js
+++ b/street-explorer/www/js/layers.js
@@ -49,7 +49,7 @@ export const makePlainGeoJsonLayer = (text) => {
   });
 };
 
-export const makeLanePolygonLayer = (text) => {
+export const lanePolygonStyle = (feature) => {
   // These could change per locale
   const colors = {
     Driving: "black",
@@ -65,34 +65,36 @@ export const makeLanePolygonLayer = (text) => {
     "Buffer(Planters)": "#555555",
   };
 
-  return new L.geoJSON(JSON.parse(text), {
-    style: function (feature) {
-      if (feature.properties.type == "Footway") {
-        return {
-          fill: true,
-          fillColor: "#DDDDE8",
-          stroke: true,
-          color: "black",
-          dashArray: "5,10",
-        };
-      }
-      if (feature.properties.type == "SharedUse") {
-        return {
-          fill: true,
-          fillColor: "#E5E1BB",
-          stroke: true,
-          color: "black",
-          dashArray: "5,10",
-        };
-      }
+  if (feature.properties.type == "Footway") {
+    return {
+      fill: true,
+      fillColor: "#DDDDE8",
+      stroke: true,
+      color: "black",
+      dashArray: "5,10",
+    };
+  }
+  if (feature.properties.type == "SharedUse") {
+    return {
+      fill: true,
+      fillColor: "#E5E1BB",
+      stroke: true,
+      color: "black",
+      dashArray: "5,10",
+    };
+  }
 
-      return {
-        fill: true,
-        fillColor: colors[feature.properties.type] || "red",
-        fillOpacity: 0.9,
-        stroke: false,
-      };
-    },
+  return {
+    fill: true,
+    fillColor: colors[feature.properties.type] || "red",
+    fillOpacity: 0.9,
+    stroke: false,
+  };
+};
+
+export const makeLanePolygonLayer = (text) => {
+  return new L.geoJSON(JSON.parse(text), {
+    style: lanePolygonStyle,
     onEachFeature: function (feature, layer) {
       layer.on({
         mouseover: function (ev) {

--- a/street-explorer/www/js/leaflet.js
+++ b/street-explorer/www/js/leaflet.js
@@ -1,0 +1,42 @@
+export function setupLeafletMap(mapContainer) {
+  const osm = L.tileLayer(
+    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    {
+      maxNativeZoom: 18,
+      maxZoom: 21,
+      attribution: "© OpenStreetMap",
+    }
+  );
+  const arcgis = L.tileLayer(
+    "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    {
+      attribution: "© ArcGIS",
+      maxNativeZoom: 18,
+      maxZoom: 21,
+    }
+  );
+
+  const map = L.map(mapContainer, {
+    layers: [osm],
+    maxZoom: 21,
+    zoomSnap: 0,
+    zoomDelta: 0.5,
+    scrollWheelZoom: false,
+    smoothWheelZoom: true,
+    smoothSensitivity: 1,
+  }).setView([40.0, 10.0], 4);
+
+  new GeoSearch.GeoSearchControl({
+    provider: new GeoSearch.OpenStreetMapProvider(),
+    showMarker: false,
+    autoClose: true,
+  }).addTo(map);
+
+  new L.hash(map);
+
+  L.control
+    .layers({ OpenStreetMap: osm, ArcGIS: arcgis }, {}, { collapsed: false })
+    .addTo(map);
+
+  return map;
+}

--- a/street-explorer/www/js/main.js
+++ b/street-explorer/www/js/main.js
@@ -20,6 +20,7 @@ import {
   makeLayerControl,
   SequentialLayerGroup,
 } from "./controls.js";
+import { setupLeafletMap } from "./leaflet.js";
 import init, { JsStreetNetwork } from "./osm2streets-js/osm2streets_js.js";
 
 await init();
@@ -258,49 +259,6 @@ function importOSM(groupName, app, osmXML, addOSMLayer) {
   } catch (err) {
     window.alert(`Import failed: ${err}`);
   }
-}
-
-function setupLeafletMap(mapContainer) {
-  const osm = L.tileLayer(
-    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-    {
-      maxNativeZoom: 18,
-      maxZoom: 21,
-      attribution: "© OpenStreetMap",
-    }
-  );
-  const arcgis = L.tileLayer(
-    "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-    {
-      attribution: "© ArcGIS",
-      maxNativeZoom: 18,
-      maxZoom: 21,
-    }
-  );
-
-  const map = L.map(mapContainer, {
-    layers: [osm],
-    maxZoom: 21,
-    zoomSnap: 0,
-    zoomDelta: 0.5,
-    scrollWheelZoom: false,
-    smoothWheelZoom: true,
-    smoothSensitivity: 1,
-  }).setView([40.0, 10.0], 4);
-
-  new GeoSearch.GeoSearchControl({
-    provider: new GeoSearch.OpenStreetMapProvider(),
-    showMarker: false,
-    autoClose: true,
-  }).addTo(map);
-
-  new L.hash(map);
-
-  L.control
-    .layers({ OpenStreetMap: osm, ArcGIS: arcgis }, {}, { collapsed: false })
-    .addTo(map);
-
-  return map;
 }
 
 // TODO Unused. Preserve logic for dragging individual files as layers.

--- a/street-explorer/www/lane_editor.html
+++ b/street-explorer/www/lane_editor.html
@@ -46,6 +46,8 @@
           <li>Don't edit a way that's partly clipped</li>
         </ul>
       </div>
+      <div id="edits-list">0 edits</div>
+      <button type="button" id="osc">Download .osc file</button>
     </aside>
     <div id="map"></div>
   </body>

--- a/street-explorer/www/lane_editor.html
+++ b/street-explorer/www/lane_editor.html
@@ -25,7 +25,7 @@
     </script>
   </head>
   <body>
-    <aside>
+    <aside style="max-width: 35rem">
       <header>
         <h1>osm2streets lane editor</h1>
         <p>
@@ -35,8 +35,8 @@
           >
         </p>
       </header>
-
       <button type="button" id="import-view">import current view</button>
+      <div id="tags"></div>
     </aside>
     <div id="map"></div>
   </body>

--- a/street-explorer/www/lane_editor.html
+++ b/street-explorer/www/lane_editor.html
@@ -37,6 +37,15 @@
       </header>
       <button type="button" id="import-view">import current view</button>
       <div id="tags"></div>
+      <div>
+        <strong>Warnings:</strong>
+        <ul>
+          <li><strong>This tool is an early experiment</strong></li>
+          <li>Don't use this tool without understanding OSM tagging</li>
+          <li>Be careful around sidepaths, footways, and dual carriageways</li>
+          <li>Don't edit a way that's partly clipped</li>
+        </ul>
+      </div>
     </aside>
     <div id="map"></div>
   </body>

--- a/street-explorer/www/lane_editor.html
+++ b/street-explorer/www/lane_editor.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>osm2streets lane editor</title>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, user-scalable=no"
+    />
+
+    <link rel="stylesheet" href="css/reset.css" />
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/deps/leaflet.css" />
+    <link rel="stylesheet" href="css/deps/geosearch.css" />
+
+    <script src="js/deps/leaflet.js"></script>
+    <script src="js/deps/SmoothWheelZoom.js"></script>
+    <script src="js/deps/geosearch.umd.js"></script>
+    <script src="js/deps/leaflet-hash.js"></script>
+
+    <script type="module">
+      import { LaneEditor } from "./js/lane_editor.js";
+      window.app = new LaneEditor(document.getElementById("map"));
+    </script>
+  </head>
+  <body>
+    <aside>
+      <header>
+        <h1>osm2streets lane editor</h1>
+        <p>
+          Improve OSM lane tagging with
+          <a href="https://github.com/a-b-street/osm2streets" target="_blank"
+            >osm2streets</a
+          >
+        </p>
+      </header>
+
+      <button type="button" id="import-view">import current view</button>
+    </aside>
+    <div id="map"></div>
+  </body>
+</html>

--- a/streets_reader/src/osm_reader/reader.rs
+++ b/streets_reader/src/osm_reader/reader.rs
@@ -35,6 +35,7 @@ pub struct Way {
     pub nodes: Vec<NodeID>,
     pub pts: Vec<Pt2D>,
     pub tags: Tags,
+    pub version: Option<usize>,
 }
 
 pub struct Relation {
@@ -101,6 +102,10 @@ pub fn read(raw_string: &str, input_gps_bounds: &GPSBounds, timer: &mut Timer) -
                 if doc.ways.contains_key(&id) {
                     bail!("Duplicate {}, your .osm is corrupt", id);
                 }
+                let version = obj
+                    .attributes
+                    .get("version")
+                    .and_then(|x| x.parse::<usize>().ok());
 
                 let mut nodes = Vec::new();
                 let mut pts = Vec::new();
@@ -118,7 +123,15 @@ pub fn read(raw_string: &str, input_gps_bounds: &GPSBounds, timer: &mut Timer) -
                 let tags = read_tags(&mut reader);
 
                 if !nodes.is_empty() {
-                    doc.ways.insert(id, Way { nodes, pts, tags });
+                    doc.ways.insert(
+                        id,
+                        Way {
+                            nodes,
+                            pts,
+                            tags,
+                            version,
+                        },
+                    );
                 }
             }
             "relation" => {

--- a/streets_reader/src/osm_reader/reader.rs
+++ b/streets_reader/src/osm_reader/reader.rs
@@ -182,10 +182,6 @@ fn read_tags(reader: &mut Peekable<ElementReader>) -> Tags {
         let obj = reader.next().unwrap();
         let key = obj.attribute("k");
         let value = obj.attribute("v");
-        // Filter out really useless data
-        if key.starts_with("tiger:") || key.starts_with("old_name:") {
-            continue;
-        }
         tags.insert(key, unescape(value).unwrap());
     }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -21,7 +21,7 @@ mod tests {
             .unwrap_or_else(|_| String::new());
 
         let clip_pts = None;
-        let mut street_network = streets_reader::osm_to_street_network(
+        let (mut street_network, _) = streets_reader::osm_to_street_network(
             &std::fs::read_to_string(format!("{path}/input.osm"))?,
             clip_pts,
             MapConfig::default(),


### PR DESCRIPTION
See #132 for the idea. If we assume the user knows OSM tagging, we can just let them edit tags and re-render with osm2streets. This didn't take long to put together, and another few hours of work would get it to the point where I would use it for real to fix a bunch of bus lane tagging.


https://user-images.githubusercontent.com/1664407/204142669-e8057989-90bc-4708-9a89-03e5bef77e83.mp4

Some quick next steps:
- Generate and download a `.osc` file with the changes, which can be opened in JOSM and uploaded
- Click off a road to reset the view
- Don't allow editing a road that's clipped, because the user won't know how far it stretches and if the lanes are correct
- Indicate the forwards direction of the way, to help with tagging

Longer term:
- Do oauth and submit OSM changes directly to the API
- Split a way when lanes change
  - This is hard to code up just at the OSM data model level, because relations have to be maintained. IIRC I've seen @tordans start a conversation somewhere around common code to do that. Happen to know anything we could use?
- Bring in the osm2lanes cross section cards view and don't require editing the tags manually at all