### PR TITLE
Improve intersections in some cases by extending untrimmed road edges…

### DIFF
--- a/osm2streets/src/geometry/general_case.rs
+++ b/osm2streets/src/geometry/general_case.rs
@@ -36,13 +36,27 @@ pub fn trim_to_corners(
         }
 
         // Look for where the two road edges collide, closest to the intersection.
-        if let Some((mut pt, _)) = one.pl.reversed().intersection(&two.pl.reversed()) {
-            // TODO Hack. PolyLine intersection appears to be broken when the first points match.
-            // Fix upstream.
-            if one.pl.last_pt() == two.pl.last_pt() {
-                pt = one.pl.last_pt();
-            }
+        let mut collision_pt = None;
+        if let Some((pt, _)) = one.pl.reversed().intersection(&two.pl.reversed()) {
+            collision_pt = Some(pt);
+        }
 
+        // TODO Hack. PolyLine intersection appears to be broken when the first points match.
+        // Fix upstream.
+        if one.pl.last_pt() == two.pl.last_pt() {
+            collision_pt = Some(one.pl.last_pt());
+        }
+
+        // If there's no hit, try extending both lines and seeing if they hit
+        if collision_pt.is_none() {
+            let longer_one = one.pl.extend_to_length(2.0 * one.pl.length()).reversed();
+            let longer_two = two.pl.extend_to_length(2.0 * two.pl.length()).reversed();
+            if let Some((pt, _)) = longer_one.intersection(&longer_two) {
+                collision_pt = Some(pt);
+            }
+        }
+
+        if let Some(pt) = collision_pt {
             // For both edges, project perpendicularly back to the original center, and trim back
             // to that point.
             for side in [one, two] {
@@ -79,7 +93,6 @@ pub fn trim_to_corners(
                 }
             }
         }
-        // TODO If there's no hit, consider extending both lines and seeing if they hit
     }
 
     // After trimming all the roads, look at the edges again


### PR DESCRIPTION
… a bit. #136

I'm not sure we should do this. But just to discuss the idea...

seattle_slip_lanes improves:
![Screenshot from 2022-12-08 14-58-43](https://user-images.githubusercontent.com/1664407/206479564-0a8d6582-93d4-409c-9f46-6731d92fe8ef.png)
![Screenshot from 2022-12-08 14-58-49](https://user-images.githubusercontent.com/1664407/206479600-4b95141a-2426-4856-a9fa-5a2573350a46.png)
Though this is a weird case, because got overlapping intersections, or very nearly.

aurora_sausage_link reveals an interesting problem.
![Screenshot from 2022-12-08 14-59-51](https://user-images.githubusercontent.com/1664407/206479919-6046ad24-18f9-4f0c-99e3-a4cd4cba1953.png)
![Screenshot from 2022-12-08 15-00-01](https://user-images.githubusercontent.com/1664407/206479947-cc0b8130-6fa7-4998-bf7c-19718a5ec731.png)
It's OK before, but we create less minimal intersections, and then the road doesn't meet the intersection cleanly. Because the trimmed back center is right on a slight curve, when we project left and right, the miter/bevel/whatever join acts a bit differently.

Is this an idea worth pursuing and refining? I'm more tempted to focus on something like seattle_slip_lanes where it gets us a bit closer to something good, but keep focusing on this one test case and figure out **everything** needed to make it look better.