### PR TITLE
Add layer to GeoJSON output for roads

### DIFF
--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -42,6 +42,7 @@ impl StreetNetwork {
                     ),
                     ("src_i", road.src_i.0.into()),
                     ("dst_i", road.dst_i.0.into()),
+                    ("layer", road.layer.into()),
                 ]),
             ));
         }
@@ -100,6 +101,7 @@ impl StreetNetwork {
                     make_props(&[
                         ("type", format!("{:?}", lane.lt).into()),
                         ("road", road.id.0.into()),
+                        ("layer", road.layer.into()),
                         ("index", idx.into()),
                         ("width", lane.width.inner_meters().into()),
                         ("direction", format!("{:?}", lane.dir).into()),
@@ -153,7 +155,10 @@ impl StreetNetwork {
                     ) {
                         pairs.push((
                             poly.to_geojson(gps_bounds),
-                            make_props(&[("type", "center line".into())]),
+                            make_props(&[
+                                ("type", "center line".into()),
+                                ("layer", road.layer.into()),
+                            ]),
                         ));
                     }
                     continue;
@@ -169,7 +174,10 @@ impl StreetNetwork {
                     ) {
                         pairs.push((
                             poly.to_geojson(gps_bounds),
-                            make_props(&[("type", "lane separator".into())]),
+                            make_props(&[
+                                ("type", "lane separator".into()),
+                                ("layer", road.layer.into()),
+                            ]),
                         ));
                     }
                 }
@@ -202,7 +210,7 @@ impl StreetNetwork {
                     .to_outline(thickness / 2.0);
                     pairs.push((
                         arrow.to_geojson(gps_bounds),
-                        make_props(&[("type", "lane arrow".into())]),
+                        make_props(&[("type", "lane arrow".into()), ("layer", road.layer.into())]),
                     ));
                 }
             }
@@ -221,14 +229,14 @@ impl StreetNetwork {
                         .must_shift_right((lane.width - thickness) / 2.0)
                         .make_polygons(thickness)
                         .to_geojson(gps_bounds),
-                    make_props(&[("type", "buffer edge".into())]),
+                    make_props(&[("type", "buffer edge".into()), ("layer", road.layer.into())]),
                 ));
                 pairs.push((
                     center
                         .must_shift_left((lane.width - thickness) / 2.0)
                         .make_polygons(thickness)
                         .to_geojson(gps_bounds),
-                    make_props(&[("type", "buffer edge".into())]),
+                    make_props(&[("type", "buffer edge".into()), ("layer", road.layer.into())]),
                 ));
 
                 // Diagonal stripes along the lane
@@ -246,7 +254,10 @@ impl StreetNetwork {
                         Line::must_new(left, right)
                             .make_polygons(thickness)
                             .to_geojson(gps_bounds),
-                        make_props(&[("type", "buffer stripe".into())]),
+                        make_props(&[
+                            ("type", "buffer stripe".into()),
+                            ("layer", road.layer.into()),
+                        ]),
                     ));
                 }
             }

--- a/tests/src/arizona_highways/geometry.json
+++ b/tests/src/arizona_highways/geometry.json
@@ -62,6 +62,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           23806615
         ],
@@ -116,6 +117,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           23806634
         ],
@@ -154,6 +156,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 1,
         "osm_way_ids": [
           97736474
         ],
@@ -192,6 +195,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           97736490
         ],
@@ -230,6 +234,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 1,
         "osm_way_ids": [
           106408374
         ],
@@ -268,6 +273,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           106408376
         ],
@@ -306,6 +312,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 1,
         "osm_way_ids": [
           106408377
         ],
@@ -344,6 +351,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 1,
         "osm_way_ids": [
           106408380
         ],
@@ -382,6 +390,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           131610256
         ],
@@ -420,6 +429,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           184601643
         ],
@@ -458,6 +468,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           237561058
         ],
@@ -496,6 +507,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           237561059
         ],
@@ -534,6 +546,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           237561059
         ],
@@ -572,6 +585,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           237561060
         ],
@@ -610,6 +624,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           237561061
         ],
@@ -648,6 +663,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           237561061
         ],
@@ -686,6 +702,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           237561063
         ],
@@ -724,6 +741,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           237561063
         ],
@@ -762,6 +780,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           237561064
         ],
@@ -800,6 +819,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           237561064
         ],
@@ -838,6 +858,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           237561065
         ],
@@ -876,6 +897,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           237561066
         ],
@@ -914,6 +936,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           237561067
         ],
@@ -952,6 +975,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           237561068
         ],
@@ -998,6 +1022,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           237561069
         ],
@@ -1036,6 +1061,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           237881873
         ],
@@ -1074,6 +1100,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           237881874
         ],
@@ -1112,6 +1139,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           237881875
         ],
@@ -1150,6 +1178,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           237881876
         ],
@@ -1188,6 +1217,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           237881877
         ],
@@ -1226,6 +1256,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           237881878
         ],
@@ -1264,6 +1295,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           237881879
         ],
@@ -1302,6 +1334,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           237881880
         ],
@@ -1340,6 +1373,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           237881881
         ],
@@ -1386,6 +1420,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           237881882
         ],
@@ -1432,6 +1467,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           237881883
         ],
@@ -1486,6 +1522,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           237881884
         ],
@@ -1556,6 +1593,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           237881885
         ],
@@ -1634,6 +1672,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           237881886
         ],
@@ -1696,6 +1735,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           237881887
         ],
@@ -1734,6 +1774,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           238055918
         ],
@@ -1772,6 +1813,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           326998445,
           512550749
@@ -1811,6 +1853,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           436235317
         ],
@@ -1849,6 +1892,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           436235324
         ],
@@ -1887,6 +1931,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           436235329
         ],
@@ -1925,6 +1970,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 1,
         "osm_way_ids": [
           436235332
         ],
@@ -1963,6 +2009,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 1,
         "osm_way_ids": [
           436235333
         ],
@@ -2009,6 +2056,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           436235334
         ],
@@ -2055,6 +2103,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 1,
         "osm_way_ids": [
           436235335
         ],
@@ -2093,6 +2142,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           437324814
         ],
@@ -2131,6 +2181,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           437324816
         ],
@@ -2169,6 +2220,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           437324818
         ],
@@ -2207,6 +2259,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           437324821
         ],
@@ -2245,6 +2298,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           437325029
         ],
@@ -2283,6 +2337,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           437325030
         ],
@@ -2321,6 +2376,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           437325586
         ],
@@ -2367,6 +2423,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           437325591
         ],
@@ -2445,6 +2502,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           508916718
         ],
@@ -2483,6 +2541,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           512550749
         ],
@@ -2521,6 +2580,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           528305072
         ],
@@ -2559,6 +2619,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           528305479
         ],
@@ -2597,6 +2658,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           528307072
         ],
@@ -2635,6 +2697,7 @@
       },
       "properties": {
         "dst_i": 56,
+        "layer": 0,
         "osm_way_ids": [
           528307073
         ],
@@ -2673,6 +2736,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           528310266
         ],
@@ -2711,6 +2775,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           606189735
         ],
@@ -2749,6 +2814,7 @@
       },
       "properties": {
         "dst_i": 62,
+        "layer": 0,
         "osm_way_ids": [
           606189736
         ],
@@ -2787,6 +2853,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           606189736
         ],
@@ -2849,6 +2916,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           608764856
         ],
@@ -2911,6 +2979,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           608764857
         ],
@@ -2949,6 +3018,7 @@
       },
       "properties": {
         "dst_i": 61,
+        "layer": 0,
         "osm_way_ids": [
           665499814,
           665499815
@@ -2988,6 +3058,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           1051003905
         ],
@@ -3026,6 +3097,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           1051003906
         ],

--- a/tests/src/aurora_sausage_link/geometry.json
+++ b/tests/src/aurora_sausage_link/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           36954059
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           518371186
         ],
@@ -106,6 +108,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           518371192
         ],
@@ -144,6 +147,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           735407291
         ],
@@ -190,6 +194,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           792024856
         ],
@@ -236,6 +241,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           792024857
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           792024858
         ],
@@ -328,6 +335,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           792024859
         ],
@@ -366,6 +374,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           893136312
         ],
@@ -404,6 +413,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           975775897
         ],

--- a/tests/src/borough_sausage_links/geometry.json
+++ b/tests/src/borough_sausage_links/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           26248221
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           31248255
         ],
@@ -114,6 +116,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           31248255
         ],
@@ -152,6 +155,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           31248255
         ],
@@ -190,6 +194,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           95568203
         ],
@@ -228,6 +233,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           100799869
         ],
@@ -266,6 +272,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           100799869
         ],
@@ -304,6 +311,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           100799869
         ],
@@ -342,6 +350,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           100799869
         ],
@@ -396,6 +405,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           100799873
         ],
@@ -434,6 +444,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           100799873
         ],
@@ -472,6 +483,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           100799873
         ],
@@ -510,6 +522,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           100799873
         ],
@@ -548,6 +561,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           100799897
         ],
@@ -586,6 +600,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           100799924
         ],
@@ -624,6 +639,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           100799946
         ],
@@ -662,6 +678,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           150182429
         ],
@@ -700,6 +717,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           210112374
         ],
@@ -738,6 +756,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           211779456
         ],
@@ -776,6 +795,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           211780341,
           539540865
@@ -815,6 +835,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           211780343,
           539540880
@@ -854,6 +875,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           211780349,
           211781358
@@ -901,6 +923,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           211780353
         ],
@@ -947,6 +970,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           211780353
         ],
@@ -985,6 +1009,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           211781360,
           539540879
@@ -1032,6 +1057,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           211782553
         ],
@@ -1078,6 +1104,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           211782554
         ],
@@ -1124,6 +1151,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           211782556
         ],
@@ -1162,6 +1190,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           222795385
         ],
@@ -1200,6 +1229,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           243285287
         ],
@@ -1238,6 +1268,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           380116492
         ],
@@ -1276,6 +1307,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           454007398
         ],
@@ -1338,6 +1370,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           454007398
         ],
@@ -1376,6 +1409,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           462430761
         ],
@@ -1414,6 +1448,7 @@
       },
       "properties": {
         "dst_i": 57,
+        "layer": 0,
         "osm_way_ids": [
           462430761
         ],
@@ -1452,6 +1487,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           462430761
         ],
@@ -1490,6 +1526,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           539534590
         ],
@@ -1528,6 +1565,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           539534590
         ],
@@ -1566,6 +1604,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           539534591
         ],
@@ -1628,6 +1667,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           539534592
         ],
@@ -1666,6 +1706,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           539534593
         ],
@@ -1704,6 +1745,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           539534595
         ],
@@ -1750,6 +1792,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           539534596
         ],
@@ -1804,6 +1847,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           539534596
         ],
@@ -1842,6 +1886,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           539534597
         ],
@@ -1888,6 +1933,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           539534599
         ],
@@ -1926,6 +1972,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           539534603
         ],
@@ -1964,6 +2011,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           539534605
         ],
@@ -2010,6 +2058,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           539534605
         ],
@@ -2048,6 +2097,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           539534606
         ],
@@ -2086,6 +2136,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           539534607
         ],
@@ -2124,6 +2175,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           539534608
         ],
@@ -2186,6 +2238,7 @@
       },
       "properties": {
         "dst_i": 52,
+        "layer": 0,
         "osm_way_ids": [
           539534609
         ],
@@ -2224,6 +2277,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           539539172
         ],
@@ -2262,6 +2316,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           539540870
         ],
@@ -2300,6 +2355,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           539540874
         ],
@@ -2362,6 +2418,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           539540878
         ],
@@ -2400,6 +2457,7 @@
       },
       "properties": {
         "dst_i": 52,
+        "layer": 0,
         "osm_way_ids": [
           539540881
         ],
@@ -2438,6 +2496,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           539540882
         ],
@@ -2484,6 +2543,7 @@
       },
       "properties": {
         "dst_i": 57,
+        "layer": 0,
         "osm_way_ids": [
           852420879,
           539534598
@@ -2523,6 +2583,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           1059354151
         ],

--- a/tests/src/bristol_contraflow_cycleway/geometry.json
+++ b/tests/src/bristol_contraflow_cycleway/geometry.json
@@ -38,6 +38,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           4019483
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           4019483
         ],
@@ -122,6 +124,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           4019484
         ],
@@ -160,6 +163,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           8454004
         ],
@@ -198,6 +202,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           8454004
         ],
@@ -244,6 +249,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           24042775
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           24042775
         ],
@@ -320,6 +327,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           24042775
         ],
@@ -358,6 +366,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           24042783
         ],
@@ -396,6 +405,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           24042783
         ],
@@ -434,6 +444,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           25874031
         ],
@@ -472,6 +483,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           106281101
         ],
@@ -510,6 +522,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           106281106
         ],
@@ -556,6 +569,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           203117010
         ],
@@ -594,6 +608,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           210831867
         ],
@@ -648,6 +663,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           280732115
         ],
@@ -710,6 +726,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           280732115
         ],
@@ -748,6 +765,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           824782255
         ],
@@ -786,6 +804,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           824782255
         ],
@@ -824,6 +843,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           824782255
         ],
@@ -870,6 +890,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           824782255
         ],
@@ -908,6 +929,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           905798389
         ],
@@ -946,6 +968,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           905798389
         ],
@@ -984,6 +1007,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           905798392
         ],
@@ -1078,6 +1102,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           905830125
         ],
@@ -1116,6 +1141,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           905830130
         ],
@@ -1162,6 +1188,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           1004031465
         ],
@@ -1200,6 +1227,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           1004031465
         ],

--- a/tests/src/bristol_sausage_links/geometry.json
+++ b/tests/src/bristol_sausage_links/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           4013379
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           4019484
         ],
@@ -114,6 +116,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           4036224
         ],
@@ -152,6 +155,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           15509329
         ],
@@ -190,6 +194,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           15509329
         ],
@@ -228,6 +233,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           26605055
         ],
@@ -266,6 +272,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           157371356
         ],
@@ -304,6 +311,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           291394487,
           481131862
@@ -343,6 +351,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           481131864,
           481131864
@@ -382,6 +391,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           481131866,
           481131867
@@ -421,6 +431,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           481131868
         ],
@@ -459,6 +470,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           481131869
         ],
@@ -497,6 +509,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           481131870
         ],
@@ -543,6 +556,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           997182616
         ],
@@ -581,6 +595,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           997453942
         ],
@@ -619,6 +634,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           997453943
         ],
@@ -657,6 +673,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           1004419284
         ],

--- a/tests/src/cycleway_rejoin_road/geometry.json
+++ b/tests/src/cycleway_rejoin_road/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           4256208
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           4256300
         ],
@@ -106,6 +108,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           4256387
         ],
@@ -144,6 +147,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           4256387
         ],
@@ -182,6 +186,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           4256388
         ],
@@ -220,6 +225,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           4256480
         ],
@@ -274,6 +280,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           4256703
         ],
@@ -312,6 +319,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           4256703
         ],
@@ -350,6 +358,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           4256704
         ],
@@ -388,6 +397,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           37830507
         ],
@@ -426,6 +436,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           49218983
         ],
@@ -464,6 +475,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           49218983
         ],
@@ -502,6 +514,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           49218983
         ],
@@ -540,6 +553,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           112683088
         ],
@@ -594,6 +608,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           449250558
         ],
@@ -640,6 +655,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           473149319
         ],
@@ -694,6 +710,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           505956321
         ],
@@ -732,6 +749,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           505956322
         ],
@@ -778,6 +796,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           507120964
         ],
@@ -816,6 +835,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           507124192
         ],
@@ -854,6 +874,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           507124192
         ],
@@ -892,6 +913,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           507124192
         ],
@@ -930,6 +952,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           507124193
         ],
@@ -968,6 +991,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           605012633
         ],
@@ -1006,6 +1030,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           605012633
         ],
@@ -1044,6 +1069,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           605012636
         ],
@@ -1082,6 +1108,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           605014315
         ],
@@ -1120,6 +1147,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           605014316
         ],
@@ -1166,6 +1194,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           605014316
         ],
@@ -1204,6 +1233,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           605014316
         ],
@@ -1242,6 +1272,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           784643056
         ],
@@ -1280,6 +1311,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           798193875
         ],
@@ -1318,6 +1350,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           798193875
         ],
@@ -1356,6 +1389,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           798193875
         ],
@@ -1418,6 +1452,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           933882058,
           990187777
@@ -1457,6 +1492,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           988439993
         ],
@@ -1503,6 +1539,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           988439993
         ],
@@ -1541,6 +1578,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           988439994
         ],
@@ -1587,6 +1625,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           988442666
         ],
@@ -1625,6 +1664,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           988442666
         ],
@@ -1663,6 +1703,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           988442667
         ],
@@ -1701,6 +1742,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           988442667
         ],
@@ -1747,6 +1789,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           988442668
         ],
@@ -1785,6 +1828,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           988442669
         ],
@@ -1823,6 +1867,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           990184954
         ],
@@ -1861,6 +1906,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           990184958
         ],
@@ -1899,6 +1945,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           990187778
         ],
@@ -1937,6 +1984,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           990187781
         ],
@@ -1975,6 +2023,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           1068255164
         ],
@@ -2013,6 +2062,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           1068255165
         ],

--- a/tests/src/fremantle_placement/geometry.json
+++ b/tests/src/fremantle_placement/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           8067058
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           8067058
         ],
@@ -114,6 +116,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           8106170
         ],
@@ -152,6 +155,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           69706081
         ],
@@ -190,6 +194,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           80963333
         ],
@@ -244,6 +249,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           129518972
         ],
@@ -290,6 +296,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           129518972
         ],
@@ -336,6 +343,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           129518972
         ],
@@ -374,6 +382,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           174458314
         ],
@@ -412,6 +421,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           174458314
         ],
@@ -466,6 +476,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           292025661
         ],
@@ -512,6 +523,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           292025666
         ],
@@ -550,6 +562,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           292151260
         ],
@@ -588,6 +601,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           298328308
         ],
@@ -626,6 +640,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           298328321
         ],
@@ -664,6 +679,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           298328328
         ],
@@ -702,6 +718,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           298328336
         ],
@@ -740,6 +757,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           298328342
         ],
@@ -778,6 +796,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           298328346
         ],
@@ -816,6 +835,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           298328362
         ],
@@ -854,6 +874,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           298328362,
           319289852
@@ -893,6 +914,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           319289828
         ],
@@ -971,6 +993,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           319289829
         ],
@@ -1009,6 +1032,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           319289830
         ],
@@ -1047,6 +1071,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           319289830
         ],
@@ -1101,6 +1126,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           319289831
         ],
@@ -1139,6 +1165,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           319289839
         ],
@@ -1177,6 +1204,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           319289839
         ],
@@ -1215,6 +1243,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           319289860
         ],
@@ -1253,6 +1282,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           319289860
         ],
@@ -1299,6 +1329,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           319289861
         ],
@@ -1337,6 +1368,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           568347393
         ],
@@ -1375,6 +1407,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           568347394
         ],
@@ -1413,6 +1446,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           568347395
         ],
@@ -1459,6 +1493,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           568347396
         ],
@@ -1505,6 +1540,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           663510804
         ],
@@ -1543,6 +1579,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           666911243
         ],
@@ -1581,6 +1618,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           671208478,
           292025662
@@ -1620,6 +1658,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           671208478
         ],
@@ -1658,6 +1697,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           671208480
         ],
@@ -1696,6 +1736,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           671211371
         ],
@@ -1734,6 +1775,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           671211373
         ],
@@ -1772,6 +1814,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           671211375
         ],
@@ -1818,6 +1861,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           671212276
         ],
@@ -1856,6 +1900,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           671212277
         ],
@@ -1894,6 +1939,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           671212278
         ],
@@ -1932,6 +1978,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           1047823846
         ],
@@ -1978,6 +2025,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           1117516011
         ],
@@ -2016,6 +2064,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           1117516012
         ],

--- a/tests/src/i5_exit_ramp/geometry.json
+++ b/tests/src/i5_exit_ramp/geometry.json
@@ -46,6 +46,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 3,
         "osm_way_ids": [
           4637378
         ],
@@ -92,6 +93,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 3,
         "osm_way_ids": [
           4644156
         ],
@@ -146,6 +148,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           4644164
         ],
@@ -192,6 +195,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 3,
         "osm_way_ids": [
           4644167
         ],
@@ -254,6 +258,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 2,
         "osm_way_ids": [
           4644170
         ],
@@ -292,6 +297,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           4725116
         ],
@@ -330,6 +336,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           4869147
         ],
@@ -376,6 +383,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 3,
         "osm_way_ids": [
           4869148
         ],
@@ -414,6 +422,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           4915352
         ],
@@ -452,6 +461,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           6400787
         ],
@@ -490,6 +500,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           6412023
         ],
@@ -528,6 +539,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           6412023
         ],
@@ -566,6 +578,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           6412023
         ],
@@ -604,6 +617,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           7978667,
           863212079
@@ -675,6 +689,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           19795320,
           454116174
@@ -714,6 +729,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 1,
         "osm_way_ids": [
           34528139
         ],
@@ -752,6 +768,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           39948315
         ],
@@ -790,6 +807,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           49668015
         ],
@@ -836,6 +854,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           50848121
         ],
@@ -882,6 +901,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           50848121
         ],
@@ -928,6 +948,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           106165951
         ],
@@ -966,6 +987,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 2,
         "osm_way_ids": [
           124272614
         ],
@@ -1004,6 +1026,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           163631482
         ],
@@ -1042,6 +1065,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 3,
         "osm_way_ids": [
           175933057
         ],
@@ -1088,6 +1112,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           177678723
         ],
@@ -1126,6 +1151,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           261639788
         ],
@@ -1180,6 +1206,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           305036669,
           305036669
@@ -1219,6 +1246,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           331907114
         ],
@@ -1257,6 +1285,7 @@
       },
       "properties": {
         "dst_i": 52,
+        "layer": 0,
         "osm_way_ids": [
           331907114
         ],
@@ -1295,6 +1324,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           331907114
         ],
@@ -1333,6 +1363,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           337263523
         ],
@@ -1379,6 +1410,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           337263523
         ],
@@ -1417,6 +1449,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           337263523
         ],
@@ -1455,6 +1488,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           337263524
         ],
@@ -1493,6 +1527,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           337263524
         ],
@@ -1531,6 +1566,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           362821492
         ],
@@ -1577,6 +1613,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           455866872
         ],
@@ -1615,6 +1652,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 2,
         "osm_way_ids": [
           474077561
         ],
@@ -1661,6 +1699,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           486269221
         ],
@@ -1699,6 +1738,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           486281532
         ],
@@ -1737,6 +1777,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           607520174
         ],
@@ -1775,6 +1816,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           607520176
         ],
@@ -1813,6 +1855,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           608754116
         ],
@@ -1851,6 +1894,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 3,
         "osm_way_ids": [
           622519703
         ],
@@ -1889,6 +1933,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           863212082
         ],
@@ -1927,6 +1972,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           952835360
         ],
@@ -1973,6 +2019,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           1025401762,
           1025401757

--- a/tests/src/kingsway_junction/geometry.json
+++ b/tests/src/kingsway_junction/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           4852872
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           4852873
         ],
@@ -122,6 +124,7 @@
       },
       "properties": {
         "dst_i": 70,
+        "layer": 0,
         "osm_way_ids": [
           4852875
         ],
@@ -176,6 +179,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           4905401
         ],
@@ -214,6 +218,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           4905402
         ],
@@ -252,6 +257,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           50147875
         ],
@@ -290,6 +296,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           59876786,
           59876790
@@ -329,6 +336,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           59876786
         ],
@@ -367,6 +375,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           60007818
         ],
@@ -405,6 +414,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           60007839
         ],
@@ -451,6 +461,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           60577044
         ],
@@ -489,6 +500,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           60577053
         ],
@@ -527,6 +539,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           60577054
         ],
@@ -565,6 +578,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           81981143
         ],
@@ -603,6 +617,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           81981151
         ],
@@ -657,6 +672,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           81981154
         ],
@@ -695,6 +711,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           81981159
         ],
@@ -733,6 +750,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           81981181
         ],
@@ -779,6 +797,7 @@
       },
       "properties": {
         "dst_i": 62,
+        "layer": 0,
         "osm_way_ids": [
           81981181
         ],
@@ -825,6 +844,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           81981181
         ],
@@ -863,6 +883,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           81981186
         ],
@@ -901,6 +922,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           81981186
         ],
@@ -939,6 +961,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           81981186
         ],
@@ -977,6 +1000,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           112414473
         ],
@@ -1015,6 +1039,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 1,
         "osm_way_ids": [
           112414474
         ],
@@ -1053,6 +1078,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 1,
         "osm_way_ids": [
           112414481
         ],
@@ -1091,6 +1117,7 @@
       },
       "properties": {
         "dst_i": 63,
+        "layer": 0,
         "osm_way_ids": [
           112414483
         ],
@@ -1129,6 +1156,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           112414483
         ],
@@ -1167,6 +1195,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           217211130
         ],
@@ -1205,6 +1234,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           274251515
         ],
@@ -1243,6 +1273,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           274252960
         ],
@@ -1281,6 +1312,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           274252961
         ],
@@ -1327,6 +1359,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           274252961
         ],
@@ -1365,6 +1398,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           274252961
         ],
@@ -1419,6 +1453,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           274252963
         ],
@@ -1457,6 +1492,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           274252964
         ],
@@ -1511,6 +1547,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           274252966
         ],
@@ -1557,6 +1594,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           287798313
         ],
@@ -1595,6 +1633,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": -1,
         "osm_way_ids": [
           287798314
         ],
@@ -1657,6 +1696,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           287798653
         ],
@@ -1703,6 +1743,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           287798653
         ],
@@ -1741,6 +1782,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           287798653
         ],
@@ -1787,6 +1829,7 @@
       },
       "properties": {
         "dst_i": 55,
+        "layer": 0,
         "osm_way_ids": [
           287801356
         ],
@@ -1833,6 +1876,7 @@
       },
       "properties": {
         "dst_i": 57,
+        "layer": 0,
         "osm_way_ids": [
           288279759
         ],
@@ -1895,6 +1939,7 @@
       },
       "properties": {
         "dst_i": 59,
+        "layer": 0,
         "osm_way_ids": [
           288281501,
           690683790
@@ -1934,6 +1979,7 @@
       },
       "properties": {
         "dst_i": 70,
+        "layer": 0,
         "osm_way_ids": [
           288281502
         ],
@@ -1972,6 +2018,7 @@
       },
       "properties": {
         "dst_i": 59,
+        "layer": 0,
         "osm_way_ids": [
           288281503
         ],
@@ -2010,6 +2057,7 @@
       },
       "properties": {
         "dst_i": 60,
+        "layer": 0,
         "osm_way_ids": [
           288281503
         ],
@@ -2048,6 +2096,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           288283759
         ],
@@ -2086,6 +2135,7 @@
       },
       "properties": {
         "dst_i": 62,
+        "layer": 0,
         "osm_way_ids": [
           412698692
         ],
@@ -2124,6 +2174,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           560119117
         ],
@@ -2162,6 +2213,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           560119117
         ],
@@ -2200,6 +2252,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           560119117
         ],
@@ -2246,6 +2299,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           560532687
         ],
@@ -2284,6 +2338,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           654987749
         ],
@@ -2322,6 +2377,7 @@
       },
       "properties": {
         "dst_i": 86,
+        "layer": 0,
         "osm_way_ids": [
           654987750
         ],
@@ -2360,6 +2416,7 @@
       },
       "properties": {
         "dst_i": 83,
+        "layer": 0,
         "osm_way_ids": [
           654987750
         ],
@@ -2398,6 +2455,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           654987750
         ],
@@ -2444,6 +2502,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           654987755
         ],
@@ -2482,6 +2541,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           654987756
         ],
@@ -2520,6 +2580,7 @@
       },
       "properties": {
         "dst_i": 69,
+        "layer": 0,
         "osm_way_ids": [
           686956434
         ],
@@ -2558,6 +2619,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           690683794
         ],
@@ -2596,6 +2658,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           690683796
         ],
@@ -2634,6 +2697,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           690683797
         ],
@@ -2680,6 +2744,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           690683798
         ],
@@ -2718,6 +2783,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           690683799
         ],
@@ -2756,6 +2822,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           693079615
         ],
@@ -2794,6 +2861,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           773118441
         ],
@@ -2832,6 +2900,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           773118442
         ],
@@ -2870,6 +2939,7 @@
       },
       "properties": {
         "dst_i": 77,
+        "layer": 0,
         "osm_way_ids": [
           965055857
         ],
@@ -2908,6 +2978,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           965055858
         ],
@@ -2946,6 +3017,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           965055862
         ],
@@ -2992,6 +3064,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           999493252
         ],
@@ -3030,6 +3103,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           999493253
         ],
@@ -3076,6 +3150,7 @@
       },
       "properties": {
         "dst_i": 70,
+        "layer": 0,
         "osm_way_ids": [
           999493421
         ],
@@ -3114,6 +3189,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           1003081552
         ],
@@ -3152,6 +3228,7 @@
       },
       "properties": {
         "dst_i": 79,
+        "layer": 0,
         "osm_way_ids": [
           1003081553
         ],
@@ -3190,6 +3267,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           1003081554
         ],
@@ -3228,6 +3306,7 @@
       },
       "properties": {
         "dst_i": 63,
+        "layer": 0,
         "osm_way_ids": [
           1007914062
         ],
@@ -3298,6 +3377,7 @@
       },
       "properties": {
         "dst_i": 87,
+        "layer": 0,
         "osm_way_ids": [
           1007914063
         ],
@@ -3336,6 +3416,7 @@
       },
       "properties": {
         "dst_i": 92,
+        "layer": 0,
         "osm_way_ids": [
           1007914063
         ],
@@ -3374,6 +3455,7 @@
       },
       "properties": {
         "dst_i": 83,
+        "layer": 0,
         "osm_way_ids": [
           1007914063
         ],
@@ -3412,6 +3494,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 1,
         "osm_way_ids": [
           1007914064
         ],
@@ -3450,6 +3533,7 @@
       },
       "properties": {
         "dst_i": 87,
+        "layer": 0,
         "osm_way_ids": [
           1007914065
         ],
@@ -3496,6 +3580,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           1007914066
         ],
@@ -3534,6 +3619,7 @@
       },
       "properties": {
         "dst_i": 89,
+        "layer": 0,
         "osm_way_ids": [
           1007914067
         ],
@@ -3572,6 +3658,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 1,
         "osm_way_ids": [
           1007914069,
           1007914068
@@ -3611,6 +3698,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           1007914071
         ],
@@ -3649,6 +3737,7 @@
       },
       "properties": {
         "dst_i": 94,
+        "layer": 0,
         "osm_way_ids": [
           1007914071
         ],
@@ -3687,6 +3776,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           1016864436
         ],
@@ -3741,6 +3831,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           1016864436
         ],
@@ -3779,6 +3870,7 @@
       },
       "properties": {
         "dst_i": 84,
+        "layer": 0,
         "osm_way_ids": [
           1016864437
         ],
@@ -3817,6 +3909,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           1016864438
         ],

--- a/tests/src/leeds_cycleway/geometry.json
+++ b/tests/src/leeds_cycleway/geometry.json
@@ -46,6 +46,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           4049157
         ],
@@ -92,6 +93,7 @@
       },
       "properties": {
         "dst_i": 301,
+        "layer": 0,
         "osm_way_ids": [
           4371997
         ],
@@ -130,6 +132,7 @@
       },
       "properties": {
         "dst_i": 258,
+        "layer": 0,
         "osm_way_ids": [
           4372129
         ],
@@ -168,6 +171,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           4372129
         ],
@@ -206,6 +210,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           4372130
         ],
@@ -244,6 +249,7 @@
       },
       "properties": {
         "dst_i": 379,
+        "layer": 0,
         "osm_way_ids": [
           4372149
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           4372149
         ],
@@ -320,6 +327,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           4372312
         ],
@@ -358,6 +366,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           4372312
         ],
@@ -404,6 +413,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           4372313
         ],
@@ -442,6 +452,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           5949166
         ],
@@ -480,6 +491,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           5949166
         ],
@@ -518,6 +530,7 @@
       },
       "properties": {
         "dst_i": 387,
+        "layer": 0,
         "osm_way_ids": [
           5949167
         ],
@@ -556,6 +569,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           5949167
         ],
@@ -594,6 +608,7 @@
       },
       "properties": {
         "dst_i": 141,
+        "layer": 0,
         "osm_way_ids": [
           6072857
         ],
@@ -632,6 +647,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           6072857
         ],
@@ -678,6 +694,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           8050384
         ],
@@ -716,6 +733,7 @@
       },
       "properties": {
         "dst_i": 139,
+        "layer": 1,
         "osm_way_ids": [
           8050390
         ],
@@ -754,6 +772,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 1,
         "osm_way_ids": [
           8050390
         ],
@@ -792,6 +811,7 @@
       },
       "properties": {
         "dst_i": 108,
+        "layer": 0,
         "osm_way_ids": [
           27478791
         ],
@@ -846,6 +866,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           27478791
         ],
@@ -884,6 +905,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           27767549
         ],
@@ -946,6 +968,7 @@
       },
       "properties": {
         "dst_i": 63,
+        "layer": 0,
         "osm_way_ids": [
           29053005
         ],
@@ -992,6 +1015,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           29053005
         ],
@@ -1030,6 +1054,7 @@
       },
       "properties": {
         "dst_i": 309,
+        "layer": 0,
         "osm_way_ids": [
           29053006
         ],
@@ -1068,6 +1093,7 @@
       },
       "properties": {
         "dst_i": 223,
+        "layer": 0,
         "osm_way_ids": [
           29053006
         ],
@@ -1122,6 +1148,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           29184659
         ],
@@ -1168,6 +1195,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           30831325
         ],
@@ -1230,6 +1258,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           30831662
         ],
@@ -1268,6 +1297,7 @@
       },
       "properties": {
         "dst_i": 247,
+        "layer": 0,
         "osm_way_ids": [
           30831663
         ],
@@ -1306,6 +1336,7 @@
       },
       "properties": {
         "dst_i": 317,
+        "layer": 0,
         "osm_way_ids": [
           30831663
         ],
@@ -1344,6 +1375,7 @@
       },
       "properties": {
         "dst_i": 110,
+        "layer": 0,
         "osm_way_ids": [
           30831663
         ],
@@ -1390,6 +1422,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           30831663
         ],
@@ -1428,6 +1461,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           30831665
         ],
@@ -1466,6 +1500,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           30831666
         ],
@@ -1512,6 +1547,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           30831667
         ],
@@ -1582,6 +1618,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           30831667
         ],
@@ -1636,6 +1673,7 @@
       },
       "properties": {
         "dst_i": 396,
+        "layer": 0,
         "osm_way_ids": [
           30831668
         ],
@@ -1674,6 +1712,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           30831668
         ],
@@ -1712,6 +1751,7 @@
       },
       "properties": {
         "dst_i": 410,
+        "layer": 0,
         "osm_way_ids": [
           30831673
         ],
@@ -1758,6 +1798,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           30831673
         ],
@@ -1796,6 +1837,7 @@
       },
       "properties": {
         "dst_i": 414,
+        "layer": 0,
         "osm_way_ids": [
           30831674
         ],
@@ -1834,6 +1876,7 @@
       },
       "properties": {
         "dst_i": 321,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -1872,6 +1915,7 @@
       },
       "properties": {
         "dst_i": 189,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -1910,6 +1954,7 @@
       },
       "properties": {
         "dst_i": 113,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -1948,6 +1993,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -1986,6 +2032,7 @@
       },
       "properties": {
         "dst_i": 398,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -2024,6 +2071,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -2062,6 +2110,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           30831675
         ],
@@ -2100,6 +2149,7 @@
       },
       "properties": {
         "dst_i": 86,
+        "layer": 0,
         "osm_way_ids": [
           30831800
         ],
@@ -2138,6 +2188,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           30831800
         ],
@@ -2176,6 +2227,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           30831800
         ],
@@ -2214,6 +2266,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           30832035
         ],
@@ -2260,6 +2313,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 1,
         "osm_way_ids": [
           31972740
         ],
@@ -2306,6 +2360,7 @@
       },
       "properties": {
         "dst_i": 55,
+        "layer": 0,
         "osm_way_ids": [
           32855413
         ],
@@ -2344,6 +2399,7 @@
       },
       "properties": {
         "dst_i": 57,
+        "layer": 0,
         "osm_way_ids": [
           32863858
         ],
@@ -2382,6 +2438,7 @@
       },
       "properties": {
         "dst_i": 242,
+        "layer": 0,
         "osm_way_ids": [
           38732418
         ],
@@ -2420,6 +2477,7 @@
       },
       "properties": {
         "dst_i": 61,
+        "layer": 0,
         "osm_way_ids": [
           38732418
         ],
@@ -2458,6 +2516,7 @@
       },
       "properties": {
         "dst_i": 120,
+        "layer": 0,
         "osm_way_ids": [
           38732418
         ],
@@ -2496,6 +2555,7 @@
       },
       "properties": {
         "dst_i": 59,
+        "layer": 0,
         "osm_way_ids": [
           38732418
         ],
@@ -2550,6 +2610,7 @@
       },
       "properties": {
         "dst_i": 61,
+        "layer": 0,
         "osm_way_ids": [
           38732419,
           745724294
@@ -2597,6 +2658,7 @@
       },
       "properties": {
         "dst_i": 96,
+        "layer": 0,
         "osm_way_ids": [
           38732606
         ],
@@ -2651,6 +2713,7 @@
       },
       "properties": {
         "dst_i": 63,
+        "layer": 0,
         "osm_way_ids": [
           38732625
         ],
@@ -2697,6 +2760,7 @@
       },
       "properties": {
         "dst_i": 246,
+        "layer": 0,
         "osm_way_ids": [
           38732625
         ],
@@ -2735,6 +2799,7 @@
       },
       "properties": {
         "dst_i": 64,
+        "layer": 0,
         "osm_way_ids": [
           39173305
         ],
@@ -2773,6 +2838,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           39597033
         ],
@@ -2811,6 +2877,7 @@
       },
       "properties": {
         "dst_i": 67,
+        "layer": 0,
         "osm_way_ids": [
           48477918
         ],
@@ -2849,6 +2916,7 @@
       },
       "properties": {
         "dst_i": 69,
+        "layer": 0,
         "osm_way_ids": [
           51704587
         ],
@@ -2887,6 +2955,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           54108084
         ],
@@ -2933,6 +3002,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           54108084
         ],
@@ -2979,6 +3049,7 @@
       },
       "properties": {
         "dst_i": 268,
+        "layer": 0,
         "osm_way_ids": [
           113160846
         ],
@@ -3017,6 +3088,7 @@
       },
       "properties": {
         "dst_i": 160,
+        "layer": 0,
         "osm_way_ids": [
           113160846
         ],
@@ -3055,6 +3127,7 @@
       },
       "properties": {
         "dst_i": 155,
+        "layer": 0,
         "osm_way_ids": [
           113160846
         ],
@@ -3093,6 +3166,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           113160846
         ],
@@ -3139,6 +3213,7 @@
       },
       "properties": {
         "dst_i": 75,
+        "layer": 0,
         "osm_way_ids": [
           114458912
         ],
@@ -3177,6 +3252,7 @@
       },
       "properties": {
         "dst_i": 147,
+        "layer": 0,
         "osm_way_ids": [
           114458978
         ],
@@ -3215,6 +3291,7 @@
       },
       "properties": {
         "dst_i": 77,
+        "layer": 0,
         "osm_way_ids": [
           114458978
         ],
@@ -3277,6 +3354,7 @@
       },
       "properties": {
         "dst_i": 79,
+        "layer": 0,
         "osm_way_ids": [
           114459026
         ],
@@ -3315,6 +3393,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 1,
         "osm_way_ids": [
           115570255
         ],
@@ -3361,6 +3440,7 @@
       },
       "properties": {
         "dst_i": 82,
+        "layer": 0,
         "osm_way_ids": [
           121485718
         ],
@@ -3407,6 +3487,7 @@
       },
       "properties": {
         "dst_i": 77,
+        "layer": 0,
         "osm_way_ids": [
           123501444
         ],
@@ -3453,6 +3534,7 @@
       },
       "properties": {
         "dst_i": 84,
+        "layer": 0,
         "osm_way_ids": [
           123501444
         ],
@@ -3515,6 +3597,7 @@
       },
       "properties": {
         "dst_i": 75,
+        "layer": 0,
         "osm_way_ids": [
           143459488
         ],
@@ -3561,6 +3644,7 @@
       },
       "properties": {
         "dst_i": 204,
+        "layer": 0,
         "osm_way_ids": [
           143460612
         ],
@@ -3599,6 +3683,7 @@
       },
       "properties": {
         "dst_i": 74,
+        "layer": 0,
         "osm_way_ids": [
           143460612
         ],
@@ -3653,6 +3738,7 @@
       },
       "properties": {
         "dst_i": 78,
+        "layer": 0,
         "osm_way_ids": [
           143460882
         ],
@@ -3707,6 +3793,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 0,
         "osm_way_ids": [
           143460882
         ],
@@ -3745,6 +3832,7 @@
       },
       "properties": {
         "dst_i": 87,
+        "layer": 0,
         "osm_way_ids": [
           145765941
         ],
@@ -3799,6 +3887,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           145796714
         ],
@@ -3845,6 +3934,7 @@
       },
       "properties": {
         "dst_i": 82,
+        "layer": 0,
         "osm_way_ids": [
           145796715
         ],
@@ -3883,6 +3973,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           145796715
         ],
@@ -3921,6 +4012,7 @@
       },
       "properties": {
         "dst_i": 89,
+        "layer": 0,
         "osm_way_ids": [
           145796721
         ],
@@ -3959,6 +4051,7 @@
       },
       "properties": {
         "dst_i": 72,
+        "layer": 0,
         "osm_way_ids": [
           145796724
         ],
@@ -3997,6 +4090,7 @@
       },
       "properties": {
         "dst_i": 269,
+        "layer": 0,
         "osm_way_ids": [
           145796724
         ],
@@ -4035,6 +4129,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           145796724
         ],
@@ -4073,6 +4168,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           145796727
         ],
@@ -4111,6 +4207,7 @@
       },
       "properties": {
         "dst_i": 156,
+        "layer": 0,
         "osm_way_ids": [
           145796727
         ],
@@ -4149,6 +4246,7 @@
       },
       "properties": {
         "dst_i": 55,
+        "layer": 0,
         "osm_way_ids": [
           145796727
         ],
@@ -4187,6 +4285,7 @@
       },
       "properties": {
         "dst_i": 229,
+        "layer": 0,
         "osm_way_ids": [
           147463174
         ],
@@ -4257,6 +4356,7 @@
       },
       "properties": {
         "dst_i": 96,
+        "layer": 0,
         "osm_way_ids": [
           147463179
         ],
@@ -4295,6 +4395,7 @@
       },
       "properties": {
         "dst_i": 221,
+        "layer": 0,
         "osm_way_ids": [
           147479103
         ],
@@ -4333,6 +4434,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           147479103
         ],
@@ -4371,6 +4473,7 @@
       },
       "properties": {
         "dst_i": 215,
+        "layer": 0,
         "osm_way_ids": [
           147479112
         ],
@@ -4409,6 +4512,7 @@
       },
       "properties": {
         "dst_i": 261,
+        "layer": 0,
         "osm_way_ids": [
           147479112
         ],
@@ -4463,6 +4567,7 @@
       },
       "properties": {
         "dst_i": 216,
+        "layer": 0,
         "osm_way_ids": [
           147479112
         ],
@@ -4501,6 +4606,7 @@
       },
       "properties": {
         "dst_i": 100,
+        "layer": 0,
         "osm_way_ids": [
           155080992
         ],
@@ -4539,6 +4645,7 @@
       },
       "properties": {
         "dst_i": 102,
+        "layer": 0,
         "osm_way_ids": [
           155080995
         ],
@@ -4577,6 +4684,7 @@
       },
       "properties": {
         "dst_i": 360,
+        "layer": 0,
         "osm_way_ids": [
           162428102
         ],
@@ -4623,6 +4731,7 @@
       },
       "properties": {
         "dst_i": 90,
+        "layer": 0,
         "osm_way_ids": [
           162428102
         ],
@@ -4661,6 +4770,7 @@
       },
       "properties": {
         "dst_i": 267,
+        "layer": 0,
         "osm_way_ids": [
           162428102
         ],
@@ -4699,6 +4809,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           162428102
         ],
@@ -4745,6 +4856,7 @@
       },
       "properties": {
         "dst_i": 105,
+        "layer": 0,
         "osm_way_ids": [
           177344224,
           438914633
@@ -4784,6 +4896,7 @@
       },
       "properties": {
         "dst_i": 187,
+        "layer": 0,
         "osm_way_ids": [
           177344225
         ],
@@ -4838,6 +4951,7 @@
       },
       "properties": {
         "dst_i": 197,
+        "layer": 0,
         "osm_way_ids": [
           177344225
         ],
@@ -4876,6 +4990,7 @@
       },
       "properties": {
         "dst_i": 107,
+        "layer": 0,
         "osm_way_ids": [
           177344225
         ],
@@ -4922,6 +5037,7 @@
       },
       "properties": {
         "dst_i": 108,
+        "layer": 0,
         "osm_way_ids": [
           177344229
         ],
@@ -4960,6 +5076,7 @@
       },
       "properties": {
         "dst_i": 110,
+        "layer": 0,
         "osm_way_ids": [
           177344231
         ],
@@ -4998,6 +5115,7 @@
       },
       "properties": {
         "dst_i": 237,
+        "layer": 0,
         "osm_way_ids": [
           177344231
         ],
@@ -5036,6 +5154,7 @@
       },
       "properties": {
         "dst_i": 275,
+        "layer": 0,
         "osm_way_ids": [
           177344231
         ],
@@ -5074,6 +5193,7 @@
       },
       "properties": {
         "dst_i": 111,
+        "layer": 0,
         "osm_way_ids": [
           177344231
         ],
@@ -5120,6 +5240,7 @@
       },
       "properties": {
         "dst_i": 116,
+        "layer": 0,
         "osm_way_ids": [
           190821082
         ],
@@ -5158,6 +5279,7 @@
       },
       "properties": {
         "dst_i": 113,
+        "layer": 0,
         "osm_way_ids": [
           190821082
         ],
@@ -5244,6 +5366,7 @@
       },
       "properties": {
         "dst_i": 125,
+        "layer": 0,
         "osm_way_ids": [
           190821089
         ],
@@ -5322,6 +5445,7 @@
       },
       "properties": {
         "dst_i": 93,
+        "layer": 0,
         "osm_way_ids": [
           190821089
         ],
@@ -5408,6 +5532,7 @@
       },
       "properties": {
         "dst_i": 114,
+        "layer": 0,
         "osm_way_ids": [
           190821089
         ],
@@ -5446,6 +5571,7 @@
       },
       "properties": {
         "dst_i": 122,
+        "layer": 0,
         "osm_way_ids": [
           190821091
         ],
@@ -5484,6 +5610,7 @@
       },
       "properties": {
         "dst_i": 119,
+        "layer": 0,
         "osm_way_ids": [
           190821092
         ],
@@ -5546,6 +5673,7 @@
       },
       "properties": {
         "dst_i": 335,
+        "layer": 0,
         "osm_way_ids": [
           190821093
         ],
@@ -5584,6 +5712,7 @@
       },
       "properties": {
         "dst_i": 114,
+        "layer": 0,
         "osm_way_ids": [
           190821093
         ],
@@ -5622,6 +5751,7 @@
       },
       "properties": {
         "dst_i": 189,
+        "layer": 0,
         "osm_way_ids": [
           190821094
         ],
@@ -5684,6 +5814,7 @@
       },
       "properties": {
         "dst_i": 126,
+        "layer": 0,
         "osm_way_ids": [
           190821096
         ],
@@ -5722,6 +5853,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           192930242
         ],
@@ -5760,6 +5892,7 @@
       },
       "properties": {
         "dst_i": 56,
+        "layer": 1,
         "osm_way_ids": [
           206566460
         ],
@@ -5798,6 +5931,7 @@
       },
       "properties": {
         "dst_i": 131,
+        "layer": 0,
         "osm_way_ids": [
           206817419
         ],
@@ -5860,6 +5994,7 @@
       },
       "properties": {
         "dst_i": 133,
+        "layer": 0,
         "osm_way_ids": [
           312269974
         ],
@@ -5898,6 +6033,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           312269975
         ],
@@ -5936,6 +6072,7 @@
       },
       "properties": {
         "dst_i": 76,
+        "layer": 0,
         "osm_way_ids": [
           312269975,
           312269975
@@ -5975,6 +6112,7 @@
       },
       "properties": {
         "dst_i": 167,
+        "layer": 0,
         "osm_way_ids": [
           312269975
         ],
@@ -6013,6 +6151,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           312269975
         ],
@@ -6059,6 +6198,7 @@
       },
       "properties": {
         "dst_i": 136,
+        "layer": 0,
         "osm_way_ids": [
           313390685
         ],
@@ -6097,6 +6237,7 @@
       },
       "properties": {
         "dst_i": 137,
+        "layer": 1,
         "osm_way_ids": [
           313390688
         ],
@@ -6135,6 +6276,7 @@
       },
       "properties": {
         "dst_i": 139,
+        "layer": 1,
         "osm_way_ids": [
           313390689
         ],
@@ -6173,6 +6315,7 @@
       },
       "properties": {
         "dst_i": 135,
+        "layer": 1,
         "osm_way_ids": [
           313390689
         ],
@@ -6211,6 +6354,7 @@
       },
       "properties": {
         "dst_i": 142,
+        "layer": 0,
         "osm_way_ids": [
           331099341
         ],
@@ -6249,6 +6393,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           363048952
         ],
@@ -6287,6 +6432,7 @@
       },
       "properties": {
         "dst_i": 145,
+        "layer": 0,
         "osm_way_ids": [
           363049114
         ],
@@ -6325,6 +6471,7 @@
       },
       "properties": {
         "dst_i": 145,
+        "layer": 0,
         "osm_way_ids": [
           363049230
         ],
@@ -6363,6 +6510,7 @@
       },
       "properties": {
         "dst_i": 129,
+        "layer": 1,
         "osm_way_ids": [
           400349312,
           206566459
@@ -6402,6 +6550,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           400349314
         ],
@@ -6440,6 +6589,7 @@
       },
       "properties": {
         "dst_i": 148,
+        "layer": 0,
         "osm_way_ids": [
           438378829
         ],
@@ -6486,6 +6636,7 @@
       },
       "properties": {
         "dst_i": 168,
+        "layer": 0,
         "osm_way_ids": [
           438378831
         ],
@@ -6540,6 +6691,7 @@
       },
       "properties": {
         "dst_i": 149,
+        "layer": 0,
         "osm_way_ids": [
           438378831
         ],
@@ -6578,6 +6730,7 @@
       },
       "properties": {
         "dst_i": 388,
+        "layer": 0,
         "osm_way_ids": [
           438914633,
           30831674
@@ -6617,6 +6770,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           453297315
         ],
@@ -6663,6 +6817,7 @@
       },
       "properties": {
         "dst_i": 152,
+        "layer": 0,
         "osm_way_ids": [
           453297317
         ],
@@ -6701,6 +6856,7 @@
       },
       "properties": {
         "dst_i": 200,
+        "layer": 0,
         "osm_way_ids": [
           454077550
         ],
@@ -6747,6 +6903,7 @@
       },
       "properties": {
         "dst_i": 153,
+        "layer": 0,
         "osm_way_ids": [
           454077550
         ],
@@ -6785,6 +6942,7 @@
       },
       "properties": {
         "dst_i": 155,
+        "layer": 0,
         "osm_way_ids": [
           491178797
         ],
@@ -6823,6 +6981,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           491178797
         ],
@@ -6861,6 +7020,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           491178798
         ],
@@ -6907,6 +7067,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           491178799
         ],
@@ -6945,6 +7106,7 @@
       },
       "properties": {
         "dst_i": 400,
+        "layer": 0,
         "osm_way_ids": [
           491178800,
           4371997
@@ -6992,6 +7154,7 @@
       },
       "properties": {
         "dst_i": 158,
+        "layer": 0,
         "osm_way_ids": [
           491178800
         ],
@@ -7030,6 +7193,7 @@
       },
       "properties": {
         "dst_i": 209,
+        "layer": 0,
         "osm_way_ids": [
           491178801
         ],
@@ -7084,6 +7248,7 @@
       },
       "properties": {
         "dst_i": 267,
+        "layer": 0,
         "osm_way_ids": [
           491178801
         ],
@@ -7122,6 +7287,7 @@
       },
       "properties": {
         "dst_i": 160,
+        "layer": 0,
         "osm_way_ids": [
           491178801
         ],
@@ -7160,6 +7326,7 @@
       },
       "properties": {
         "dst_i": 161,
+        "layer": 0,
         "osm_way_ids": [
           491178801
         ],
@@ -7198,6 +7365,7 @@
       },
       "properties": {
         "dst_i": 163,
+        "layer": 0,
         "osm_way_ids": [
           566234612
         ],
@@ -7236,6 +7404,7 @@
       },
       "properties": {
         "dst_i": 165,
+        "layer": 0,
         "osm_way_ids": [
           573276642
         ],
@@ -7274,6 +7443,7 @@
       },
       "properties": {
         "dst_i": 167,
+        "layer": 0,
         "osm_way_ids": [
           573276645
         ],
@@ -7320,6 +7490,7 @@
       },
       "properties": {
         "dst_i": 84,
+        "layer": 0,
         "osm_way_ids": [
           573276646
         ],
@@ -7366,6 +7537,7 @@
       },
       "properties": {
         "dst_i": 170,
+        "layer": 0,
         "osm_way_ids": [
           573276648
         ],
@@ -7404,6 +7576,7 @@
       },
       "properties": {
         "dst_i": 394,
+        "layer": 0,
         "osm_way_ids": [
           573276649
         ],
@@ -7442,6 +7615,7 @@
       },
       "properties": {
         "dst_i": 385,
+        "layer": 0,
         "osm_way_ids": [
           573276649
         ],
@@ -7480,6 +7654,7 @@
       },
       "properties": {
         "dst_i": 172,
+        "layer": 0,
         "osm_way_ids": [
           573276649
         ],
@@ -7518,6 +7693,7 @@
       },
       "properties": {
         "dst_i": 393,
+        "layer": 0,
         "osm_way_ids": [
           573276650,
           573276651
@@ -7557,6 +7733,7 @@
       },
       "properties": {
         "dst_i": 174,
+        "layer": 0,
         "osm_way_ids": [
           573276650
         ],
@@ -7595,6 +7772,7 @@
       },
       "properties": {
         "dst_i": 284,
+        "layer": 0,
         "osm_way_ids": [
           573276651
         ],
@@ -7633,6 +7811,7 @@
       },
       "properties": {
         "dst_i": 175,
+        "layer": 0,
         "osm_way_ids": [
           573276652
         ],
@@ -7671,6 +7850,7 @@
       },
       "properties": {
         "dst_i": 176,
+        "layer": 0,
         "osm_way_ids": [
           573276654
         ],
@@ -7709,6 +7889,7 @@
       },
       "properties": {
         "dst_i": 177,
+        "layer": 0,
         "osm_way_ids": [
           573276655
         ],
@@ -7747,6 +7928,7 @@
       },
       "properties": {
         "dst_i": 149,
+        "layer": 0,
         "osm_way_ids": [
           573276656
         ],
@@ -7785,6 +7967,7 @@
       },
       "properties": {
         "dst_i": 181,
+        "layer": 0,
         "osm_way_ids": [
           573276657
         ],
@@ -7823,6 +8006,7 @@
       },
       "properties": {
         "dst_i": 180,
+        "layer": 0,
         "osm_way_ids": [
           573276658
         ],
@@ -7861,6 +8045,7 @@
       },
       "properties": {
         "dst_i": 170,
+        "layer": 0,
         "osm_way_ids": [
           573276659
         ],
@@ -7907,6 +8092,7 @@
       },
       "properties": {
         "dst_i": 179,
+        "layer": 0,
         "osm_way_ids": [
           573276659
         ],
@@ -7961,6 +8147,7 @@
       },
       "properties": {
         "dst_i": 179,
+        "layer": 0,
         "osm_way_ids": [
           573276660
         ],
@@ -8015,6 +8202,7 @@
       },
       "properties": {
         "dst_i": 182,
+        "layer": 0,
         "osm_way_ids": [
           573276662,
           573276662
@@ -8054,6 +8242,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           573276662
         ],
@@ -8092,6 +8281,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           583053002
         ],
@@ -8146,6 +8336,7 @@
       },
       "properties": {
         "dst_i": 74,
+        "layer": 0,
         "osm_way_ids": [
           583053006
         ],
@@ -8184,6 +8375,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           603499170
         ],
@@ -8222,6 +8414,7 @@
       },
       "properties": {
         "dst_i": 226,
+        "layer": 0,
         "osm_way_ids": [
           603499175
         ],
@@ -8260,6 +8453,7 @@
       },
       "properties": {
         "dst_i": 187,
+        "layer": 0,
         "osm_way_ids": [
           603499183
         ],
@@ -8298,6 +8492,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           603499183
         ],
@@ -8336,6 +8531,7 @@
       },
       "properties": {
         "dst_i": 112,
+        "layer": 0,
         "osm_way_ids": [
           616128591
         ],
@@ -8374,6 +8570,7 @@
       },
       "properties": {
         "dst_i": 122,
+        "layer": 0,
         "osm_way_ids": [
           616128591
         ],
@@ -8412,6 +8609,7 @@
       },
       "properties": {
         "dst_i": 189,
+        "layer": 0,
         "osm_way_ids": [
           616128591
         ],
@@ -8450,6 +8648,7 @@
       },
       "properties": {
         "dst_i": 190,
+        "layer": 0,
         "osm_way_ids": [
           616128591
         ],
@@ -8488,6 +8687,7 @@
       },
       "properties": {
         "dst_i": 336,
+        "layer": 0,
         "osm_way_ids": [
           616128591
         ],
@@ -8526,6 +8726,7 @@
       },
       "properties": {
         "dst_i": 192,
+        "layer": 0,
         "osm_way_ids": [
           619248620
         ],
@@ -8564,6 +8765,7 @@
       },
       "properties": {
         "dst_i": 224,
+        "layer": 0,
         "osm_way_ids": [
           619360566
         ],
@@ -8610,6 +8812,7 @@
       },
       "properties": {
         "dst_i": 376,
+        "layer": 0,
         "osm_way_ids": [
           619360566
         ],
@@ -8648,6 +8851,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           619360566
         ],
@@ -8686,6 +8890,7 @@
       },
       "properties": {
         "dst_i": 266,
+        "layer": 1,
         "osm_way_ids": [
           636647073
         ],
@@ -8724,6 +8929,7 @@
       },
       "properties": {
         "dst_i": 52,
+        "layer": 1,
         "osm_way_ids": [
           636647073
         ],
@@ -8770,6 +8976,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           650344876
         ],
@@ -8808,6 +9015,7 @@
       },
       "properties": {
         "dst_i": 196,
+        "layer": 0,
         "osm_way_ids": [
           650344877
         ],
@@ -8846,6 +9054,7 @@
       },
       "properties": {
         "dst_i": 197,
+        "layer": 0,
         "osm_way_ids": [
           663356010
         ],
@@ -8892,6 +9101,7 @@
       },
       "properties": {
         "dst_i": 185,
+        "layer": 0,
         "osm_way_ids": [
           663356010
         ],
@@ -8930,6 +9140,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           663356011
         ],
@@ -8984,6 +9195,7 @@
       },
       "properties": {
         "dst_i": 204,
+        "layer": 0,
         "osm_way_ids": [
           663639106
         ],
@@ -9022,6 +9234,7 @@
       },
       "properties": {
         "dst_i": 203,
+        "layer": 0,
         "osm_way_ids": [
           663639106
         ],
@@ -9068,6 +9281,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           663639106
         ],
@@ -9106,6 +9320,7 @@
       },
       "properties": {
         "dst_i": 200,
+        "layer": 0,
         "osm_way_ids": [
           663639107
         ],
@@ -9144,6 +9359,7 @@
       },
       "properties": {
         "dst_i": 206,
+        "layer": 0,
         "osm_way_ids": [
           663639107
         ],
@@ -9182,6 +9398,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           663639107
         ],
@@ -9228,6 +9445,7 @@
       },
       "properties": {
         "dst_i": 82,
+        "layer": 0,
         "osm_way_ids": [
           663639109
         ],
@@ -9266,6 +9484,7 @@
       },
       "properties": {
         "dst_i": 202,
+        "layer": 0,
         "osm_way_ids": [
           663639110
         ],
@@ -9312,6 +9531,7 @@
       },
       "properties": {
         "dst_i": 204,
+        "layer": 0,
         "osm_way_ids": [
           663639111
         ],
@@ -9358,6 +9578,7 @@
       },
       "properties": {
         "dst_i": 201,
+        "layer": 0,
         "osm_way_ids": [
           663639111
         ],
@@ -9396,6 +9617,7 @@
       },
       "properties": {
         "dst_i": 55,
+        "layer": 0,
         "osm_way_ids": [
           663639111
         ],
@@ -9438,6 +9660,7 @@
       },
       "properties": {
         "dst_i": 206,
+        "layer": 0,
         "osm_way_ids": [
           663639111
         ],
@@ -9484,6 +9707,7 @@
       },
       "properties": {
         "dst_i": 141,
+        "layer": 0,
         "osm_way_ids": [
           663639111
         ],
@@ -9530,6 +9754,7 @@
       },
       "properties": {
         "dst_i": 209,
+        "layer": 0,
         "osm_way_ids": [
           663639112
         ],
@@ -9576,6 +9801,7 @@
       },
       "properties": {
         "dst_i": 162,
+        "layer": 0,
         "osm_way_ids": [
           663639113
         ],
@@ -9614,6 +9840,7 @@
       },
       "properties": {
         "dst_i": 308,
+        "layer": 0,
         "osm_way_ids": [
           663639113
         ],
@@ -9652,6 +9879,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           663639113
         ],
@@ -9690,6 +9918,7 @@
       },
       "properties": {
         "dst_i": 212,
+        "layer": 0,
         "osm_way_ids": [
           663639114
         ],
@@ -9728,6 +9957,7 @@
       },
       "properties": {
         "dst_i": 320,
+        "layer": 0,
         "osm_way_ids": [
           663639115
         ],
@@ -9798,6 +10028,7 @@
       },
       "properties": {
         "dst_i": 320,
+        "layer": 0,
         "osm_way_ids": [
           663639116
         ],
@@ -9836,6 +10067,7 @@
       },
       "properties": {
         "dst_i": 213,
+        "layer": 0,
         "osm_way_ids": [
           663639116
         ],
@@ -9882,6 +10114,7 @@
       },
       "properties": {
         "dst_i": 211,
+        "layer": 0,
         "osm_way_ids": [
           663639118
         ],
@@ -9944,6 +10177,7 @@
       },
       "properties": {
         "dst_i": 216,
+        "layer": 0,
         "osm_way_ids": [
           663641181
         ],
@@ -10054,6 +10288,7 @@
       },
       "properties": {
         "dst_i": 219,
+        "layer": 0,
         "osm_way_ids": [
           663641181
         ],
@@ -10092,6 +10327,7 @@
       },
       "properties": {
         "dst_i": 220,
+        "layer": 0,
         "osm_way_ids": [
           663641181
         ],
@@ -10146,6 +10382,7 @@
       },
       "properties": {
         "dst_i": 215,
+        "layer": 0,
         "osm_way_ids": [
           663641181,
           663641181
@@ -10185,6 +10422,7 @@
       },
       "properties": {
         "dst_i": 375,
+        "layer": 0,
         "osm_way_ids": [
           668984459
         ],
@@ -10223,6 +10461,7 @@
       },
       "properties": {
         "dst_i": 217,
+        "layer": 0,
         "osm_way_ids": [
           668984459
         ],
@@ -10277,6 +10516,7 @@
       },
       "properties": {
         "dst_i": 226,
+        "layer": 0,
         "osm_way_ids": [
           668984461
         ],
@@ -10315,6 +10555,7 @@
       },
       "properties": {
         "dst_i": 219,
+        "layer": 0,
         "osm_way_ids": [
           668997030
         ],
@@ -10353,6 +10594,7 @@
       },
       "properties": {
         "dst_i": 220,
+        "layer": 0,
         "osm_way_ids": [
           668997030
         ],
@@ -10391,6 +10633,7 @@
       },
       "properties": {
         "dst_i": 223,
+        "layer": 0,
         "osm_way_ids": [
           668997030
         ],
@@ -10445,6 +10688,7 @@
       },
       "properties": {
         "dst_i": 221,
+        "layer": 0,
         "osm_way_ids": [
           668997030
         ],
@@ -10483,6 +10727,7 @@
       },
       "properties": {
         "dst_i": 223,
+        "layer": 0,
         "osm_way_ids": [
           668997031
         ],
@@ -10521,6 +10766,7 @@
       },
       "properties": {
         "dst_i": 226,
+        "layer": 0,
         "osm_way_ids": [
           668997032
         ],
@@ -10559,6 +10805,7 @@
       },
       "properties": {
         "dst_i": 145,
+        "layer": 0,
         "osm_way_ids": [
           668997033
         ],
@@ -10597,6 +10844,7 @@
       },
       "properties": {
         "dst_i": 260,
+        "layer": 0,
         "osm_way_ids": [
           668997034
         ],
@@ -10635,6 +10883,7 @@
       },
       "properties": {
         "dst_i": 224,
+        "layer": 0,
         "osm_way_ids": [
           668997034
         ],
@@ -10673,6 +10922,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           670751728
         ],
@@ -10711,6 +10961,7 @@
       },
       "properties": {
         "dst_i": 185,
+        "layer": 0,
         "osm_way_ids": [
           670751728
         ],
@@ -10773,6 +11024,7 @@
       },
       "properties": {
         "dst_i": 229,
+        "layer": 0,
         "osm_way_ids": [
           673667995
         ],
@@ -10819,6 +11071,7 @@
       },
       "properties": {
         "dst_i": 213,
+        "layer": 0,
         "osm_way_ids": [
           673667995
         ],
@@ -10873,6 +11126,7 @@
       },
       "properties": {
         "dst_i": 231,
+        "layer": 0,
         "osm_way_ids": [
           673731116
         ],
@@ -10919,6 +11173,7 @@
       },
       "properties": {
         "dst_i": 230,
+        "layer": 0,
         "osm_way_ids": [
           673731116
         ],
@@ -10957,6 +11212,7 @@
       },
       "properties": {
         "dst_i": 232,
+        "layer": 0,
         "osm_way_ids": [
           673731118
         ],
@@ -11003,6 +11259,7 @@
       },
       "properties": {
         "dst_i": 233,
+        "layer": 0,
         "osm_way_ids": [
           673731126
         ],
@@ -11049,6 +11306,7 @@
       },
       "properties": {
         "dst_i": 234,
+        "layer": 0,
         "osm_way_ids": [
           673731132,
           177344229
@@ -11120,6 +11378,7 @@
       },
       "properties": {
         "dst_i": 120,
+        "layer": 0,
         "osm_way_ids": [
           673731136
         ],
@@ -11158,6 +11417,7 @@
       },
       "properties": {
         "dst_i": 252,
+        "layer": 0,
         "osm_way_ids": [
           673731136
         ],
@@ -11212,6 +11472,7 @@
       },
       "properties": {
         "dst_i": 196,
+        "layer": 0,
         "osm_way_ids": [
           673731136
         ],
@@ -11274,6 +11535,7 @@
       },
       "properties": {
         "dst_i": 239,
+        "layer": 0,
         "osm_way_ids": [
           673731136
         ],
@@ -11312,6 +11574,7 @@
       },
       "properties": {
         "dst_i": 308,
+        "layer": 0,
         "osm_way_ids": [
           673734329
         ],
@@ -11350,6 +11613,7 @@
       },
       "properties": {
         "dst_i": 242,
+        "layer": 0,
         "osm_way_ids": [
           673734329
         ],
@@ -11388,6 +11652,7 @@
       },
       "properties": {
         "dst_i": 237,
+        "layer": 0,
         "osm_way_ids": [
           673734329,
           673731135
@@ -11435,6 +11700,7 @@
       },
       "properties": {
         "dst_i": 283,
+        "layer": 0,
         "osm_way_ids": [
           673734330
         ],
@@ -11473,6 +11739,7 @@
       },
       "properties": {
         "dst_i": 178,
+        "layer": 0,
         "osm_way_ids": [
           673734330
         ],
@@ -11519,6 +11786,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           673734333
         ],
@@ -11565,6 +11833,7 @@
       },
       "properties": {
         "dst_i": 245,
+        "layer": 0,
         "osm_way_ids": [
           673736353
         ],
@@ -11603,6 +11872,7 @@
       },
       "properties": {
         "dst_i": 247,
+        "layer": 0,
         "osm_way_ids": [
           673737341
         ],
@@ -11641,6 +11911,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           673737341
         ],
@@ -11679,6 +11950,7 @@
       },
       "properties": {
         "dst_i": 389,
+        "layer": 0,
         "osm_way_ids": [
           692442629
         ],
@@ -11717,6 +11989,7 @@
       },
       "properties": {
         "dst_i": 249,
+        "layer": 0,
         "osm_way_ids": [
           692442629
         ],
@@ -11787,6 +12060,7 @@
       },
       "properties": {
         "dst_i": 250,
+        "layer": 0,
         "osm_way_ids": [
           701166698
         ],
@@ -11865,6 +12139,7 @@
       },
       "properties": {
         "dst_i": 250,
+        "layer": 0,
         "osm_way_ids": [
           701166699
         ],
@@ -11919,6 +12194,7 @@
       },
       "properties": {
         "dst_i": 252,
+        "layer": 0,
         "osm_way_ids": [
           701166702
         ],
@@ -11957,6 +12233,7 @@
       },
       "properties": {
         "dst_i": 256,
+        "layer": 0,
         "osm_way_ids": [
           701166709
         ],
@@ -12011,6 +12288,7 @@
       },
       "properties": {
         "dst_i": 258,
+        "layer": 0,
         "osm_way_ids": [
           701166712
         ],
@@ -12057,6 +12335,7 @@
       },
       "properties": {
         "dst_i": 106,
+        "layer": 0,
         "osm_way_ids": [
           701166712
         ],
@@ -12111,6 +12390,7 @@
       },
       "properties": {
         "dst_i": 250,
+        "layer": 0,
         "osm_way_ids": [
           702394096,
           702394096
@@ -12150,6 +12430,7 @@
       },
       "properties": {
         "dst_i": 260,
+        "layer": 0,
         "osm_way_ids": [
           702394734
         ],
@@ -12188,6 +12469,7 @@
       },
       "properties": {
         "dst_i": 261,
+        "layer": 0,
         "osm_way_ids": [
           702394735
         ],
@@ -12242,6 +12524,7 @@
       },
       "properties": {
         "dst_i": 181,
+        "layer": 0,
         "osm_way_ids": [
           702394736,
           760649542
@@ -12281,6 +12564,7 @@
       },
       "properties": {
         "dst_i": 280,
+        "layer": 0,
         "osm_way_ids": [
           702394736
         ],
@@ -12319,6 +12603,7 @@
       },
       "properties": {
         "dst_i": 263,
+        "layer": 0,
         "osm_way_ids": [
           702394736
         ],
@@ -12357,6 +12642,7 @@
       },
       "properties": {
         "dst_i": 381,
+        "layer": 0,
         "osm_way_ids": [
           702394737
         ],
@@ -12395,6 +12681,7 @@
       },
       "properties": {
         "dst_i": 264,
+        "layer": 0,
         "osm_way_ids": [
           702394737
         ],
@@ -12433,6 +12720,7 @@
       },
       "properties": {
         "dst_i": 209,
+        "layer": 0,
         "osm_way_ids": [
           717747209
         ],
@@ -12471,6 +12759,7 @@
       },
       "properties": {
         "dst_i": 266,
+        "layer": 0,
         "osm_way_ids": [
           717747209
         ],
@@ -12509,6 +12798,7 @@
       },
       "properties": {
         "dst_i": 267,
+        "layer": 0,
         "osm_way_ids": [
           717747209
         ],
@@ -12547,6 +12837,7 @@
       },
       "properties": {
         "dst_i": 268,
+        "layer": 0,
         "osm_way_ids": [
           717747209
         ],
@@ -12585,6 +12876,7 @@
       },
       "properties": {
         "dst_i": 269,
+        "layer": 0,
         "osm_way_ids": [
           717747209
         ],
@@ -12623,6 +12915,7 @@
       },
       "properties": {
         "dst_i": 270,
+        "layer": 0,
         "osm_way_ids": [
           717747209
         ],
@@ -12685,6 +12978,7 @@
       },
       "properties": {
         "dst_i": 272,
+        "layer": 0,
         "osm_way_ids": [
           718449717
         ],
@@ -12723,6 +13017,7 @@
       },
       "properties": {
         "dst_i": 274,
+        "layer": 0,
         "osm_way_ids": [
           737539059
         ],
@@ -12825,6 +13120,7 @@
       },
       "properties": {
         "dst_i": 413,
+        "layer": 0,
         "osm_way_ids": [
           745724293
         ],
@@ -12863,6 +13159,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           745724293
         ],
@@ -12901,6 +13198,7 @@
       },
       "properties": {
         "dst_i": 275,
+        "layer": 0,
         "osm_way_ids": [
           745724294
         ],
@@ -12947,6 +13245,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           745724295
         ],
@@ -12985,6 +13284,7 @@
       },
       "properties": {
         "dst_i": 277,
+        "layer": 0,
         "osm_way_ids": [
           745724297
         ],
@@ -13031,6 +13331,7 @@
       },
       "properties": {
         "dst_i": 278,
+        "layer": 0,
         "osm_way_ids": [
           760129761
         ],
@@ -13069,6 +13370,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           760129762
         ],
@@ -13107,6 +13409,7 @@
       },
       "properties": {
         "dst_i": 244,
+        "layer": 0,
         "osm_way_ids": [
           760649541
         ],
@@ -13145,6 +13448,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           760649543
         ],
@@ -13183,6 +13487,7 @@
       },
       "properties": {
         "dst_i": 287,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13221,6 +13526,7 @@
       },
       "properties": {
         "dst_i": 295,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13275,6 +13581,7 @@
       },
       "properties": {
         "dst_i": 294,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13313,6 +13620,7 @@
       },
       "properties": {
         "dst_i": 298,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13351,6 +13659,7 @@
       },
       "properties": {
         "dst_i": 293,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13389,6 +13698,7 @@
       },
       "properties": {
         "dst_i": 289,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13427,6 +13737,7 @@
       },
       "properties": {
         "dst_i": 284,
+        "layer": 0,
         "osm_way_ids": [
           775795899
         ],
@@ -13465,6 +13776,7 @@
       },
       "properties": {
         "dst_i": 284,
+        "layer": 0,
         "osm_way_ids": [
           775795900
         ],
@@ -13503,6 +13815,7 @@
       },
       "properties": {
         "dst_i": 287,
+        "layer": 0,
         "osm_way_ids": [
           775795901
         ],
@@ -13541,6 +13854,7 @@
       },
       "properties": {
         "dst_i": 289,
+        "layer": 0,
         "osm_way_ids": [
           775795902
         ],
@@ -13619,6 +13933,7 @@
       },
       "properties": {
         "dst_i": 292,
+        "layer": 0,
         "osm_way_ids": [
           775795904,
           775795905,
@@ -13659,6 +13974,7 @@
       },
       "properties": {
         "dst_i": 294,
+        "layer": 0,
         "osm_way_ids": [
           775795907
         ],
@@ -13697,6 +14013,7 @@
       },
       "properties": {
         "dst_i": 296,
+        "layer": 0,
         "osm_way_ids": [
           775795908
         ],
@@ -13735,6 +14052,7 @@
       },
       "properties": {
         "dst_i": 298,
+        "layer": 0,
         "osm_way_ids": [
           775795909
         ],
@@ -13773,6 +14091,7 @@
       },
       "properties": {
         "dst_i": 287,
+        "layer": 0,
         "osm_way_ids": [
           775795910
         ],
@@ -13835,6 +14154,7 @@
       },
       "properties": {
         "dst_i": 301,
+        "layer": 0,
         "osm_way_ids": [
           775795915,
           775795918
@@ -13874,6 +14194,7 @@
       },
       "properties": {
         "dst_i": 320,
+        "layer": 0,
         "osm_way_ids": [
           775795916
         ],
@@ -13912,6 +14233,7 @@
       },
       "properties": {
         "dst_i": 320,
+        "layer": 0,
         "osm_way_ids": [
           775795918
         ],
@@ -13950,6 +14272,7 @@
       },
       "properties": {
         "dst_i": 212,
+        "layer": 0,
         "osm_way_ids": [
           775795921
         ],
@@ -14012,6 +14335,7 @@
       },
       "properties": {
         "dst_i": 243,
+        "layer": 0,
         "osm_way_ids": [
           775795921
         ],
@@ -14050,6 +14374,7 @@
       },
       "properties": {
         "dst_i": 163,
+        "layer": 0,
         "osm_way_ids": [
           775795921
         ],
@@ -14088,6 +14413,7 @@
       },
       "properties": {
         "dst_i": 308,
+        "layer": 0,
         "osm_way_ids": [
           775795921
         ],
@@ -14134,6 +14460,7 @@
       },
       "properties": {
         "dst_i": 218,
+        "layer": 0,
         "osm_way_ids": [
           775795921
         ],
@@ -14172,6 +14499,7 @@
       },
       "properties": {
         "dst_i": 309,
+        "layer": 0,
         "osm_way_ids": [
           775795921
         ],
@@ -14210,6 +14538,7 @@
       },
       "properties": {
         "dst_i": 320,
+        "layer": 0,
         "osm_way_ids": [
           775795922
         ],
@@ -14248,6 +14577,7 @@
       },
       "properties": {
         "dst_i": 307,
+        "layer": 0,
         "osm_way_ids": [
           775795922
         ],
@@ -14286,6 +14616,7 @@
       },
       "properties": {
         "dst_i": 306,
+        "layer": 0,
         "osm_way_ids": [
           775795923,
           147463174
@@ -14325,6 +14656,7 @@
       },
       "properties": {
         "dst_i": 310,
+        "layer": 0,
         "osm_way_ids": [
           775795923
         ],
@@ -14371,6 +14703,7 @@
       },
       "properties": {
         "dst_i": 315,
+        "layer": 0,
         "osm_way_ids": [
           775795925
         ],
@@ -14409,6 +14742,7 @@
       },
       "properties": {
         "dst_i": 292,
+        "layer": 0,
         "osm_way_ids": [
           775795925
         ],
@@ -14447,6 +14781,7 @@
       },
       "properties": {
         "dst_i": 314,
+        "layer": 0,
         "osm_way_ids": [
           775795925
         ],
@@ -14485,6 +14820,7 @@
       },
       "properties": {
         "dst_i": 316,
+        "layer": 0,
         "osm_way_ids": [
           775795926
         ],
@@ -14531,6 +14867,7 @@
       },
       "properties": {
         "dst_i": 317,
+        "layer": 0,
         "osm_way_ids": [
           775795929,
           673731133
@@ -14570,6 +14907,7 @@
       },
       "properties": {
         "dst_i": 228,
+        "layer": 0,
         "osm_way_ids": [
           776103800
         ],
@@ -14616,6 +14954,7 @@
       },
       "properties": {
         "dst_i": 318,
+        "layer": 0,
         "osm_way_ids": [
           778025016
         ],
@@ -14654,6 +14993,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           778025017
         ],
@@ -14700,6 +15040,7 @@
       },
       "properties": {
         "dst_i": 373,
+        "layer": 0,
         "osm_way_ids": [
           778025023
         ],
@@ -14770,6 +15111,7 @@
       },
       "properties": {
         "dst_i": 228,
+        "layer": 0,
         "osm_way_ids": [
           778025023
         ],
@@ -14808,6 +15150,7 @@
       },
       "properties": {
         "dst_i": 336,
+        "layer": 0,
         "osm_way_ids": [
           778102285
         ],
@@ -14846,6 +15189,7 @@
       },
       "properties": {
         "dst_i": 119,
+        "layer": 0,
         "osm_way_ids": [
           778102285
         ],
@@ -14884,6 +15228,7 @@
       },
       "properties": {
         "dst_i": 321,
+        "layer": 0,
         "osm_way_ids": [
           778102285
         ],
@@ -14922,6 +15267,7 @@
       },
       "properties": {
         "dst_i": 301,
+        "layer": 0,
         "osm_way_ids": [
           778102286
         ],
@@ -14960,6 +15306,7 @@
       },
       "properties": {
         "dst_i": 324,
+        "layer": 0,
         "osm_way_ids": [
           778102287,
           190821092
@@ -14999,6 +15346,7 @@
       },
       "properties": {
         "dst_i": 189,
+        "layer": 0,
         "osm_way_ids": [
           778102288,
           190821094
@@ -15070,6 +15418,7 @@
       },
       "properties": {
         "dst_i": 321,
+        "layer": 0,
         "osm_way_ids": [
           778102289
         ],
@@ -15116,6 +15465,7 @@
       },
       "properties": {
         "dst_i": 122,
+        "layer": 0,
         "osm_way_ids": [
           778102289
         ],
@@ -15162,6 +15512,7 @@
       },
       "properties": {
         "dst_i": 327,
+        "layer": 0,
         "osm_way_ids": [
           778102289
         ],
@@ -15200,6 +15551,7 @@
       },
       "properties": {
         "dst_i": 152,
+        "layer": 0,
         "osm_way_ids": [
           778102290
         ],
@@ -15238,6 +15590,7 @@
       },
       "properties": {
         "dst_i": 332,
+        "layer": 0,
         "osm_way_ids": [
           778102291
         ],
@@ -15276,6 +15629,7 @@
       },
       "properties": {
         "dst_i": 329,
+        "layer": 0,
         "osm_way_ids": [
           778102291
         ],
@@ -15314,6 +15668,7 @@
       },
       "properties": {
         "dst_i": 97,
+        "layer": 0,
         "osm_way_ids": [
           779181825
         ],
@@ -15352,6 +15707,7 @@
       },
       "properties": {
         "dst_i": 223,
+        "layer": 0,
         "osm_way_ids": [
           779181825
         ],
@@ -15398,6 +15754,7 @@
       },
       "properties": {
         "dst_i": 324,
+        "layer": 0,
         "osm_way_ids": [
           779181826
         ],
@@ -15436,6 +15793,7 @@
       },
       "properties": {
         "dst_i": 325,
+        "layer": 0,
         "osm_way_ids": [
           779181826
         ],
@@ -15482,6 +15840,7 @@
       },
       "properties": {
         "dst_i": 332,
+        "layer": 0,
         "osm_way_ids": [
           779181826
         ],
@@ -15520,6 +15879,7 @@
       },
       "properties": {
         "dst_i": 130,
+        "layer": 0,
         "osm_way_ids": [
           812851864
         ],
@@ -15558,6 +15918,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           813941484
         ],
@@ -15596,6 +15957,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           823888306
         ],
@@ -15634,6 +15996,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           823888306
         ],
@@ -15688,6 +16051,7 @@
       },
       "properties": {
         "dst_i": 335,
+        "layer": 0,
         "osm_way_ids": [
           845622686
         ],
@@ -15726,6 +16090,7 @@
       },
       "properties": {
         "dst_i": 59,
+        "layer": 0,
         "osm_way_ids": [
           845622686
         ],
@@ -15764,6 +16129,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           845622687
         ],
@@ -15802,6 +16168,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           845622689
         ],
@@ -15848,6 +16215,7 @@
       },
       "properties": {
         "dst_i": 336,
+        "layer": 0,
         "osm_way_ids": [
           845622689
         ],
@@ -15894,6 +16262,7 @@
       },
       "properties": {
         "dst_i": 272,
+        "layer": 0,
         "osm_way_ids": [
           845622690
         ],
@@ -15932,6 +16301,7 @@
       },
       "properties": {
         "dst_i": 195,
+        "layer": 0,
         "osm_way_ids": [
           845622691
         ],
@@ -15970,6 +16340,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           845622691
         ],
@@ -16008,6 +16379,7 @@
       },
       "properties": {
         "dst_i": 246,
+        "layer": 0,
         "osm_way_ids": [
           864595640
         ],
@@ -16046,6 +16418,7 @@
       },
       "properties": {
         "dst_i": 235,
+        "layer": 0,
         "osm_way_ids": [
           864595641,
           864595642,
@@ -16111,6 +16484,7 @@
       },
       "properties": {
         "dst_i": 95,
+        "layer": 0,
         "osm_way_ids": [
           864595644,
           864595645,
@@ -16170,6 +16544,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           890039689
         ],
@@ -16208,6 +16583,7 @@
       },
       "properties": {
         "dst_i": 361,
+        "layer": 0,
         "osm_way_ids": [
           894330328
         ],
@@ -16246,6 +16622,7 @@
       },
       "properties": {
         "dst_i": 362,
+        "layer": 0,
         "osm_way_ids": [
           894330329
         ],
@@ -16284,6 +16661,7 @@
       },
       "properties": {
         "dst_i": 369,
+        "layer": 0,
         "osm_way_ids": [
           913030752
         ],
@@ -16322,6 +16700,7 @@
       },
       "properties": {
         "dst_i": 364,
+        "layer": 0,
         "osm_way_ids": [
           913030752
         ],
@@ -16360,6 +16739,7 @@
       },
       "properties": {
         "dst_i": 370,
+        "layer": 0,
         "osm_way_ids": [
           913030753
         ],
@@ -16398,6 +16778,7 @@
       },
       "properties": {
         "dst_i": 366,
+        "layer": 0,
         "osm_way_ids": [
           913030753
         ],
@@ -16436,6 +16817,7 @@
       },
       "properties": {
         "dst_i": 368,
+        "layer": 0,
         "osm_way_ids": [
           913030756
         ],
@@ -16474,6 +16856,7 @@
       },
       "properties": {
         "dst_i": 370,
+        "layer": 0,
         "osm_way_ids": [
           913030760
         ],
@@ -16512,6 +16895,7 @@
       },
       "properties": {
         "dst_i": 371,
+        "layer": 0,
         "osm_way_ids": [
           913030760
         ],
@@ -16558,6 +16942,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           936169264
         ],
@@ -16596,6 +16981,7 @@
       },
       "properties": {
         "dst_i": 373,
+        "layer": 0,
         "osm_way_ids": [
           943136734
         ],
@@ -16634,6 +17020,7 @@
       },
       "properties": {
         "dst_i": 374,
+        "layer": 0,
         "osm_way_ids": [
           943136734
         ],
@@ -16672,6 +17059,7 @@
       },
       "properties": {
         "dst_i": 375,
+        "layer": 0,
         "osm_way_ids": [
           943136735
         ],
@@ -16710,6 +17098,7 @@
       },
       "properties": {
         "dst_i": 376,
+        "layer": 0,
         "osm_way_ids": [
           943136735
         ],
@@ -16748,6 +17137,7 @@
       },
       "properties": {
         "dst_i": 380,
+        "layer": 0,
         "osm_way_ids": [
           944039772
         ],
@@ -16802,6 +17192,7 @@
       },
       "properties": {
         "dst_i": 379,
+        "layer": 0,
         "osm_way_ids": [
           944039772
         ],
@@ -16840,6 +17231,7 @@
       },
       "properties": {
         "dst_i": 380,
+        "layer": 0,
         "osm_way_ids": [
           944039773
         ],
@@ -16878,6 +17270,7 @@
       },
       "properties": {
         "dst_i": 383,
+        "layer": 0,
         "osm_way_ids": [
           971371100
         ],
@@ -16916,6 +17309,7 @@
       },
       "properties": {
         "dst_i": 382,
+        "layer": 0,
         "osm_way_ids": [
           971371100
         ],
@@ -16962,6 +17356,7 @@
       },
       "properties": {
         "dst_i": 384,
+        "layer": 0,
         "osm_way_ids": [
           971371101
         ],
@@ -17000,6 +17395,7 @@
       },
       "properties": {
         "dst_i": 385,
+        "layer": 0,
         "osm_way_ids": [
           1003280130
         ],
@@ -17038,6 +17434,7 @@
       },
       "properties": {
         "dst_i": 387,
+        "layer": 0,
         "osm_way_ids": [
           1003280134
         ],
@@ -17076,6 +17473,7 @@
       },
       "properties": {
         "dst_i": 389,
+        "layer": 0,
         "osm_way_ids": [
           1003280138
         ],
@@ -17114,6 +17512,7 @@
       },
       "properties": {
         "dst_i": 169,
+        "layer": 0,
         "osm_way_ids": [
           1009731656
         ],
@@ -17152,6 +17551,7 @@
       },
       "properties": {
         "dst_i": 392,
+        "layer": 0,
         "osm_way_ids": [
           1009731656
         ],
@@ -17206,6 +17606,7 @@
       },
       "properties": {
         "dst_i": 394,
+        "layer": 0,
         "osm_way_ids": [
           1009731660
         ],
@@ -17244,6 +17645,7 @@
       },
       "properties": {
         "dst_i": 171,
+        "layer": 0,
         "osm_way_ids": [
           1009731661
         ],
@@ -17282,6 +17684,7 @@
       },
       "properties": {
         "dst_i": 183,
+        "layer": 0,
         "osm_way_ids": [
           1009731662
         ],
@@ -17320,6 +17723,7 @@
       },
       "properties": {
         "dst_i": 101,
+        "layer": 0,
         "osm_way_ids": [
           1009731662
         ],
@@ -17358,6 +17762,7 @@
       },
       "properties": {
         "dst_i": 395,
+        "layer": 0,
         "osm_way_ids": [
           1010049066
         ],
@@ -17396,6 +17801,7 @@
       },
       "properties": {
         "dst_i": 400,
+        "layer": 0,
         "osm_way_ids": [
           1010049066
         ],
@@ -17442,6 +17848,7 @@
       },
       "properties": {
         "dst_i": 323,
+        "layer": 0,
         "osm_way_ids": [
           1010049066
         ],
@@ -17480,6 +17887,7 @@
       },
       "properties": {
         "dst_i": 158,
+        "layer": 0,
         "osm_way_ids": [
           1010049068
         ],
@@ -17526,6 +17934,7 @@
       },
       "properties": {
         "dst_i": 397,
+        "layer": 0,
         "osm_way_ids": [
           1010049070
         ],
@@ -17572,6 +17981,7 @@
       },
       "properties": {
         "dst_i": 399,
+        "layer": 0,
         "osm_way_ids": [
           1010049071
         ],
@@ -17618,6 +18028,7 @@
       },
       "properties": {
         "dst_i": 132,
+        "layer": 0,
         "osm_way_ids": [
           1019599366
         ],
@@ -17656,6 +18067,7 @@
       },
       "properties": {
         "dst_i": 133,
+        "layer": 0,
         "osm_way_ids": [
           1019599367
         ],
@@ -17702,6 +18114,7 @@
       },
       "properties": {
         "dst_i": 405,
+        "layer": 0,
         "osm_way_ids": [
           1060145090
         ],
@@ -17756,6 +18169,7 @@
       },
       "properties": {
         "dst_i": 404,
+        "layer": 0,
         "osm_way_ids": [
           1060145090
         ],
@@ -17794,6 +18208,7 @@
       },
       "properties": {
         "dst_i": 407,
+        "layer": 0,
         "osm_way_ids": [
           1060145091,
           1060145092
@@ -17833,6 +18248,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           1079858511
         ],
@@ -17879,6 +18295,7 @@
       },
       "properties": {
         "dst_i": 364,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],
@@ -17917,6 +18334,7 @@
       },
       "properties": {
         "dst_i": 366,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],
@@ -17955,6 +18373,7 @@
       },
       "properties": {
         "dst_i": 368,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],
@@ -18001,6 +18420,7 @@
       },
       "properties": {
         "dst_i": 277,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],
@@ -18039,6 +18459,7 @@
       },
       "properties": {
         "dst_i": 411,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],
@@ -18077,6 +18498,7 @@
       },
       "properties": {
         "dst_i": 413,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],
@@ -18115,6 +18537,7 @@
       },
       "properties": {
         "dst_i": 414,
+        "layer": 0,
         "osm_way_ids": [
           177344221
         ],

--- a/tests/src/montlake_roundabout/geometry.json
+++ b/tests/src/montlake_roundabout/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           6348168
         ],
@@ -84,6 +85,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           6383154
         ],
@@ -154,6 +156,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           6460090
         ],
@@ -192,6 +195,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           36952952
         ],
@@ -238,6 +242,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           992268928
         ],
@@ -284,6 +289,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           992268929
         ],
@@ -330,6 +336,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           992268929
         ],
@@ -376,6 +383,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           992268929
         ],
@@ -422,6 +430,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           992268929
         ],

--- a/tests/src/northgate_dual_carriageway/geometry.json
+++ b/tests/src/northgate_dual_carriageway/geometry.json
@@ -38,6 +38,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           6459889
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           6491620
         ],
@@ -114,6 +116,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           10738297
         ],
@@ -152,6 +155,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           35083333
         ],
@@ -190,6 +194,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           39721050
         ],
@@ -228,6 +233,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           39721050
         ],
@@ -266,6 +272,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           39721063
         ],
@@ -304,6 +311,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           39721064
         ],
@@ -342,6 +350,7 @@
       },
       "properties": {
         "dst_i": 92,
+        "layer": 0,
         "osm_way_ids": [
           39721065
         ],
@@ -380,6 +389,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           39721065
         ],
@@ -418,6 +428,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           39762207
         ],
@@ -472,6 +483,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           39762207
         ],
@@ -510,6 +522,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           39762208
         ],
@@ -548,6 +561,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           39762212
         ],
@@ -586,6 +600,7 @@
       },
       "properties": {
         "dst_i": 72,
+        "layer": 0,
         "osm_way_ids": [
           39765322
         ],
@@ -624,6 +639,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           39765322
         ],
@@ -662,6 +678,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           39765322
         ],
@@ -700,6 +717,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           39765323
         ],
@@ -738,6 +756,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           39946258
         ],
@@ -776,6 +795,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": -1,
         "osm_way_ids": [
           39946264
         ],
@@ -838,6 +858,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           39946269
         ],
@@ -884,6 +905,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           54580993
         ],
@@ -922,6 +944,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           77304223
         ],
@@ -960,6 +983,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           77304223
         ],
@@ -998,6 +1022,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           180075371
         ],
@@ -1036,6 +1061,7 @@
       },
       "properties": {
         "dst_i": 79,
+        "layer": 0,
         "osm_way_ids": [
           180075374
         ],
@@ -1074,6 +1100,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           180075374
         ],
@@ -1112,6 +1139,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           186162534
         ],
@@ -1150,6 +1178,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           186162535
         ],
@@ -1188,6 +1217,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           186162539
         ],
@@ -1234,6 +1264,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           186162540
         ],
@@ -1272,6 +1303,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           186162540
         ],
@@ -1310,6 +1342,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           186162540
         ],
@@ -1348,6 +1381,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           186162540
         ],
@@ -1394,6 +1428,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           186162540
         ],
@@ -1432,6 +1467,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           186162542
         ],
@@ -1478,6 +1514,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           240442161
         ],
@@ -1524,6 +1561,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           264983008
         ],
@@ -1570,6 +1608,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           264983009
         ],
@@ -1608,6 +1647,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           333930518
         ],
@@ -1646,6 +1686,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           333930518
         ],
@@ -1684,6 +1725,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           333930519
         ],
@@ -1722,6 +1764,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           367192712
         ],
@@ -1760,6 +1803,7 @@
       },
       "properties": {
         "dst_i": 52,
+        "layer": 0,
         "osm_way_ids": [
           399554362
         ],
@@ -1798,6 +1842,7 @@
       },
       "properties": {
         "dst_i": 56,
+        "layer": 0,
         "osm_way_ids": [
           428093498
         ],
@@ -1844,6 +1889,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           428093500
         ],
@@ -1890,6 +1936,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           428093502
         ],
@@ -1928,6 +1975,7 @@
       },
       "properties": {
         "dst_i": 60,
+        "layer": 0,
         "osm_way_ids": [
           428093503
         ],
@@ -1966,6 +2014,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           428093506
         ],
@@ -2004,6 +2053,7 @@
       },
       "properties": {
         "dst_i": 65,
+        "layer": 0,
         "osm_way_ids": [
           428093506
         ],
@@ -2042,6 +2092,7 @@
       },
       "properties": {
         "dst_i": 61,
+        "layer": 0,
         "osm_way_ids": [
           428093506
         ],
@@ -2088,6 +2139,7 @@
       },
       "properties": {
         "dst_i": 62,
+        "layer": 0,
         "osm_way_ids": [
           428093507
         ],
@@ -2126,6 +2178,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           428093508
         ],
@@ -2172,6 +2225,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           428093508
         ],
@@ -2210,6 +2264,7 @@
       },
       "properties": {
         "dst_i": 64,
+        "layer": 0,
         "osm_way_ids": [
           468773475
         ],
@@ -2248,6 +2303,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           486023140
         ],
@@ -2286,6 +2342,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           486023141
         ],
@@ -2332,6 +2389,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           486023142
         ],
@@ -2370,6 +2428,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           486023142
         ],
@@ -2408,6 +2467,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           486023143
         ],
@@ -2446,6 +2506,7 @@
       },
       "properties": {
         "dst_i": 75,
+        "layer": 0,
         "osm_way_ids": [
           486030664
         ],
@@ -2484,6 +2545,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           486030664
         ],
@@ -2522,6 +2584,7 @@
       },
       "properties": {
         "dst_i": 67,
+        "layer": 0,
         "osm_way_ids": [
           486030665
         ],
@@ -2560,6 +2623,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           486030665
         ],
@@ -2598,6 +2662,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           562271663,
           987216714
@@ -2637,6 +2702,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           562271664
         ],
@@ -2675,6 +2741,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           562271664
         ],
@@ -2713,6 +2780,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           565363876
         ],
@@ -2751,6 +2819,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           575282247
         ],
@@ -2789,6 +2858,7 @@
       },
       "properties": {
         "dst_i": 74,
+        "layer": 0,
         "osm_way_ids": [
           590774650
         ],
@@ -2827,6 +2897,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           731048579,
           428093497
@@ -2866,6 +2937,7 @@
       },
       "properties": {
         "dst_i": 75,
+        "layer": 0,
         "osm_way_ids": [
           741175092
         ],
@@ -2904,6 +2976,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           741175092
         ],
@@ -2942,6 +3015,7 @@
       },
       "properties": {
         "dst_i": 77,
+        "layer": 0,
         "osm_way_ids": [
           777096915
         ],
@@ -2980,6 +3054,7 @@
       },
       "properties": {
         "dst_i": 78,
+        "layer": 0,
         "osm_way_ids": [
           803703472
         ],
@@ -3018,6 +3093,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           816455128
         ],
@@ -3056,6 +3132,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           816455128
         ],
@@ -3094,6 +3171,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           816455128
         ],
@@ -3132,6 +3210,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           816455490
         ],
@@ -3178,6 +3257,7 @@
       },
       "properties": {
         "dst_i": 80,
+        "layer": 0,
         "osm_way_ids": [
           875075135
         ],
@@ -3216,6 +3296,7 @@
       },
       "properties": {
         "dst_i": 82,
+        "layer": 0,
         "osm_way_ids": [
           987034730
         ],
@@ -3254,6 +3335,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           987216714
         ],
@@ -3292,6 +3374,7 @@
       },
       "properties": {
         "dst_i": 83,
+        "layer": 0,
         "osm_way_ids": [
           987216714
         ],
@@ -3330,6 +3413,7 @@
       },
       "properties": {
         "dst_i": 83,
+        "layer": 0,
         "osm_way_ids": [
           987216715
         ],
@@ -3368,6 +3452,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           987216715
         ],
@@ -3406,6 +3491,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           987216715
         ],
@@ -3452,6 +3538,7 @@
       },
       "properties": {
         "dst_i": 137,
+        "layer": 0,
         "osm_way_ids": [
           987216715,
           39765316
@@ -3507,6 +3594,7 @@
       },
       "properties": {
         "dst_i": 90,
+        "layer": 0,
         "osm_way_ids": [
           995002481
         ],
@@ -3561,6 +3649,7 @@
       },
       "properties": {
         "dst_i": 106,
+        "layer": 0,
         "osm_way_ids": [
           995002481
         ],
@@ -3599,6 +3688,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           995002481,
           995002480,
@@ -3655,6 +3745,7 @@
       },
       "properties": {
         "dst_i": 89,
+        "layer": 0,
         "osm_way_ids": [
           995002573
         ],
@@ -3701,6 +3792,7 @@
       },
       "properties": {
         "dst_i": 90,
+        "layer": 0,
         "osm_way_ids": [
           995002574,
           468773475
@@ -3740,6 +3832,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           995002586
         ],
@@ -3786,6 +3879,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           996138767,
           39721045
@@ -3833,6 +3927,7 @@
       },
       "properties": {
         "dst_i": 92,
+        "layer": 0,
         "osm_way_ids": [
           1010448520
         ],
@@ -3879,6 +3974,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           1010448520
         ],
@@ -3965,6 +4061,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           1010448521,
           35083333
@@ -4004,6 +4101,7 @@
       },
       "properties": {
         "dst_i": 94,
+        "layer": 0,
         "osm_way_ids": [
           1017390619
         ],
@@ -4042,6 +4140,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           1017417857
         ],
@@ -4080,6 +4179,7 @@
       },
       "properties": {
         "dst_i": 97,
+        "layer": 0,
         "osm_way_ids": [
           1054161097
         ],
@@ -4118,6 +4218,7 @@
       },
       "properties": {
         "dst_i": 96,
+        "layer": 0,
         "osm_way_ids": [
           1054161102
         ],
@@ -4156,6 +4257,7 @@
       },
       "properties": {
         "dst_i": 99,
+        "layer": 0,
         "osm_way_ids": [
           1054161104
         ],
@@ -4194,6 +4296,7 @@
       },
       "properties": {
         "dst_i": 101,
+        "layer": 0,
         "osm_way_ids": [
           1054883387
         ],
@@ -4232,6 +4335,7 @@
       },
       "properties": {
         "dst_i": 102,
+        "layer": 0,
         "osm_way_ids": [
           1054883388
         ],
@@ -4270,6 +4374,7 @@
       },
       "properties": {
         "dst_i": 104,
+        "layer": 0,
         "osm_way_ids": [
           1054883390
         ],
@@ -4308,6 +4413,7 @@
       },
       "properties": {
         "dst_i": 106,
+        "layer": 0,
         "osm_way_ids": [
           1054883391
         ],
@@ -4346,6 +4452,7 @@
       },
       "properties": {
         "dst_i": 59,
+        "layer": 0,
         "osm_way_ids": [
           1054980554
         ],
@@ -4384,6 +4491,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           1054983185
         ],
@@ -4430,6 +4538,7 @@
       },
       "properties": {
         "dst_i": 117,
+        "layer": 0,
         "osm_way_ids": [
           1057705467
         ],
@@ -4468,6 +4577,7 @@
       },
       "properties": {
         "dst_i": 115,
+        "layer": 0,
         "osm_way_ids": [
           1057705467
         ],
@@ -4518,6 +4628,7 @@
       },
       "properties": {
         "dst_i": 108,
+        "layer": 0,
         "osm_way_ids": [
           1057705467
         ],
@@ -4556,6 +4667,7 @@
       },
       "properties": {
         "dst_i": 110,
+        "layer": 0,
         "osm_way_ids": [
           1057705470
         ],
@@ -4594,6 +4706,7 @@
       },
       "properties": {
         "dst_i": 112,
+        "layer": 0,
         "osm_way_ids": [
           1057705472
         ],
@@ -4632,6 +4745,7 @@
       },
       "properties": {
         "dst_i": 114,
+        "layer": 0,
         "osm_way_ids": [
           1057705474
         ],
@@ -4670,6 +4784,7 @@
       },
       "properties": {
         "dst_i": 116,
+        "layer": 0,
         "osm_way_ids": [
           1057705475
         ],
@@ -4708,6 +4823,7 @@
       },
       "properties": {
         "dst_i": 118,
+        "layer": 0,
         "osm_way_ids": [
           1057705476
         ],
@@ -4746,6 +4862,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           1061736838,
           428093500
@@ -4793,6 +4910,7 @@
       },
       "properties": {
         "dst_i": 120,
+        "layer": 0,
         "osm_way_ids": [
           1064067352
         ],
@@ -4831,6 +4949,7 @@
       },
       "properties": {
         "dst_i": 122,
+        "layer": 0,
         "osm_way_ids": [
           1064067354
         ],
@@ -4869,6 +4988,7 @@
       },
       "properties": {
         "dst_i": 124,
+        "layer": 0,
         "osm_way_ids": [
           1067521781
         ],
@@ -4907,6 +5027,7 @@
       },
       "properties": {
         "dst_i": 130,
+        "layer": 0,
         "osm_way_ids": [
           1067521783,
           1067521786
@@ -4946,6 +5067,7 @@
       },
       "properties": {
         "dst_i": 128,
+        "layer": 0,
         "osm_way_ids": [
           1067521785,
           1067521784
@@ -5009,6 +5131,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           1067521787
         ],
@@ -5047,6 +5170,7 @@
       },
       "properties": {
         "dst_i": 132,
+        "layer": 0,
         "osm_way_ids": [
           1067521787
         ],
@@ -5109,6 +5233,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           1067521788
         ],
@@ -5155,6 +5280,7 @@
       },
       "properties": {
         "dst_i": 139,
+        "layer": 0,
         "osm_way_ids": [
           39765316
         ],

--- a/tests/src/oneway_loop/geometry.json
+++ b/tests/src/oneway_loop/geometry.json
@@ -46,6 +46,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 2,
         "osm_way_ids": [
           3987296
         ],
@@ -84,6 +85,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           4255128
         ],
@@ -122,6 +124,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           4255128
         ],
@@ -168,6 +171,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           58780084
         ],
@@ -222,6 +226,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           58780084
         ],
@@ -268,6 +273,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           58780084
         ],
@@ -314,6 +320,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           58780084
         ],
@@ -360,6 +367,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           58780084
         ],
@@ -406,6 +414,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           93197247,
           1039090211
@@ -445,6 +454,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           93197247
         ],
@@ -483,6 +493,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           93197247
         ],
@@ -529,6 +540,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           93197247
         ],
@@ -583,6 +595,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           93197252
         ],
@@ -621,6 +634,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           93197279
         ],
@@ -659,6 +673,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           93197279
         ],
@@ -697,6 +712,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           93197279
         ],
@@ -735,6 +751,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           93197279
         ],
@@ -773,6 +790,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           93197290
         ],
@@ -819,6 +837,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           93197290
         ],
@@ -857,6 +876,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           93197290
         ],
@@ -911,6 +931,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           93197290
         ],
@@ -957,6 +978,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           157890035
         ],
@@ -1035,6 +1057,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           157890038
         ],
@@ -1073,6 +1096,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           157890038
         ],
@@ -1119,6 +1143,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 3,
         "osm_way_ids": [
           164435841
         ],
@@ -1165,6 +1190,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           303611910
         ],
@@ -1219,6 +1245,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           392134505
         ],
@@ -1265,6 +1292,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           678658474
         ],
@@ -1303,6 +1331,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           678658474
         ],
@@ -1341,6 +1370,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           840754192
         ],
@@ -1387,6 +1417,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           958202228,
           958202229
@@ -1466,6 +1497,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           1039090212
         ],
@@ -1504,6 +1536,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           1039090215
         ],
@@ -1542,6 +1575,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           1039090216
         ],
@@ -1580,6 +1614,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           1041221413
         ],

--- a/tests/src/perth_peanut_roundabout/geometry.json
+++ b/tests/src/perth_peanut_roundabout/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           8596837,
           1024116250
@@ -69,6 +70,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           35468309
         ],
@@ -107,6 +109,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           35468309
         ],
@@ -145,6 +148,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           35468318
         ],
@@ -183,6 +187,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           35468318
         ],
@@ -237,6 +242,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           44953152
         ],
@@ -275,6 +281,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           45913246
         ],
@@ -321,6 +328,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           45913252,
           45913252
@@ -360,6 +368,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           45913252
         ],
@@ -414,6 +423,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           45913252
         ],
@@ -468,6 +478,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           45913252
         ],
@@ -522,6 +533,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           45913252
         ],
@@ -560,6 +572,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           45913252
         ],
@@ -614,6 +627,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           45913252
         ],
@@ -652,6 +666,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           579311220,
           579311234
@@ -691,6 +706,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           579311221
         ],
@@ -729,6 +745,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           664081635
         ],
@@ -767,6 +784,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           668245612
         ],
@@ -813,6 +831,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           668245613
         ],
@@ -875,6 +894,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           668245614
         ],
@@ -921,6 +941,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           668245618
         ],
@@ -959,6 +980,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           668245621
         ],
@@ -1005,6 +1027,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           668245625
         ],

--- a/tests/src/perth_stretched_lights/geometry.json
+++ b/tests/src/perth_stretched_lights/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           663147559
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           668230253
         ],
@@ -122,6 +124,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           668230254
         ],
@@ -160,6 +163,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           671997852
         ],
@@ -198,6 +202,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           671997854
         ],
@@ -236,6 +241,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           671997854
         ],
@@ -274,6 +280,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           671997854
         ],
@@ -312,6 +319,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           671997856
         ],

--- a/tests/src/quad_intersection/geometry.json
+++ b/tests/src/quad_intersection/geometry.json
@@ -38,6 +38,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           4634847
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           4636141
         ],
@@ -122,6 +124,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 1,
         "osm_way_ids": [
           4636259
         ],
@@ -160,6 +163,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           6344531
         ],
@@ -206,6 +210,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           6390208
         ],
@@ -244,6 +249,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           6390208
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           40416108
         ],
@@ -336,6 +343,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           332060228
         ],
@@ -382,6 +390,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           332060243
         ],
@@ -420,6 +429,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           332060248
         ],
@@ -474,6 +484,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           332060263,
           752724204
@@ -529,6 +540,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": -2,
         "osm_way_ids": [
           372672863
         ],
@@ -567,6 +579,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           424636846
         ],
@@ -605,6 +618,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           424636850
         ],
@@ -643,6 +657,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           424807771
         ],
@@ -681,6 +696,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 1,
         "osm_way_ids": [
           428224940
         ],
@@ -735,6 +751,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           428224942
         ],
@@ -773,6 +790,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 1,
         "osm_way_ids": [
           431103956
         ],
@@ -835,6 +853,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           531617255
         ],
@@ -889,6 +908,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           607798222
         ],
@@ -935,6 +955,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           760445304,
           424807773
@@ -982,6 +1003,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": -2,
         "osm_way_ids": [
           824708856
         ],
@@ -1036,6 +1058,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           981013925,
           1000034207
@@ -1091,6 +1114,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           981013928,
           1000034197
@@ -1154,6 +1178,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": -1,
         "osm_way_ids": [
           981053035
         ],
@@ -1192,6 +1217,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           981053036
         ],
@@ -1238,6 +1264,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": -1,
         "osm_way_ids": [
           981053037
         ],
@@ -1276,6 +1303,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           981053038,
           424807772
@@ -1315,6 +1343,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           1000034196
         ],
@@ -1353,6 +1382,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           1000034201
         ],
@@ -1407,6 +1437,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 1,
         "osm_way_ids": [
           1036136082
         ],
@@ -1453,6 +1484,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           1036136084
         ],
@@ -1491,6 +1523,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           1036136085
         ],

--- a/tests/src/roosevelt_cycletrack/geometry.json
+++ b/tests/src/roosevelt_cycletrack/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           6362058
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           6362058
         ],
@@ -106,6 +108,7 @@
       },
       "properties": {
         "dst_i": 65,
+        "layer": 0,
         "osm_way_ids": [
           6435688
         ],
@@ -144,6 +147,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           6435688
         ],
@@ -182,6 +186,7 @@
       },
       "properties": {
         "dst_i": 64,
+        "layer": 0,
         "osm_way_ids": [
           6487262
         ],
@@ -220,6 +225,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           6487262
         ],
@@ -258,6 +264,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           6493601
         ],
@@ -296,6 +303,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           6517852,
           6517852
@@ -335,6 +343,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           6517852
         ],
@@ -381,6 +390,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           7978645
         ],
@@ -419,6 +429,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           7978646
         ],
@@ -457,6 +468,7 @@
       },
       "properties": {
         "dst_i": 69,
+        "layer": 0,
         "osm_way_ids": [
           158781164
         ],
@@ -495,6 +507,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           158781164
         ],
@@ -533,6 +546,7 @@
       },
       "properties": {
         "dst_i": 67,
+        "layer": 0,
         "osm_way_ids": [
           158781177
         ],
@@ -571,6 +585,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           158781177
         ],
@@ -609,6 +624,7 @@
       },
       "properties": {
         "dst_i": 60,
+        "layer": 0,
         "osm_way_ids": [
           296557976
         ],
@@ -647,6 +663,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           296557976
         ],
@@ -685,6 +702,7 @@
       },
       "properties": {
         "dst_i": 94,
+        "layer": 0,
         "osm_way_ids": [
           331771747
         ],
@@ -723,6 +741,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           331771747
         ],
@@ -761,6 +780,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           332753236
         ],
@@ -799,6 +819,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           363224303
         ],
@@ -837,6 +858,7 @@
       },
       "properties": {
         "dst_i": 59,
+        "layer": 0,
         "osm_way_ids": [
           394703522
         ],
@@ -875,6 +897,7 @@
       },
       "properties": {
         "dst_i": 55,
+        "layer": 0,
         "osm_way_ids": [
           394703522
         ],
@@ -913,6 +936,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           394703522
         ],
@@ -951,6 +975,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           394703523
         ],
@@ -989,6 +1014,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1027,6 +1053,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1065,6 +1092,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1103,6 +1131,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1141,6 +1170,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1179,6 +1209,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1217,6 +1248,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           421652698
         ],
@@ -1255,6 +1287,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           421652698,
           421652699
@@ -1294,6 +1327,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           421652699
         ],
@@ -1332,6 +1366,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           421652699
         ],
@@ -1370,6 +1405,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           421652699
         ],
@@ -1408,6 +1444,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           428097444
         ],
@@ -1470,6 +1507,7 @@
       },
       "properties": {
         "dst_i": 76,
+        "layer": 0,
         "osm_way_ids": [
           428097445
         ],
@@ -1508,6 +1546,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           428097446
         ],
@@ -1546,6 +1585,7 @@
       },
       "properties": {
         "dst_i": 77,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -1584,6 +1624,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -1622,6 +1663,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -1660,6 +1702,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -1698,6 +1741,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -1736,6 +1780,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -1782,6 +1827,7 @@
       },
       "properties": {
         "dst_i": 89,
+        "layer": 0,
         "osm_way_ids": [
           456889627,
           754995509,
@@ -1838,6 +1884,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           486283205
         ],
@@ -1876,6 +1923,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           490957412
         ],
@@ -1914,6 +1962,7 @@
       },
       "properties": {
         "dst_i": 70,
+        "layer": 0,
         "osm_way_ids": [
           565125028
         ],
@@ -1960,6 +2009,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           565125032
         ],
@@ -2014,6 +2064,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           565125033
         ],
@@ -2052,6 +2103,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           621283284
         ],
@@ -2090,6 +2142,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           621283284
         ],
@@ -2128,6 +2181,7 @@
       },
       "properties": {
         "dst_i": 51,
+        "layer": 0,
         "osm_way_ids": [
           621283289
         ],
@@ -2174,6 +2228,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           621351851
         ],
@@ -2212,6 +2267,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           621646780,
           331771747
@@ -2251,6 +2307,7 @@
       },
       "properties": {
         "dst_i": 56,
+        "layer": 0,
         "osm_way_ids": [
           625839910
         ],
@@ -2289,6 +2346,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           625839910
         ],
@@ -2327,6 +2385,7 @@
       },
       "properties": {
         "dst_i": 54,
+        "layer": 0,
         "osm_way_ids": [
           625839911
         ],
@@ -2381,6 +2440,7 @@
       },
       "properties": {
         "dst_i": 56,
+        "layer": 0,
         "osm_way_ids": [
           625839912
         ],
@@ -2419,6 +2479,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           625840701
         ],
@@ -2465,6 +2526,7 @@
       },
       "properties": {
         "dst_i": 57,
+        "layer": 0,
         "osm_way_ids": [
           625840702
         ],
@@ -2527,6 +2589,7 @@
       },
       "properties": {
         "dst_i": 60,
+        "layer": 0,
         "osm_way_ids": [
           625840702
         ],
@@ -2565,6 +2628,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           670796677
         ],
@@ -2603,6 +2667,7 @@
       },
       "properties": {
         "dst_i": 79,
+        "layer": 0,
         "osm_way_ids": [
           687885754
         ],
@@ -2641,6 +2706,7 @@
       },
       "properties": {
         "dst_i": 61,
+        "layer": 0,
         "osm_way_ids": [
           687885754
         ],
@@ -2679,6 +2745,7 @@
       },
       "properties": {
         "dst_i": 64,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2717,6 +2784,7 @@
       },
       "properties": {
         "dst_i": 65,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2755,6 +2823,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2793,6 +2862,7 @@
       },
       "properties": {
         "dst_i": 67,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2831,6 +2901,7 @@
       },
       "properties": {
         "dst_i": 68,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2869,6 +2940,7 @@
       },
       "properties": {
         "dst_i": 69,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2907,6 +2979,7 @@
       },
       "properties": {
         "dst_i": 70,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -2969,6 +3042,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -3015,6 +3089,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -3061,6 +3136,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -3115,6 +3191,7 @@
       },
       "properties": {
         "dst_i": 76,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -3169,6 +3246,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -3207,6 +3285,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -3245,6 +3324,7 @@
       },
       "properties": {
         "dst_i": 76,
+        "layer": 0,
         "osm_way_ids": [
           754995508
         ],
@@ -3283,6 +3363,7 @@
       },
       "properties": {
         "dst_i": 78,
+        "layer": 0,
         "osm_way_ids": [
           765860708
         ],
@@ -3321,6 +3402,7 @@
       },
       "properties": {
         "dst_i": 80,
+        "layer": 0,
         "osm_way_ids": [
           894958714
         ],
@@ -3375,6 +3457,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 0,
         "osm_way_ids": [
           894958716,
           894958724,
@@ -3415,6 +3498,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 0,
         "osm_way_ids": [
           894958717,
           894958718,
@@ -3463,6 +3547,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           894958722
         ],
@@ -3501,6 +3586,7 @@
       },
       "properties": {
         "dst_i": 89,
+        "layer": 0,
         "osm_way_ids": [
           894958722
         ],
@@ -3555,6 +3641,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 0,
         "osm_way_ids": [
           894958723,
           894958715,
@@ -3595,6 +3682,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           990596236
         ],
@@ -3633,6 +3721,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           990596236
         ],
@@ -3671,6 +3760,7 @@
       },
       "properties": {
         "dst_i": 93,
+        "layer": 0,
         "osm_way_ids": [
           990596237
         ],
@@ -3717,6 +3807,7 @@
       },
       "properties": {
         "dst_i": 95,
+        "layer": 0,
         "osm_way_ids": [
           1058899922
         ],
@@ -3755,6 +3846,7 @@
       },
       "properties": {
         "dst_i": 97,
+        "layer": 0,
         "osm_way_ids": [
           158266283
         ],
@@ -3793,6 +3885,7 @@
       },
       "properties": {
         "dst_i": 99,
+        "layer": 0,
         "osm_way_ids": [
           158266283
         ],
@@ -3839,6 +3932,7 @@
       },
       "properties": {
         "dst_i": 101,
+        "layer": 0,
         "osm_way_ids": [
           990596235,
           990596235
@@ -3886,6 +3980,7 @@
       },
       "properties": {
         "dst_i": 90,
+        "layer": 0,
         "osm_way_ids": [
           990596238,
           990596238
@@ -3933,6 +4028,7 @@
       },
       "properties": {
         "dst_i": 104,
+        "layer": 0,
         "osm_way_ids": [
           990596238
         ],

--- a/tests/src/seattle_slip_lane/geometry.json
+++ b/tests/src/seattle_slip_lane/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           7978644
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           7978646
         ],
@@ -106,6 +108,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           331771747
         ],
@@ -144,6 +147,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           331771747
         ],
@@ -182,6 +186,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           363224303
         ],
@@ -220,6 +225,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           428097444
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           428097445
         ],
@@ -320,6 +327,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           428097447
         ],
@@ -358,6 +366,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           428098916
         ],
@@ -396,6 +405,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           428098916
         ],
@@ -442,6 +452,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           456889627,
           754995509,
@@ -498,6 +509,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           486283205
         ],
@@ -536,6 +548,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           621646780,
           331771747
@@ -575,6 +588,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           670796677
         ],
@@ -613,6 +627,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           687885754
         ],
@@ -651,6 +666,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           687885754
         ],
@@ -697,6 +713,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -751,6 +768,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -805,6 +823,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -843,6 +862,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           712316019
         ],
@@ -897,6 +917,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           735238605,
           1058899922,
@@ -939,6 +960,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           735238605
         ],
@@ -977,6 +999,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           735238605
         ],
@@ -1015,6 +1038,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           754995508
         ],
@@ -1053,6 +1077,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           894958714
         ],
@@ -1107,6 +1132,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           894958716,
           894958724,
@@ -1147,6 +1173,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           894958717,
           894958718,
@@ -1195,6 +1222,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           894958722
         ],
@@ -1233,6 +1261,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           894958722
         ],
@@ -1287,6 +1316,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           894958723,
           894958715,
@@ -1335,6 +1365,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           1058899922
         ],
@@ -1373,6 +1404,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           1058899922
         ],
@@ -1411,6 +1443,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           1058899923
         ],
@@ -1449,6 +1482,7 @@
       },
       "properties": {
         "dst_i": 49,
+        "layer": 0,
         "osm_way_ids": [
           1058899923,
           1058899931,
@@ -1489,6 +1523,7 @@
       },
       "properties": {
         "dst_i": 45,
+        "layer": 0,
         "osm_way_ids": [
           1058899926,
           1058899924,

--- a/tests/src/seattle_triangle/geometry.json
+++ b/tests/src/seattle_triangle/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           173554574
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           399134513
         ],
@@ -106,6 +108,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           399134516
         ],
@@ -144,6 +147,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           399134517
         ],
@@ -182,6 +186,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           399134517
         ],
@@ -220,6 +225,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           428087109
         ],
@@ -258,6 +264,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           428087110
         ],
@@ -296,6 +303,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           465971494
         ],
@@ -334,6 +342,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           490176742
         ],
@@ -372,6 +381,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           490176742
         ],
@@ -410,6 +420,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           609362310
         ],
@@ -448,6 +459,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           609362311
         ],
@@ -486,6 +498,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           609362315
         ],
@@ -524,6 +537,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           609362316
         ],
@@ -562,6 +576,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           609362318
         ],
@@ -600,6 +615,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           609362319
         ],
@@ -638,6 +654,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           609362321
         ],
@@ -676,6 +693,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           609362322
         ],
@@ -714,6 +732,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           609362324
         ],
@@ -752,6 +771,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           758464860
         ],
@@ -806,6 +826,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": -1,
         "osm_way_ids": [
           948577962
         ],
@@ -868,6 +889,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": -1,
         "osm_way_ids": [
           948577962
         ],
@@ -906,6 +928,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           1051046917
         ],
@@ -944,6 +967,7 @@
       },
       "properties": {
         "dst_i": 31,
+        "layer": 0,
         "osm_way_ids": [
           1054971765
         ],

--- a/tests/src/service_road_loop/geometry.json
+++ b/tests/src/service_road_loop/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           340292788
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           340292788
         ],
@@ -106,6 +108,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           340292788
         ],
@@ -144,6 +147,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           340292788
         ],
@@ -182,6 +186,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           340292788
         ],
@@ -220,6 +225,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           340292788
         ],
@@ -258,6 +264,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           367061135
         ],
@@ -312,6 +319,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           590064037
         ],
@@ -350,6 +358,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           590064037
         ],
@@ -396,6 +405,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           590064037
         ],
@@ -442,6 +452,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           625826660
         ],
@@ -480,6 +491,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           640910758,
           640910773
@@ -527,6 +539,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           640910762,
           640910765
@@ -566,6 +579,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           640910764
         ],
@@ -612,6 +626,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           640910765
         ],
@@ -690,6 +705,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           640910770
         ],
@@ -736,6 +752,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           640910773
         ],
@@ -774,6 +791,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           640910773
         ],
@@ -820,6 +838,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           640910773
         ],
@@ -858,6 +877,7 @@
       },
       "properties": {
         "dst_i": 18,
+        "layer": 0,
         "osm_way_ids": [
           640910767
         ],
@@ -896,6 +916,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           640910767
         ],

--- a/tests/src/st_georges_cycletrack/geometry.json
+++ b/tests/src/st_georges_cycletrack/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           4253528
         ],
@@ -68,6 +69,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           4253572,
           4253572
@@ -123,6 +125,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           4253575
         ],
@@ -169,6 +172,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           4253575
         ],
@@ -207,6 +211,7 @@
       },
       "properties": {
         "dst_i": 115,
+        "layer": 0,
         "osm_way_ids": [
           4253668
         ],
@@ -253,6 +258,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           4253668
         ],
@@ -291,6 +297,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           4253669
         ],
@@ -329,6 +336,7 @@
       },
       "properties": {
         "dst_i": 80,
+        "layer": 0,
         "osm_way_ids": [
           4255754
         ],
@@ -367,6 +375,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           8614531
         ],
@@ -405,6 +414,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           8614531
         ],
@@ -443,6 +453,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           8614531
         ],
@@ -481,6 +492,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           8614531
         ],
@@ -519,6 +531,7 @@
       },
       "properties": {
         "dst_i": 78,
+        "layer": 0,
         "osm_way_ids": [
           10873089
         ],
@@ -581,6 +594,7 @@
       },
       "properties": {
         "dst_i": 128,
+        "layer": 0,
         "osm_way_ids": [
           10873089
         ],
@@ -627,6 +641,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           10873089
         ],
@@ -665,6 +680,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           10873090
         ],
@@ -703,6 +719,7 @@
       },
       "properties": {
         "dst_i": 82,
+        "layer": 0,
         "osm_way_ids": [
           24365211
         ],
@@ -757,6 +774,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           24365211
         ],
@@ -803,6 +821,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           24397614
         ],
@@ -841,6 +860,7 @@
       },
       "properties": {
         "dst_i": 79,
+        "layer": 0,
         "osm_way_ids": [
           24420020
         ],
@@ -887,6 +907,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           24420020
         ],
@@ -941,6 +962,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           24935826
         ],
@@ -995,6 +1017,7 @@
       },
       "properties": {
         "dst_i": 87,
+        "layer": 0,
         "osm_way_ids": [
           38893561
         ],
@@ -1065,6 +1088,7 @@
       },
       "properties": {
         "dst_i": 35,
+        "layer": 0,
         "osm_way_ids": [
           102702446
         ],
@@ -1207,6 +1231,7 @@
       },
       "properties": {
         "dst_i": 36,
+        "layer": 0,
         "osm_way_ids": [
           170791368,
           8614532
@@ -1262,6 +1287,7 @@
       },
       "properties": {
         "dst_i": 133,
+        "layer": 0,
         "osm_way_ids": [
           170791370
         ],
@@ -1324,6 +1350,7 @@
       },
       "properties": {
         "dst_i": 130,
+        "layer": 0,
         "osm_way_ids": [
           170791370
         ],
@@ -1378,6 +1405,7 @@
       },
       "properties": {
         "dst_i": 132,
+        "layer": 0,
         "osm_way_ids": [
           170791370
         ],
@@ -1432,6 +1460,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           170791370
         ],
@@ -1478,6 +1507,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           195553642
         ],
@@ -1516,6 +1546,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           195553644
         ],
@@ -1554,6 +1585,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           195553671
         ],
@@ -1600,6 +1632,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           207815830,
           692656160
@@ -1639,6 +1672,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           207815830
         ],
@@ -1685,6 +1719,7 @@
       },
       "properties": {
         "dst_i": 47,
+        "layer": 0,
         "osm_way_ids": [
           207816746
         ],
@@ -1723,6 +1758,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           238634697
         ],
@@ -1761,6 +1797,7 @@
       },
       "properties": {
         "dst_i": 117,
+        "layer": 0,
         "osm_way_ids": [
           238634697
         ],
@@ -1807,6 +1844,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           238634697
         ],
@@ -1845,6 +1883,7 @@
       },
       "properties": {
         "dst_i": 43,
+        "layer": 0,
         "osm_way_ids": [
           238634697
         ],
@@ -1883,6 +1922,7 @@
       },
       "properties": {
         "dst_i": 102,
+        "layer": 0,
         "osm_way_ids": [
           238956293
         ],
@@ -1921,6 +1961,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           238956293
         ],
@@ -1959,6 +2000,7 @@
       },
       "properties": {
         "dst_i": 62,
+        "layer": 0,
         "osm_way_ids": [
           245866919
         ],
@@ -1997,6 +2039,7 @@
       },
       "properties": {
         "dst_i": 52,
+        "layer": 0,
         "osm_way_ids": [
           245866919
         ],
@@ -2035,6 +2078,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           289700825,
           326268770
@@ -2074,6 +2118,7 @@
       },
       "properties": {
         "dst_i": 56,
+        "layer": 0,
         "osm_way_ids": [
           289700826
         ],
@@ -2112,6 +2157,7 @@
       },
       "properties": {
         "dst_i": 55,
+        "layer": 0,
         "osm_way_ids": [
           289700827
         ],
@@ -2150,6 +2196,7 @@
       },
       "properties": {
         "dst_i": 58,
+        "layer": 0,
         "osm_way_ids": [
           289700827
         ],
@@ -2196,6 +2243,7 @@
       },
       "properties": {
         "dst_i": 98,
+        "layer": 0,
         "osm_way_ids": [
           289700829
         ],
@@ -2250,6 +2298,7 @@
       },
       "properties": {
         "dst_i": 60,
+        "layer": 0,
         "osm_way_ids": [
           289700829
         ],
@@ -2296,6 +2345,7 @@
       },
       "properties": {
         "dst_i": 62,
+        "layer": 0,
         "osm_way_ids": [
           324757118
         ],
@@ -2342,6 +2392,7 @@
       },
       "properties": {
         "dst_i": 64,
+        "layer": 0,
         "osm_way_ids": [
           326268789
         ],
@@ -2380,6 +2431,7 @@
       },
       "properties": {
         "dst_i": 80,
+        "layer": 0,
         "osm_way_ids": [
           372964760,
           1067864761,
@@ -2420,6 +2472,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           372964760
         ],
@@ -2458,6 +2511,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           376517850
         ],
@@ -2504,6 +2558,7 @@
       },
       "properties": {
         "dst_i": 44,
+        "layer": 0,
         "osm_way_ids": [
           376559958
         ],
@@ -2542,6 +2597,7 @@
       },
       "properties": {
         "dst_i": 69,
+        "layer": 0,
         "osm_way_ids": [
           376571542
         ],
@@ -2588,6 +2644,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           384169730
         ],
@@ -2650,6 +2707,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           384614786
         ],
@@ -2728,6 +2786,7 @@
       },
       "properties": {
         "dst_i": 70,
+        "layer": 0,
         "osm_way_ids": [
           384614787
         ],
@@ -2774,6 +2833,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           384736850
         ],
@@ -2828,6 +2888,7 @@
       },
       "properties": {
         "dst_i": 83,
+        "layer": 0,
         "osm_way_ids": [
           385685030
         ],
@@ -2866,6 +2927,7 @@
       },
       "properties": {
         "dst_i": 110,
+        "layer": 0,
         "osm_way_ids": [
           385685030
         ],
@@ -2904,6 +2966,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           385685030
         ],
@@ -2950,6 +3013,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           385685033
         ],
@@ -2988,6 +3052,7 @@
       },
       "properties": {
         "dst_i": 75,
+        "layer": 0,
         "osm_way_ids": [
           391783139
         ],
@@ -3026,6 +3091,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           391783265
         ],
@@ -3072,6 +3138,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           391783435
         ],
@@ -3118,6 +3185,7 @@
       },
       "properties": {
         "dst_i": 129,
+        "layer": 0,
         "osm_way_ids": [
           391783435
         ],
@@ -3164,6 +3232,7 @@
       },
       "properties": {
         "dst_i": 131,
+        "layer": 0,
         "osm_way_ids": [
           391783435
         ],
@@ -3210,6 +3279,7 @@
       },
       "properties": {
         "dst_i": 75,
+        "layer": 0,
         "osm_way_ids": [
           391783435
         ],
@@ -3248,6 +3318,7 @@
       },
       "properties": {
         "dst_i": 22,
+        "layer": 0,
         "osm_way_ids": [
           414489467
         ],
@@ -3286,6 +3357,7 @@
       },
       "properties": {
         "dst_i": 77,
+        "layer": 0,
         "osm_way_ids": [
           414489467
         ],
@@ -3324,6 +3396,7 @@
       },
       "properties": {
         "dst_i": 78,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3362,6 +3435,7 @@
       },
       "properties": {
         "dst_i": 84,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3400,6 +3474,7 @@
       },
       "properties": {
         "dst_i": 79,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3438,6 +3513,7 @@
       },
       "properties": {
         "dst_i": 80,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3476,6 +3552,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3514,6 +3591,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3552,6 +3630,7 @@
       },
       "properties": {
         "dst_i": 0,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3590,6 +3669,7 @@
       },
       "properties": {
         "dst_i": 82,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3628,6 +3708,7 @@
       },
       "properties": {
         "dst_i": 118,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3666,6 +3747,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3704,6 +3786,7 @@
       },
       "properties": {
         "dst_i": 67,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3766,6 +3849,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           414489468
         ],
@@ -3804,6 +3888,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           414489469
         ],
@@ -3842,6 +3927,7 @@
       },
       "properties": {
         "dst_i": 84,
+        "layer": 0,
         "osm_way_ids": [
           414489470
         ],
@@ -3880,6 +3966,7 @@
       },
       "properties": {
         "dst_i": 85,
+        "layer": 0,
         "osm_way_ids": [
           414489472
         ],
@@ -3918,6 +4005,7 @@
       },
       "properties": {
         "dst_i": 66,
+        "layer": 0,
         "osm_way_ids": [
           414489473
         ],
@@ -3980,6 +4068,7 @@
       },
       "properties": {
         "dst_i": 86,
+        "layer": 0,
         "osm_way_ids": [
           414489474
         ],
@@ -4018,6 +4107,7 @@
       },
       "properties": {
         "dst_i": 88,
+        "layer": 0,
         "osm_way_ids": [
           416813994
         ],
@@ -4056,6 +4146,7 @@
       },
       "properties": {
         "dst_i": 120,
+        "layer": 0,
         "osm_way_ids": [
           416813995
         ],
@@ -4094,6 +4185,7 @@
       },
       "properties": {
         "dst_i": 94,
+        "layer": 0,
         "osm_way_ids": [
           416813995
         ],
@@ -4132,6 +4224,7 @@
       },
       "properties": {
         "dst_i": 90,
+        "layer": 0,
         "osm_way_ids": [
           416813995
         ],
@@ -4170,6 +4263,7 @@
       },
       "properties": {
         "dst_i": 87,
+        "layer": 0,
         "osm_way_ids": [
           416813997
         ],
@@ -4208,6 +4302,7 @@
       },
       "properties": {
         "dst_i": 92,
+        "layer": 0,
         "osm_way_ids": [
           472241629
         ],
@@ -4262,6 +4357,7 @@
       },
       "properties": {
         "dst_i": 94,
+        "layer": 0,
         "osm_way_ids": [
           497716975
         ],
@@ -4324,6 +4420,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           497716975
         ],
@@ -4378,6 +4475,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           639129600
         ],
@@ -4424,6 +4522,7 @@
       },
       "properties": {
         "dst_i": 101,
+        "layer": 0,
         "osm_way_ids": [
           639129602
         ],
@@ -4462,6 +4561,7 @@
       },
       "properties": {
         "dst_i": 96,
+        "layer": 0,
         "osm_way_ids": [
           639129602
         ],
@@ -4500,6 +4600,7 @@
       },
       "properties": {
         "dst_i": 53,
+        "layer": 0,
         "osm_way_ids": [
           639129835
         ],
@@ -4554,6 +4655,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           639131232
         ],
@@ -4592,6 +4694,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           639131233
         ],
@@ -4638,6 +4741,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           639131234,
           195553645
@@ -4677,6 +4781,7 @@
       },
       "properties": {
         "dst_i": 97,
+        "layer": 0,
         "osm_way_ids": [
           639131235
         ],
@@ -4715,6 +4820,7 @@
       },
       "properties": {
         "dst_i": 40,
+        "layer": 0,
         "osm_way_ids": [
           639131236
         ],
@@ -4753,6 +4859,7 @@
       },
       "properties": {
         "dst_i": 99,
+        "layer": 0,
         "osm_way_ids": [
           665723648
         ],
@@ -4791,6 +4898,7 @@
       },
       "properties": {
         "dst_i": 101,
+        "layer": 0,
         "osm_way_ids": [
           665723650
         ],
@@ -4861,6 +4969,7 @@
       },
       "properties": {
         "dst_i": 103,
+        "layer": 0,
         "osm_way_ids": [
           691679653
         ],
@@ -4907,6 +5016,7 @@
       },
       "properties": {
         "dst_i": 91,
+        "layer": 0,
         "osm_way_ids": [
           692655614
         ],
@@ -4945,6 +5055,7 @@
       },
       "properties": {
         "dst_i": 73,
+        "layer": 0,
         "osm_way_ids": [
           692655616
         ],
@@ -4983,6 +5094,7 @@
       },
       "properties": {
         "dst_i": 107,
+        "layer": 0,
         "osm_way_ids": [
           692655619
         ],
@@ -5021,6 +5133,7 @@
       },
       "properties": {
         "dst_i": 109,
+        "layer": 0,
         "osm_way_ids": [
           692655620
         ],
@@ -5059,6 +5172,7 @@
       },
       "properties": {
         "dst_i": 26,
+        "layer": 0,
         "osm_way_ids": [
           692657140
         ],
@@ -5097,6 +5211,7 @@
       },
       "properties": {
         "dst_i": 110,
+        "layer": 0,
         "osm_way_ids": [
           744805932
         ],
@@ -5135,6 +5250,7 @@
       },
       "properties": {
         "dst_i": 112,
+        "layer": 0,
         "osm_way_ids": [
           744805933
         ],
@@ -5221,6 +5337,7 @@
       },
       "properties": {
         "dst_i": 71,
+        "layer": 0,
         "osm_way_ids": [
           749074721
         ],
@@ -5259,6 +5376,7 @@
       },
       "properties": {
         "dst_i": 46,
+        "layer": 0,
         "osm_way_ids": [
           749104030
         ],
@@ -5313,6 +5431,7 @@
       },
       "properties": {
         "dst_i": 116,
+        "layer": 0,
         "osm_way_ids": [
           827811098
         ],
@@ -5351,6 +5470,7 @@
       },
       "properties": {
         "dst_i": 118,
+        "layer": 0,
         "osm_way_ids": [
           966046560
         ],
@@ -5397,6 +5517,7 @@
       },
       "properties": {
         "dst_i": 120,
+        "layer": 0,
         "osm_way_ids": [
           966551635
         ],
@@ -5435,6 +5556,7 @@
       },
       "properties": {
         "dst_i": 122,
+        "layer": 0,
         "osm_way_ids": [
           967112705
         ],
@@ -5473,6 +5595,7 @@
       },
       "properties": {
         "dst_i": 124,
+        "layer": 0,
         "osm_way_ids": [
           967116266
         ],
@@ -5511,6 +5634,7 @@
       },
       "properties": {
         "dst_i": 125,
+        "layer": 0,
         "osm_way_ids": [
           967715649
         ],
@@ -5573,6 +5697,7 @@
       },
       "properties": {
         "dst_i": 127,
+        "layer": 0,
         "osm_way_ids": [
           988447904
         ],
@@ -5611,6 +5736,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           988447904
         ],
@@ -5673,6 +5799,7 @@
       },
       "properties": {
         "dst_i": 128,
+        "layer": 0,
         "osm_way_ids": [
           988447905
         ],
@@ -5711,6 +5838,7 @@
       },
       "properties": {
         "dst_i": 130,
+        "layer": 0,
         "osm_way_ids": [
           1066518362
         ],
@@ -5749,6 +5877,7 @@
       },
       "properties": {
         "dst_i": 132,
+        "layer": 0,
         "osm_way_ids": [
           1066518363
         ],
@@ -5787,6 +5916,7 @@
       },
       "properties": {
         "dst_i": 134,
+        "layer": 0,
         "osm_way_ids": [
           1066518364
         ],
@@ -5825,6 +5955,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           1067864758,
           1067864759
@@ -5864,6 +5995,7 @@
       },
       "properties": {
         "dst_i": 81,
+        "layer": 0,
         "osm_way_ids": [
           1067864760
         ],
@@ -5902,6 +6034,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           1067864762,
           1067864763
@@ -5941,6 +6074,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           1067864763,
           1067864764
@@ -5980,6 +6114,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           1067864764
         ],
@@ -6018,6 +6153,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           1069976319
         ],

--- a/tests/src/taipei/geometry.json
+++ b/tests/src/taipei/geometry.json
@@ -38,6 +38,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           33090413
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           51423083
         ],
@@ -114,6 +116,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           51423084
         ],
@@ -160,6 +163,7 @@
       },
       "properties": {
         "dst_i": 4,
+        "layer": 0,
         "osm_way_ids": [
           51423093
         ],
@@ -198,6 +202,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           51423093
         ],
@@ -236,6 +241,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           51885076
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           51885154
         ],
@@ -320,6 +327,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           51885154
         ],
@@ -358,6 +366,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           51885154
         ],
@@ -396,6 +405,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           51885159
         ],
@@ -434,6 +444,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           51885159
         ],
@@ -472,6 +483,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           51885164
         ],
@@ -510,6 +522,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           51885164
         ],
@@ -548,6 +561,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           51885164
         ],
@@ -586,6 +600,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           203799162
         ],
@@ -632,6 +647,7 @@
       },
       "properties": {
         "dst_i": 34,
+        "layer": 0,
         "osm_way_ids": [
           203799175,
           447726775
@@ -671,6 +687,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           289004429
         ],
@@ -709,6 +726,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           289004429
         ],
@@ -747,6 +765,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           306251259
         ],
@@ -785,6 +804,7 @@
       },
       "properties": {
         "dst_i": 24,
+        "layer": 0,
         "osm_way_ids": [
           306251259
         ],
@@ -823,6 +843,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           306251260
         ],
@@ -861,6 +882,7 @@
       },
       "properties": {
         "dst_i": 28,
+        "layer": 0,
         "osm_way_ids": [
           310620429
         ],
@@ -899,6 +921,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           310677980
         ],
@@ -937,6 +960,7 @@
       },
       "properties": {
         "dst_i": 29,
+        "layer": 0,
         "osm_way_ids": [
           310677986
         ],
@@ -975,6 +999,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           401523526
         ],
@@ -1013,6 +1038,7 @@
       },
       "properties": {
         "dst_i": 32,
+        "layer": 0,
         "osm_way_ids": [
           415405686
         ],
@@ -1051,6 +1077,7 @@
       },
       "properties": {
         "dst_i": 33,
+        "layer": 0,
         "osm_way_ids": [
           415405686
         ],
@@ -1105,6 +1132,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           461272339
         ],
@@ -1143,6 +1171,7 @@
       },
       "properties": {
         "dst_i": 37,
+        "layer": 0,
         "osm_way_ids": [
           461272339
         ],
@@ -1181,6 +1210,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           468047661
         ],
@@ -1219,6 +1249,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           468047664
         ],
@@ -1257,6 +1288,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           506351786
         ],
@@ -1295,6 +1327,7 @@
       },
       "properties": {
         "dst_i": 27,
+        "layer": 0,
         "osm_way_ids": [
           506351786
         ],
@@ -1341,6 +1374,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           506351807
         ],
@@ -1379,6 +1413,7 @@
       },
       "properties": {
         "dst_i": 41,
+        "layer": 0,
         "osm_way_ids": [
           506351807
         ],
@@ -1417,6 +1452,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           506351814
         ],
@@ -1463,6 +1499,7 @@
       },
       "properties": {
         "dst_i": 42,
+        "layer": 0,
         "osm_way_ids": [
           506351826
         ],
@@ -1501,6 +1538,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           506351837
         ],
@@ -1539,6 +1577,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           506351852
         ],
@@ -1577,6 +1616,7 @@
       },
       "properties": {
         "dst_i": 13,
+        "layer": 0,
         "osm_way_ids": [
           506351852
         ],
@@ -1615,6 +1655,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           506351852
         ],
@@ -1653,6 +1694,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           515156284
         ],
@@ -1691,6 +1733,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           515156284
         ],
@@ -1729,6 +1772,7 @@
       },
       "properties": {
         "dst_i": 39,
+        "layer": 0,
         "osm_way_ids": [
           515156285
         ],
@@ -1775,6 +1819,7 @@
       },
       "properties": {
         "dst_i": 30,
+        "layer": 0,
         "osm_way_ids": [
           515156290
         ],
@@ -1813,6 +1858,7 @@
       },
       "properties": {
         "dst_i": 48,
+        "layer": 0,
         "osm_way_ids": [
           1012478860
         ],
@@ -1859,6 +1905,7 @@
       },
       "properties": {
         "dst_i": 38,
+        "layer": 0,
         "osm_way_ids": [
           1047456820
         ],
@@ -1905,6 +1952,7 @@
       },
       "properties": {
         "dst_i": 50,
+        "layer": 0,
         "osm_way_ids": [
           1047456821
         ],

--- a/tests/src/tempe_light_rail/geometry.json
+++ b/tests/src/tempe_light_rail/geometry.json
@@ -30,6 +30,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           136876988
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           422264711
         ],
@@ -114,6 +116,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           422264712,
           422264712
@@ -153,6 +156,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           422264712
         ],
@@ -191,6 +195,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           436789564
         ],
@@ -237,6 +242,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           436789580
         ],
@@ -275,6 +281,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           436942356
         ],
@@ -313,6 +320,7 @@
       },
       "properties": {
         "dst_i": 10,
+        "layer": 0,
         "osm_way_ids": [
           436942361,
           436942361
@@ -352,6 +360,7 @@
       },
       "properties": {
         "dst_i": 15,
+        "layer": 0,
         "osm_way_ids": [
           436942362
         ],
@@ -390,6 +399,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           436942362
         ],
@@ -444,6 +454,7 @@
       },
       "properties": {
         "dst_i": 16,
+        "layer": 0,
         "osm_way_ids": [
           802759574
         ],
@@ -482,6 +493,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           845775034
         ],
@@ -528,6 +540,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           966022991
         ],
@@ -566,6 +579,7 @@
       },
       "properties": {
         "dst_i": 20,
+        "layer": 0,
         "osm_way_ids": [
           966022991
         ],
@@ -620,6 +634,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           966022995
         ],
@@ -658,6 +673,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           966022995
         ],

--- a/tests/src/tempe_split/geometry.json
+++ b/tests/src/tempe_split/geometry.json
@@ -38,6 +38,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           5607328
         ],
@@ -76,6 +77,7 @@
       },
       "properties": {
         "dst_i": 3,
+        "layer": 0,
         "osm_way_ids": [
           256917837
         ],
@@ -122,6 +124,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           436791113
         ],
@@ -160,6 +163,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           436791491
         ],
@@ -206,6 +210,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           436791498
         ],
@@ -244,6 +249,7 @@
       },
       "properties": {
         "dst_i": 11,
+        "layer": 0,
         "osm_way_ids": [
           436794680
         ],
@@ -282,6 +288,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           436794680
         ],
@@ -320,6 +327,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           436794701
         ],
@@ -358,6 +366,7 @@
       },
       "properties": {
         "dst_i": 8,
+        "layer": 0,
         "osm_way_ids": [
           436794701
         ],
@@ -396,6 +405,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           533573776
         ],
@@ -434,6 +444,7 @@
       },
       "properties": {
         "dst_i": 9,
+        "layer": 0,
         "osm_way_ids": [
           533573776
         ],
@@ -472,6 +483,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           533573779
         ],
@@ -510,6 +522,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           600096923
         ],
@@ -548,6 +561,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           600096923
         ],
@@ -586,6 +600,7 @@
       },
       "properties": {
         "dst_i": 12,
+        "layer": 0,
         "osm_way_ids": [
           600096923
         ],
@@ -624,6 +639,7 @@
       },
       "properties": {
         "dst_i": 14,
+        "layer": 0,
         "osm_way_ids": [
           709820488
         ],
@@ -670,6 +686,7 @@
       },
       "properties": {
         "dst_i": 17,
+        "layer": 0,
         "osm_way_ids": [
           709820624
         ],
@@ -708,6 +725,7 @@
       },
       "properties": {
         "dst_i": 19,
+        "layer": 0,
         "osm_way_ids": [
           762209212
         ],
@@ -746,6 +764,7 @@
       },
       "properties": {
         "dst_i": 21,
+        "layer": 0,
         "osm_way_ids": [
           913174428
         ],
@@ -848,6 +867,7 @@
       },
       "properties": {
         "dst_i": 23,
+        "layer": 0,
         "osm_way_ids": [
           1084112485
         ],
@@ -886,6 +906,7 @@
       },
       "properties": {
         "dst_i": 25,
+        "layer": 0,
         "osm_way_ids": [
           1084112509
         ],

--- a/tests/src/tiny_loop/geometry.json
+++ b/tests/src/tiny_loop/geometry.json
@@ -70,6 +70,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           21639584
         ],
@@ -108,6 +109,7 @@
       },
       "properties": {
         "dst_i": 2,
+        "layer": 0,
         "osm_way_ids": [
           21639584
         ],
@@ -162,6 +164,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           21639584
         ],
@@ -224,6 +227,7 @@
       },
       "properties": {
         "dst_i": 1,
+        "layer": 0,
         "osm_way_ids": [
           21639584
         ],
@@ -366,6 +370,7 @@
       },
       "properties": {
         "dst_i": 6,
+        "layer": 0,
         "osm_way_ids": [
           21640660
         ],
@@ -420,6 +425,7 @@
       },
       "properties": {
         "dst_i": 5,
+        "layer": 0,
         "osm_way_ids": [
           21642266
         ],
@@ -458,6 +464,7 @@
       },
       "properties": {
         "dst_i": 7,
+        "layer": 0,
         "osm_way_ids": [
           21643579
         ],


### PR DESCRIPTION
Requested by @jakecoppinger. This is https://wiki.openstreetmap.org/wiki/Key:layer, usually 0.

I was unsuccessful in getting Leaflet to use this for z-index. I tried sorting GeoJSON features by the layer, but there are problems between layers. The lane polygon and lane markings layers are separate, but both should respect a global z-index. Leaflet does this with https://leafletjs.com/examples/map-panes/, but you can't change a layer's pane after creation, and you also can't specify a different pane for each feature created from GeoJSON, AFAICT. Hopefully it's easier in MapLibre.

Test diffs are just the new property showing up