### PR TITLE
Lane marking layer should not be interactive

### DIFF
--- a/street-explorer/www/js/layers.js
+++ b/street-explorer/www/js/layers.js
@@ -143,6 +143,7 @@ export const makeLaneMarkingsLayer = (text) => {
         stroke: false,
       };
     },
+    interactive: false,
   });
 };
 


### PR DESCRIPTION
This is an edge case as the lane markings are very small, but clicking on them does not currently select the underlying road.