### PR TITLE
Scrub A/B Street fields and half-baked logic

### DIFF
--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use geom::{Distance, Polygon, Pt2D};
+use geom::{Polygon, Pt2D};
 use serde::{Deserialize, Serialize};
 
 use crate::{osm, DrivingSide, IntersectionID, RoadID, StreetNetwork};
@@ -21,7 +21,6 @@ pub struct Intersection {
     pub polygon: Polygon,
     pub kind: IntersectionKind,
     pub control: IntersectionControl,
-    pub elevation: Distance,
 
     /// All roads connected to this intersection. They may be incoming or outgoing relative to this
     /// intersection. They're ordered clockwise aroundd the intersection.
@@ -121,7 +120,6 @@ impl StreetNetwork {
                 // Filled out later
                 roads: Vec::new(),
                 movements: Vec::new(),
-                elevation: Distance::ZERO,
                 trim_roads_for_merging: BTreeMap::new(),
             },
         );

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -233,15 +233,6 @@ impl StreetNetwork {
     }
 }
 
-/// Classifies pedestrian and cyclist crossings. Note lots of detail is missing.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum CrossingType {
-    /// Part of some traffic signal
-    Signalized,
-    /// Not part of a traffic signal
-    Unsignalized,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RestrictionType {
     BanTurns,

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -2,12 +2,11 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use abstutil::Tags;
-use geom::{Angle, Distance, PolyLine, Pt2D};
+use geom::{Angle, Distance, PolyLine};
 
 use crate::{
-    get_lane_specs_ltr, osm, CommonEndpoint, CrossingType, Direction, InputRoad, IntersectionID,
-    LaneSpec, LaneType, MapConfig, OriginalRoad, RestrictionType, RoadID, RoadWithEndpoints,
-    StreetNetwork,
+    get_lane_specs_ltr, osm, CommonEndpoint, Direction, InputRoad, IntersectionID, LaneSpec,
+    LaneType, MapConfig, OriginalRoad, RestrictionType, RoadID, RoadWithEndpoints, StreetNetwork,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -43,17 +42,6 @@ pub struct Road {
     pub turn_restrictions: Vec<(RestrictionType, RoadID)>,
     /// (via, to). For turn restrictions where 'via' is an entire road. Only BanTurns.
     pub complicated_turn_restrictions: Vec<(RoadID, RoadID)>,
-    pub percent_incline: f64,
-    /// Is there a tagged crosswalk near each end of the road?
-    pub crosswalk_forward: bool,
-    pub crosswalk_backward: bool,
-    // TODO Preserving these two across transformations (especially merging dual carriageways!)
-    // could be really hard. It might be better to split the road into two pieces to match the more
-    // often used OSM style.
-    /// Barrier nodes along this road's original center line.
-    pub barrier_nodes: Vec<Pt2D>,
-    /// Crossing nodes along this road's original center line.
-    pub crossing_nodes: Vec<(Pt2D, CrossingType)>,
 
     pub lane_specs_ltr: Vec<LaneSpec>,
 }
@@ -100,13 +88,6 @@ impl Road {
             trimmed_center_line: PolyLine::dummy(),
             turn_restrictions: Vec::new(),
             complicated_turn_restrictions: Vec::new(),
-            percent_incline: 0.0,
-            // Start assuming there's a crosswalk everywhere, and maybe filter it down
-            // later
-            crosswalk_forward: true,
-            crosswalk_backward: true,
-            barrier_nodes: Vec::new(),
-            crossing_nodes: Vec::new(),
 
             lane_specs_ltr,
         }

--- a/osm2streets/src/types.rs
+++ b/osm2streets/src/types.rs
@@ -74,8 +74,6 @@ pub struct MapConfig {
     pub osm2lanes: bool,
     /// OSM railway=rail will be included as light rail if so. Cosmetic only.
     pub include_railroads: bool,
-    /// Only include crosswalks that match a `highway=crossing` OSM node.
-    pub filter_crosswalks: bool,
 
     /// Enable experimental dog-leg intersection merging
     pub find_dog_legs_experiment: bool,
@@ -94,7 +92,6 @@ impl MapConfig {
             turn_on_red: true,
             osm2lanes: false,
             include_railroads: true,
-            filter_crosswalks: false,
             find_dog_legs_experiment: false,
             merge_osm_ways: BTreeSet::new(),
         }

--- a/streets_reader/src/extract.rs
+++ b/streets_reader/src/extract.rs
@@ -1,10 +1,10 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use osm::{NodeID, OsmID, RelationID, WayID};
 
 use abstutil::Tags;
 use geom::{HashablePt2D, Pt2D};
-use osm2streets::{osm, CrossingType, Direction, RestrictionType};
+use osm2streets::{osm, Direction, RestrictionType};
 
 use crate::osm_reader::{Node, Relation, Way};
 use crate::MapConfig;
@@ -19,11 +19,6 @@ pub struct OsmExtract {
     pub simple_turn_restrictions: Vec<(RestrictionType, WayID, NodeID, WayID)>,
     /// (relation ID, from way ID, via way ID, to way ID)
     pub complicated_turn_restrictions: Vec<(RelationID, WayID, WayID, WayID)>,
-    /// Crossings located at these points, which should be on a Road's center line
-    pub crossing_nodes: HashSet<(HashablePt2D, CrossingType)>,
-    /// Some kind of barrier nodes at these points. Only the ones on a Road center line are
-    /// relevant.
-    pub barrier_nodes: HashSet<HashablePt2D>,
 }
 
 impl OsmExtract {
@@ -34,8 +29,6 @@ impl OsmExtract {
             osm_node_ids: HashMap::new(),
             simple_turn_restrictions: Vec::new(),
             complicated_turn_restrictions: Vec::new(),
-            crossing_nodes: HashSet::new(),
-            barrier_nodes: HashSet::new(),
         }
     }
 
@@ -49,20 +42,6 @@ impl OsmExtract {
                 Direction::Fwd
             };
             self.traffic_signals.insert(node.pt.to_hashable(), dir);
-        }
-        if node.tags.is(osm::HIGHWAY, "crossing") {
-            // TODO Look for crossing:signals:* too.
-            // https://wiki.openstreetmap.org/wiki/Tag:crossing=traffic%20signals?uselang=en
-            let kind = if node.tags.is("crossing", "traffic_signals") {
-                CrossingType::Signalized
-            } else {
-                CrossingType::Unsignalized
-            };
-            self.crossing_nodes.insert((node.pt.to_hashable(), kind));
-        }
-        // TODO Any kind of barrier?
-        if node.tags.is("barrier", "bollard") {
-            self.barrier_nodes.insert(node.pt.to_hashable());
         }
     }
 

--- a/streets_reader/src/split_ways.rs
+++ b/streets_reader/src/split_ways.rs
@@ -1,17 +1,15 @@
-use std::collections::{btree_map::Entry, BTreeMap, HashMap, HashSet};
+use std::collections::{btree_map::Entry, BTreeMap, HashMap};
 
 use abstutil::{Counter, Tags, Timer};
 use geom::{Distance, HashablePt2D, PolyLine, Pt2D};
 use osm2streets::{
-    osm, CrossingType, Direction, IntersectionControl, IntersectionID, IntersectionKind,
-    OriginalRoad, Road, RoadID, StreetNetwork,
+    osm, Direction, IntersectionControl, IntersectionID, IntersectionKind, OriginalRoad, Road,
+    RoadID, StreetNetwork,
 };
 
 use super::OsmExtract;
 
 pub struct Output {
-    pub crossing_nodes: HashSet<(HashablePt2D, CrossingType)>,
-    pub barrier_nodes: HashSet<HashablePt2D>,
     /// A mapping of all points to the split road. Some internal points on roads get removed in
     /// `split_up_roads`, so this mapping isn't redundant.
     pub pt_to_road: HashMap<HashablePt2D, RoadID>,
@@ -287,11 +285,7 @@ pub fn split_up_roads(
     timer.stop("calculate intersection movements");
 
     timer.stop("splitting up roads");
-    Output {
-        crossing_nodes: input.crossing_nodes,
-        barrier_nodes: input.barrier_nodes,
-        pt_to_road,
-    }
+    Output { pt_to_road }
 }
 
 // TODO Consider doing this in PolyLine::new always. Also in extend() -- it attempts to dedupe


### PR DESCRIPTION
#127 

Elevation, crossings, and barriers are all concepts not part of osm2streets (yet). They have real use in A/B Street today, but we can simplify this codebase with proper layering. Crossings and barriers are both things that will wind up in osm2streets eventually, but the half-baked version that exists now can just stay in A/B Street.