### PR TITLE
Selection overlay indicates road direction

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -150,8 +150,8 @@ impl JsStreetNetwork {
             .unwrap();
 
         // Show a wide buffer around the way
-        let polygon =
-            PolyLine::unchecked_new(self.ways[&id].pts.clone()).make_polygons(1.5 * width);
+        let polygon = PolyLine::unchecked_new(self.ways[&id].pts.clone())
+            .make_arrow(1.5 * width, geom::ArrowCap::Triangle);
 
         abstutil::to_json(&polygon.to_geojson(Some(&self.inner.gps_bounds)))
     }

--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use abstutil::{Tags, Timer};
-use geom::PolyLine;
+use geom::{Distance, Line, PolyLine, Polygon};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -149,9 +149,28 @@ impl JsStreetNetwork {
             .map(|r| r.total_width())
             .unwrap();
 
+        let polyline = PolyLine::unchecked_new(self.ways[&id].pts.clone());
+        let chevrons = polyline.lines().flat_map(|l| {
+            let num_chevrons = (l.length() / Distance::meters(20.0)).floor() as i64;
+            (0..num_chevrons)
+                .map(|i| {
+                    let top_pt = l
+                        .dist_along(Distance::meters((i as f64 * 20.0) + 10.0))
+                        .unwrap();
+                    PolyLine::must_new(vec![
+                        top_pt.project_away(width / 2.0, l.angle().rotate_degs(135.0)),
+                        top_pt,
+                        top_pt.project_away(width / 2.0, l.angle().rotate_degs(-135.0)),
+                    ])
+                    .make_polygons(width * 0.2)
+                })
+                .collect::<Vec<Polygon>>()
+        });
+
         // Show a wide buffer around the way
-        let polygon = PolyLine::unchecked_new(self.ways[&id].pts.clone())
-            .make_arrow(1.5 * width, geom::ArrowCap::Triangle);
+        let mut polygon = polyline.make_polygons(1.5 * width);
+
+        chevrons.for_each(|c| polygon = polygon.difference(&c).unwrap()[0].clone());
 
         abstutil::to_json(&polygon.to_geojson(Some(&self.inner.gps_bounds)))
     }

--- a/street-explorer/www/js/lane_editor.js
+++ b/street-explorer/www/js/lane_editor.js
@@ -153,7 +153,13 @@ export class LaneEditor {
       JSON.parse(this.network.getGeometryForWay(id)),
       {
         style: (feature) => {
-          return { stroke: false, fill: true, color: "red", opacity: 0.5 };
+          return {
+            stroke: true,
+            fill: true,
+            color: "red",
+            weight: 1,
+            fillOpacity: 0.5,
+          };
         },
         interactive: false,
       }

--- a/street-explorer/www/js/lane_editor.js
+++ b/street-explorer/www/js/lane_editor.js
@@ -158,7 +158,7 @@ export class LaneEditor {
             fill: true,
             color: "red",
             weight: 1,
-            fillOpacity: 0.5,
+            fillOpacity: 0.3,
           };
         },
         interactive: false,


### PR DESCRIPTION
To indicate the road direction and facilitate tagging, I've been toying with the idea of indicating the direction with the selection overlay itself, instead of adding another arrow, which would add clutter and may be tricky to place with curved roads, e.g.

![image](https://user-images.githubusercontent.com/2684022/206320703-07d30a69-8407-488f-84ea-b149d326058a.png)

This is made with `make_arrow`, but it's a bit janky when there's a curve at the end of the road or with some loops.

![image](https://user-images.githubusercontent.com/2684022/206320907-b08b815f-b4ee-4a13-9230-0d98dab921e0.png)

![image](https://user-images.githubusercontent.com/2684022/206320929-f9fae618-138a-4e05-ae97-2505e6d70cd0.png)

![image](https://user-images.githubusercontent.com/2684022/206320949-cfd2ee2a-9b39-44d5-a4be-824f80585bc2.png)

![image](https://user-images.githubusercontent.com/2684022/206321019-9078eb22-ad95-49d1-869c-f629a1d770cf.png)

(looks like the intersection detection is also having issues with this last one)

I'm thinking of making a different arrow style:

![image](https://user-images.githubusercontent.com/2684022/206321348-c3ae8d9f-2ad5-4361-b1d9-59a8dcb065f5.png)
This style would allow to see the direction of the road by looking at either end, but it might make some loops look even more confusing.

![image](https://user-images.githubusercontent.com/2684022/206321742-3da7b4ba-887c-4276-bc2a-ba1fd791f248.png)
This might be better if we keep the chevrons from being created at the ends of lines. This might not work well with small cul-de-sac though (e.g. my second screenshot)

Any other ideas? Let me know what you think and if I'm looking at this the wrong way.