### PR TITLE
Show movements per lane #67

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -140,11 +140,6 @@ impl JsStreetNetwork {
         self.inner.debug_clockwise_ordering_geojson().unwrap()
     }
 
-    #[wasm_bindgen(js_name = debugAllMovementsGeojson)]
-    pub fn debug_all_movements_geojson(&self) -> String {
-        self.inner.debug_all_movements_geojson().unwrap()
-    }
-
     #[wasm_bindgen(js_name = debugMovementsFromLaneGeojson)]
     pub fn debug_movements_from_lane_geojson(&self, road: usize, index: usize) -> String {
         self.inner

--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -5,7 +5,7 @@ use geom::{Distance, LonLat, PolyLine, Polygon};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use osm2streets::{osm, DebugStreets, MapConfig, StreetNetwork, Transformation};
+use osm2streets::{osm, DebugStreets, LaneID, MapConfig, RoadID, StreetNetwork, Transformation};
 
 #[derive(Serialize, Deserialize)]
 pub struct ImportOptions {
@@ -140,9 +140,19 @@ impl JsStreetNetwork {
         self.inner.debug_clockwise_ordering_geojson().unwrap()
     }
 
-    #[wasm_bindgen(js_name = debugMovementsGeojson)]
-    pub fn debug_movements_geojson(&self) -> String {
-        self.inner.debug_movements_geojson().unwrap()
+    #[wasm_bindgen(js_name = debugAllMovementsGeojson)]
+    pub fn debug_all_movements_geojson(&self) -> String {
+        self.inner.debug_all_movements_geojson().unwrap()
+    }
+
+    #[wasm_bindgen(js_name = debugMovementsFromLaneGeojson)]
+    pub fn debug_movements_from_lane_geojson(&self, road: usize, index: usize) -> String {
+        self.inner
+            .debug_movements_from_lane_geojson(LaneID {
+                road: RoadID(road),
+                index,
+            })
+            .unwrap()
     }
 
     // TODO I think https://github.com/cloudflare/serde-wasm-bindgen would let us just return a

--- a/osm2streets/src/ids.rs
+++ b/osm2streets/src/ids.rs
@@ -37,6 +37,23 @@ impl fmt::Display for IntersectionID {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LaneID {
+    pub road: RoadID,
+    /// Index into `lane_specs_ltr`
+    #[serde(
+        serialize_with = "serialize_usize",
+        deserialize_with = "deserialize_usize"
+    )]
+    pub index: usize,
+}
+
+impl fmt::Display for LaneID {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Lane {} of {}", self.index, self.road)
+    }
+}
+
 /// It's sometimes useful to track both a road's ID and endpoints together. Use this sparingly.
 #[derive(Clone)]
 pub struct RoadWithEndpoints {

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -13,7 +13,7 @@ use geom::{GPSBounds, PolyLine, Polygon, Pt2D};
 
 pub use self::geometry::{intersection_polygon, InputRoad};
 pub(crate) use self::ids::RoadWithEndpoints;
-pub use self::ids::{CommonEndpoint, IntersectionID, RoadID};
+pub use self::ids::{CommonEndpoint, IntersectionID, LaneID, RoadID};
 pub use self::intersection::{
     Intersection, IntersectionControl, IntersectionKind, Movement, TrafficConflict,
 };

--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -339,20 +339,6 @@ impl StreetNetwork {
         result
     }
 
-    pub fn debug_all_movements_geojson(&self) -> Result<String> {
-        let mut pairs = Vec::new();
-
-        for i in self.intersections.keys() {
-            for (_, polygon) in self.movements_for_intersection(*i) {
-                pairs.push((polygon.to_geojson(Some(&self.gps_bounds)), make_props(&[])));
-            }
-        }
-
-        let obj = geom::geometries_with_properties_to_geojson(pairs);
-        let output = serde_json::to_string_pretty(&obj)?;
-        Ok(output)
-    }
-
     pub fn debug_movements_from_lane_geojson(&self, id: LaneID) -> Result<String> {
         let road = &self.roads[&id.road];
         let i = if road.lane_specs_ltr[id.index].dir == Direction::Fwd {

--- a/street-explorer/www/js/layers.js
+++ b/street-explorer/www/js/layers.js
@@ -93,8 +93,8 @@ export const lanePolygonStyle = (feature) => {
   };
 };
 
-export const makeLanePolygonLayer = (text) => {
-  return new L.geoJSON(JSON.parse(text), {
+export const makeLanePolygonLayer = (network, dynamicMovementLayer, map) => {
+  return new L.geoJSON(JSON.parse(network.toLanePolygonsGeojson()), {
     style: lanePolygonStyle,
     onEachFeature: function (feature, layer) {
       layer.on({
@@ -103,11 +103,25 @@ export const makeLanePolygonLayer = (text) => {
           layer.setStyle({
             fillOpacity: 0.5,
           });
+
+          if (dynamicMovementLayer) {
+            map.removeLayer(dynamicMovementLayer);
+          }
+          const movements = network.debugMovementsFromLaneGeojson(
+            feature.properties.road,
+            feature.properties.index
+          );
+          dynamicMovementLayer = L.geoJSON(JSON.parse(movements));
+          dynamicMovementLayer.addTo(map);
         },
         mouseout: function (ev) {
           layer.setStyle({
             fillOpacity: 0.9,
           });
+
+          if (dynamicMovementLayer) {
+            map.removeLayer(dynamicMovementLayer);
+          }
         },
       });
 

--- a/street-explorer/www/js/main.js
+++ b/street-explorer/www/js/main.js
@@ -32,6 +32,7 @@ export class StreetExplorer {
     this.currentTest = null;
     this.layers = makeLayerControl(this).addTo(this.map);
     this.settingsControl = null;
+    this.dynamicMovementLayer = null;
 
     // Add all tests to the sidebar
     loadTests();
@@ -260,7 +261,7 @@ function importOSM(groupName, app, osmXML, addOSMLayer, boundaryGeojson) {
     group.addLayer("Geometry", makePlainGeoJsonLayer(network.toGeojsonPlain()));
     group.addLayer(
       "Lane polygons",
-      makeLanePolygonLayer(network.toLanePolygonsGeojson())
+      makeLanePolygonLayer(network, app.dynamicMovementLayer, app.map)
     );
     group.addLayer(
       "Lane markings",
@@ -274,7 +275,7 @@ function importOSM(groupName, app, osmXML, addOSMLayer, boundaryGeojson) {
       makeDebugLayer(network.debugClockwiseOrderingGeojson())
     );
     group.addLazyLayer("Debug movements", () =>
-      makeDebugLayer(network.debugMovementsGeojson())
+      makeDebugLayer(network.debugAllMovementsGeojson())
     );
     // TODO Graphviz hits `ReferenceError: can't access lexical declaration 'graph' before initialization`
 
@@ -294,7 +295,11 @@ function importOSM(groupName, app, osmXML, addOSMLayer, boundaryGeojson) {
         makePlainGeoJsonLayer(step.getNetwork().toGeojsonPlain())
       );
       group.addLazyLayer("Lane polygons", () =>
-        makeLanePolygonLayer(step.getNetwork().toLanePolygonsGeojson())
+        makeLanePolygonLayer(
+          step.getNetwork(),
+          app.dynamicMovementLayer,
+          app.map
+        )
       );
       group.addLazyLayer("Lane markings", () =>
         makeLaneMarkingsLayer(step.getNetwork().toLaneMarkingsGeojson())

--- a/street-explorer/www/js/main.js
+++ b/street-explorer/www/js/main.js
@@ -274,9 +274,6 @@ function importOSM(groupName, app, osmXML, addOSMLayer, boundaryGeojson) {
     group.addLazyLayer("Debug road ordering", () =>
       makeDebugLayer(network.debugClockwiseOrderingGeojson())
     );
-    group.addLazyLayer("Debug movements", () =>
-      makeDebugLayer(network.debugAllMovementsGeojson())
-    );
     // TODO Graphviz hits `ReferenceError: can't access lexical declaration 'graph' before initialization`
 
     const numDebugSteps = network.getDebugSteps().length;


### PR DESCRIPTION
Just a small step towards richer movements. Visualizing all of them at once is too overwhelming, so just prepare for displaying something per lane. The actual filtering is still per-road right now, of course.

https://user-images.githubusercontent.com/1664407/209577533-9000615c-42ae-435e-a5bb-c00cea63c060.mp4

Is it still useful to show all movements at once, or should we remove that layer?