### PR TITLE
Prototype: Draw lane markings through the intersection for connections and forks.

### DIFF
--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -91,7 +91,7 @@ impl StreetNetwork {
             for (lane, pl) in road
                 .lane_specs_ltr
                 .iter()
-                .zip(road.get_lane_center_lines().into_iter())
+                .zip(road.get_lane_center_lines(self).into_iter())
             {
                 pairs.push((
                     pl.make_polygons(lane.width)
@@ -138,7 +138,7 @@ impl StreetNetwork {
 
         for road in self.roads.values() {
             // Always oriented in the direction of the road
-            let mut lane_centers = road.get_lane_center_lines();
+            let mut lane_centers = road.get_lane_center_lines(self);
 
             for (idx, pair) in road.lane_specs_ltr.windows(2).enumerate() {
                 // Generate a "center line" between lanes of different directions

--- a/street-explorer/www/js/layers.js
+++ b/street-explorer/www/js/layers.js
@@ -1,10 +1,10 @@
 export const makePlainGeoJsonLayer = (text) => {
-  // TODO Update for new types
   const intersectionColours = {
-    Connection: "#666",
-    Intersection: "#966",
-    Terminus: "#999",
     MapEdge: "#696",
+    Terminus: "#999",
+    Connection: "#666",
+    Fork: "#966",
+    Intersection: "black",
   };
 
   return new L.geoJSON(JSON.parse(text), {
@@ -12,7 +12,7 @@ export const makePlainGeoJsonLayer = (text) => {
       if (feature.properties.type == "intersection") {
         return {
           color:
-            intersectionColours[feature.properties.intersection_kind] || "#666",
+            intersectionColours[feature.properties.intersection_kind],
           weight: 1,
           fillOpacity: 0.7,
         };


### PR DESCRIPTION
Just exploring what this might look like. Hardcoded for `aurora_sausage_link`.
![Screenshot from 2022-12-16 16-58-24](https://user-images.githubusercontent.com/1664407/208149911-28cb4cbd-9794-417f-b8e5-ad64dd780608.png)
Actually looking for connections or forks is maybe not so relevant. The first obvious place in my mind to try to do this is at intersections between main and minor roads, where one side has a stop or give-way sign. So, problem 1, we don't have a representation for that yet. Should there be `IntersectionKind` to differentiate some of the roads have priority over the others?

Regardless of the `Kind` question, we need to start representing priority between conflicting roads. We can start looking at [highway=stop](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dstop) in OSM, and when it's missing, just use `RoadRank`. How do we want to express this? Should it just be calculated on-the-fly? Should `Intersection` store the priority along with its list of ordered roads?

We can have region-specific rendering to show the lower priority roads. The US has stop signs on the side; here's one not-birds-eye-view idea from A/B Street that doesn't necessarily look so great:
![Screenshot from 2022-12-16 17-04-08](https://user-images.githubusercontent.com/1664407/208150865-74770efa-a6ca-4c7d-aa7f-9292e7d93d2c.png)
Give way symbols in the UK will be easier to incorporate in 2D:
![Screenshot from 2022-12-16 17-04-36](https://user-images.githubusercontent.com/1664407/208150962-fca6be27-82ca-49cd-8f06-b18f0c6bf3da.png)
