### PR TITLE
Start refactoring intersection geometry code

### DIFF
--- a/osm2streets/src/geometry/mod.rs
+++ b/osm2streets/src/geometry/mod.rs
@@ -12,32 +12,22 @@ mod algorithm;
 
 use std::collections::BTreeMap;
 
-use geom::{Distance, PolyLine, Polygon};
+use geom::Polygon;
 
-use crate::{IntersectionID, RoadID};
+use crate::{IntersectionID, Road, RoadID};
 pub use algorithm::intersection_polygon;
 
-// For anyone considering removing this indirection in the future: it's used to recalculate one or
-// two intersections at a time in A/B Street's edit mode. Within just this repo, it does seem
-// redundant.
-#[derive(Clone)]
-pub struct InputRoad {
-    pub id: RoadID,
-    pub src_i: IntersectionID,
-    pub dst_i: IntersectionID,
-    /// The true center of the road, including sidewalks. The input is untrimmed when called on the
-    /// first endpoint, then trimmed on that one side when called on th second endpoint.
-    pub center_pts: PolyLine,
-    pub half_width: Distance,
-    pub highway_type: String,
-}
+// Why doesn't intersection_polygon() directly operate on a StreetNetwork? Within this repo, it
+// probably could. But this code is also used to recalculate one or two intersections at a time in
+// A/B Street's edit mode, which currently works off of a different representation than a
+// StreetNetwork. Any future refactors should keep that in mind.
 
 #[derive(Clone)]
 pub struct Results {
     pub intersection_id: IntersectionID,
     pub intersection_polygon: Polygon,
-    /// Road -> (trimmed center line, half width)
-    pub trimmed_center_pts: BTreeMap<RoadID, (PolyLine, Distance)>,
+    /// Echo back all Roads passed in, with `trimmed_center_line` modified
+    pub roads: BTreeMap<RoadID, Road>,
     /// Extra polygons with labels to debug the algorithm
     pub debug: Vec<(String, Polygon)>,
 }

--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -140,8 +140,8 @@ impl StreetNetwork {
         let mut endpoints_for_center = Vec::new();
         for r in &intersection.roads {
             let road = &self.roads[r];
-            // road.center_pts is unadjusted; it doesn't handle unequal widths yet. But that
-            // shouldn't matter for sorting.
+            // road.untrimmed_center_line is unadjusted; it doesn't handle unequal widths yet. But
+            // that shouldn't matter for sorting.
             let center_pl = if road.src_i == i {
                 road.untrimmed_center_line.reversed()
             } else if road.dst_i == i {

--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -6,9 +6,8 @@ use std::path::Path;
 use anyhow::Result;
 use geom::{ArrowCap, Distance, Line, PolyLine, Polygon, Ring};
 
-use crate::{
-    DebugStreets, Direction, DrivingSide, Intersection, LaneSpec, LaneType, RoadID, StreetNetwork,
-};
+use crate::road::RoadEdge;
+use crate::{DebugStreets, Direction, DrivingSide, Intersection, LaneType, StreetNetwork};
 
 impl StreetNetwork {
     /// Saves the plain GeoJSON rendering to a file.
@@ -398,47 +397,13 @@ fn make_props(list: &[(&str, serde_json::Value)]) -> serde_json::Map<String, ser
 // TODO Where should this live?
 /// For an intersection, show all corners where sidewalks meet.
 fn make_sidewalk_corners(streets: &StreetNetwork, intersection: &Intersection) -> Vec<Polygon> {
-    #[derive(Clone)]
-    struct Edge {
-        road: RoadID,
-        // Pointed into the intersection
-        pl: PolyLine,
-        lane: LaneSpec,
-    }
-
-    // Get the left and right edge of each road, pointed into the intersection. All sorted
-    // clockwise
-    // TODO Use the road view idea instead. Or just refactor this.
-    let mut edges = Vec::new();
-    for road in streets.roads_per_intersection(intersection.id) {
-        let mut left = Edge {
-            road: road.id,
-            pl: road
-                .trimmed_center_line
-                .must_shift_left(road.total_width() / 2.0),
-            lane: road.lane_specs_ltr[0].clone(),
-        };
-        let mut right = Edge {
-            road: road.id,
-            pl: road
-                .trimmed_center_line
-                .must_shift_right(road.total_width() / 2.0),
-            lane: road.lane_specs_ltr.last().unwrap().clone(),
-        };
-        if road.dst_i == intersection.id {
-            edges.push(right);
-            edges.push(left);
-        } else {
-            left.pl = left.pl.reversed();
-            right.pl = right.pl.reversed();
-            edges.push(left);
-            edges.push(right);
-        }
-    }
-
-    // Look at every adjacent pair
-    let mut results = Vec::new();
+    // Look at every adjacent pair of edges
+    let mut edges = RoadEdge::calculate(
+        streets.roads_per_intersection(intersection.id),
+        intersection.id,
+    );
     edges.push(edges[0].clone());
+    let mut results = Vec::new();
     for pair in edges.windows(2) {
         let one = &pair[0];
         let two = &pair[1];

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -5,8 +5,8 @@ use abstutil::Tags;
 use geom::{Angle, Distance, PolyLine};
 
 use crate::{
-    get_lane_specs_ltr, osm, CommonEndpoint, Direction, InputRoad, IntersectionID, LaneSpec,
-    LaneType, MapConfig, OriginalRoad, RestrictionType, RoadID, RoadWithEndpoints, StreetNetwork,
+    get_lane_specs_ltr, osm, CommonEndpoint, Direction, IntersectionID, LaneSpec, LaneType,
+    MapConfig, OriginalRoad, RestrictionType, RoadID, RoadWithEndpoints, StreetNetwork,
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -217,6 +217,9 @@ impl Road {
     pub fn total_width(&self) -> Distance {
         self.lane_specs_ltr.iter().map(|l| l.width).sum()
     }
+    pub fn half_width(&self) -> Distance {
+        self.total_width() / 2.0
+    }
 
     /// Returns one PolyLine representing the center of each lane in this road. This must be called
     /// after `Transformation::GenerateIntersectionGeometry` is run. The result also faces the same
@@ -249,17 +252,6 @@ impl Road {
 
     pub fn endpoints(&self) -> Vec<IntersectionID> {
         vec![self.src_i, self.dst_i]
-    }
-
-    pub(crate) fn to_input_road(&self) -> InputRoad {
-        InputRoad {
-            id: self.id,
-            src_i: self.src_i,
-            dst_i: self.dst_i,
-            center_pts: self.trimmed_center_line.clone(),
-            half_width: self.total_width() / 2.0,
-            highway_type: self.highway_type.clone(),
-        }
     }
 
     pub fn other_side(&self, i: IntersectionID) -> IntersectionID {

--- a/osm2streets/src/transform/intersection_geometry.rs
+++ b/osm2streets/src/transform/intersection_geometry.rs
@@ -20,16 +20,18 @@ pub fn generate(streets: &mut StreetNetwork, timer: &mut Timer) {
     let mut make_stop_signs = Vec::new();
     for i in streets.intersections.values() {
         timer.next();
+        // Clone the roads passed in
         let input_roads = i
             .roads
             .iter()
-            .map(|r| streets.roads[r].to_input_road())
+            .map(|r| streets.roads[r].clone())
             .collect::<Vec<_>>();
         match crate::intersection_polygon(i.id, input_roads, &i.trim_roads_for_merging) {
             Ok(results) => {
                 set_polygons.push((i.id, results.intersection_polygon));
-                for (r, (pl, _)) in results.trimmed_center_pts {
-                    streets.roads.get_mut(&r).unwrap().trimmed_center_line = pl;
+                for r in results.roads.into_values() {
+                    streets.roads.get_mut(&r.id).unwrap().trimmed_center_line =
+                        r.trimmed_center_line;
                 }
             }
             Err(err) => {
@@ -96,7 +98,7 @@ fn fix_map_edges(streets: &mut StreetNetwork) {
         let input_roads = i
             .roads
             .iter()
-            .map(|r| streets.roads[r].to_input_road())
+            .map(|r| streets.roads[r].clone())
             .collect::<Vec<_>>();
         let results = crate::intersection_polygon(
             i.id,
@@ -105,8 +107,8 @@ fn fix_map_edges(streets: &mut StreetNetwork) {
         )
         .unwrap();
         set_polygons.push((i.id, results.intersection_polygon));
-        for (r, (pl, _)) in results.trimmed_center_pts {
-            streets.roads.get_mut(&r).unwrap().trimmed_center_line = pl;
+        for r in results.roads.into_values() {
+            streets.roads.get_mut(&r.id).unwrap().trimmed_center_line = r.trimmed_center_line;
         }
         info!(
             "Shifted map edge {} out a bit to make the road a reasonable length",


### PR DESCRIPTION
This is a small start to refactoring. Instead of using this legacy `InputRoad` struct, just take a **copy** of the `Road` struct as input. All information needed for the algorithm is in there, and so when we add things like trim distances, it means we don't have to copy data back and forth between two structs. It also internally simplifies some code to populate the `Results` struct immediately.

There are a bunch of next steps, but I'll go discuss them in the issue separately. I think this is a solid first step with no diff in the tests. All of the next steps... might change some existing behavior!