### PR TITLE
Start representing and extracting explicit stop lines, with many

### DIFF
--- a/osm2streets/src/geometry/mod.rs
+++ b/osm2streets/src/geometry/mod.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use geom::{Distance, PolyLine, Polygon, Pt2D, Ring};
 
 use crate::road::RoadEdge;
-use crate::{IntersectionID, RoadID};
+use crate::{IntersectionID, RoadID, StopLine};
 
 // For anyone considering removing this indirection in the future: it's used to recalculate one or
 // two intersections at a time in A/B Street's edit mode. Within just this repo, it does seem
@@ -75,6 +75,8 @@ impl InputRoad {
             trim_end: Distance::ZERO,
             turn_restrictions: Vec::new(),
             complicated_turn_restrictions: Vec::new(),
+            stop_line_start: StopLine::dummy(),
+            stop_line_end: StopLine::dummy(),
         }
     }
 }

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -20,7 +20,7 @@ pub use self::lanes::{
     get_lane_specs_ltr, BufferType, Direction, LaneSpec, LaneType, Placement,
     NORMAL_LANE_THICKNESS, SIDEWALK_THICKNESS,
 };
-pub use self::road::Road;
+pub use self::road::{Road, StopLine, TrafficInterruption};
 pub use self::transform::Transformation;
 pub use self::types::{DrivingSide, MapConfig, NamePerLanguage};
 

--- a/osm2streets/src/operations/collapse_short_road.rs
+++ b/osm2streets/src/operations/collapse_short_road.rs
@@ -71,6 +71,7 @@ impl StreetNetwork {
         // If the intersection types differ, upgrade the surviving interesting.
         if destroy_i.control == IntersectionControl::Signalled {
             self.intersections.get_mut(&keep_i).unwrap().control = IntersectionControl::Signalled;
+            // TODO Propagate to stop lines
         }
 
         // Remember the merge

--- a/osm2streets/src/types.rs
+++ b/osm2streets/src/types.rs
@@ -94,13 +94,3 @@ pub enum DrivingSide {
     Right,
     Left,
 }
-
-/// How a lane of travel is interrupted, as it meets another or ends.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
-pub enum TrafficInterruption {
-    Uninterrupted,
-    Yield,
-    Stop,
-    Signal,
-    DeadEnd,
-}

--- a/street-explorer/js/layers.js
+++ b/street-explorer/js/layers.js
@@ -149,6 +149,8 @@ export const makeLaneMarkingsLayer = (text) => {
     "lane arrow": "white",
     "buffer edge": "white",
     "buffer stripe": "white",
+    "vehicle stop line": "white",
+    "bike stop line": "green",
   };
 
   return new L.geoJSON(JSON.parse(text), {

--- a/tests/src/bristol_contraflow_cycleway/geometry.json
+++ b/tests/src/bristol_contraflow_cycleway/geometry.json
@@ -2155,7 +2155,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "control": "Signalled",
+        "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [

--- a/tests/src/bristol_sausage_links/geometry.json
+++ b/tests/src/bristol_sausage_links/geometry.json
@@ -1461,7 +1461,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "control": "Signalled",
+        "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [

--- a/tests/src/bristol_sausage_links/road_network.dot
+++ b/tests/src/bristol_sausage_links/road_network.dot
@@ -2,7 +2,7 @@ digraph {
     0 [ label = "MapEdge" ]
     1 [ label = "Merge" ]
     2 [ label = "MapEdge" ]
-    3 [ label = "Lights RoadIntersection" ]
+    3 [ label = "Uncontrolled RoadIntersection" ]
     4 [ label = "MapEdge" ]
     5 [ label = "Merge" ]
     6 [ label = "MapEdge" ]

--- a/tests/src/leeds_cycleway/geometry.json
+++ b/tests/src/leeds_cycleway/geometry.json
@@ -30424,7 +30424,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "control": "Signalled",
+        "control": "Signed",
         "id": 263,
         "intersection_kind": "Connection",
         "movements": [
@@ -38098,7 +38098,7 @@
         "type": "Polygon"
       },
       "properties": {
-        "control": "Signalled",
+        "control": "Signed",
         "id": 433,
         "intersection_kind": "Connection",
         "movements": [],


### PR DESCRIPTION
problems. #165

Trying to start with the simple cases quickly exposed lots of issues, so I wanted to get early feedback. I think this is worth merging and iterating on, but there are also major design problems that we'll need to solve.

So far it only records and renders **explicitly** tagged stop lines. I started by setting these up for every road with defaults, but it quickly reveals a problem -- we have lots of short Roads that aren't places where vehicles stop, and so we definitely don't want to draw inferred stop lines in those places!

# Case study: borough_sausage_links

This is a good test case, because stop lines around here are very dramatically far back from the intersection itself. From cycling around in person, this is immediately noticeable and strange with a US perspective. :)

![Screenshot from 2023-01-04 11-52-13](https://user-images.githubusercontent.com/1664407/210549374-ad8d7ba1-b9d7-4a10-8ad5-b19db303c2fd.png)
![Screenshot from 2023-01-04 11-51-47](https://user-images.githubusercontent.com/1664407/210549377-723474ea-d4f4-4e13-9558-e17518eacb30.png)

The two traffic signal nodes tell us about the bike box, and the result looks decent! We happened to get lucky here and preserve the stop lines when we collapse a sausage link.

![Screenshot from 2023-01-04 11-53-40](https://user-images.githubusercontent.com/1664407/210549610-08fb402b-ca90-48d1-978b-1b9951459dff.png)
![Screenshot from 2023-01-04 11-53-28](https://user-images.githubusercontent.com/1664407/210549615-d002bace-ce4f-4b09-ade7-6f3f92a7fe0b.png)
On the western arm, we're not so lucky. `transform/sausage_links.rs` will need to merge stop lines for the two sides.

This area reveals another puzzle. Stop lines are sometimes marked on the **outgoing** roads of an intersection too: https://www.openstreetmap.org/node/9733205389. I guess this is to handle cases when turning vehicles don't clear the junction before the pedestrian phase goes on. I'm not sure this is something we want to represent, or how to work it in.

# Case study: seattle_slip_lane

![Screenshot from 2023-01-04 11-59-39](https://user-images.githubusercontent.com/1664407/210550589-4be90c9c-8d22-433c-ba10-88724a8653a3.png)
The main road's stop lines are coming from https://www.openstreetmap.org/node/4829741818, a signalized crossing node. This case highlights what happens when we're not yet successfully trimming geometry. And also maybe some nuance about basing stop line distances on reference lines.