### PR TITLE
Remove the useless RefCell from debugging calls, letting StreetNetwork

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -113,10 +113,8 @@ impl JsStreetNetwork {
 
     #[wasm_bindgen(js_name = getDebugSteps)]
     pub fn get_debug_steps(&self) -> Vec<JsValue> {
-        // TODO Figure out how to borrow from the RefCell instead of cloning
         self.inner
             .debug_steps
-            .borrow()
             .iter()
             .map(|x| JsValue::from(JsDebugStreets { inner: x.clone() }))
             .collect()

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -3,7 +3,6 @@ extern crate anyhow;
 #[macro_use]
 extern crate log;
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -58,7 +57,7 @@ pub struct StreetNetwork {
     pub config: MapConfig,
 
     #[serde(skip_serializing, skip_deserializing)]
-    pub debug_steps: RefCell<Vec<DebugStreets>>,
+    pub debug_steps: Vec<DebugStreets>,
 
     intersection_id_counter: usize,
     road_id_counter: usize,
@@ -86,7 +85,7 @@ impl StreetNetwork {
             gps_bounds: GPSBounds::new(),
             config: MapConfig::default(),
 
-            debug_steps: RefCell::new(Vec::new()),
+            debug_steps: Vec::new(),
 
             intersection_id_counter: 0,
             road_id_counter: 0,
@@ -145,7 +144,7 @@ impl StreetNetwork {
             .collect()
     }
 
-    pub(crate) fn start_debug_step<I: Into<String>>(&self, label: I) {
+    pub(crate) fn start_debug_step<I: Into<String>>(&mut self, label: I) {
         let copy = DebugStreets {
             label: label.into(),
             streets: StreetNetwork {
@@ -154,41 +153,41 @@ impl StreetNetwork {
                 boundary_polygon: self.boundary_polygon.clone(),
                 gps_bounds: self.gps_bounds.clone(),
                 config: self.config.clone(),
-                debug_steps: RefCell::new(Vec::new()),
+                debug_steps: Vec::new(),
                 intersection_id_counter: self.intersection_id_counter,
                 road_id_counter: self.road_id_counter,
             },
             points: Vec::new(),
             polylines: Vec::new(),
         };
-        self.debug_steps.borrow_mut().push(copy);
+        self.debug_steps.push(copy);
     }
 
     /// Only start a new debug step if there's at least one already (indicating that debugging is
     /// enabled).
-    pub(crate) fn maybe_start_debug_step<I: Into<String>>(&self, label: I) {
-        if self.debug_steps.borrow().is_empty() {
+    pub(crate) fn maybe_start_debug_step<I: Into<String>>(&mut self, label: I) {
+        if self.debug_steps.is_empty() {
             return;
         }
         self.start_debug_step(label);
     }
 
-    pub(crate) fn debug_intersection<I: Into<String>>(&self, i: IntersectionID, label: I) {
-        if let Some(step) = self.debug_steps.borrow_mut().last_mut() {
+    pub(crate) fn debug_intersection<I: Into<String>>(&mut self, i: IntersectionID, label: I) {
+        if let Some(step) = self.debug_steps.last_mut() {
             step.points
                 .push((self.intersections[&i].polygon.center(), label.into()));
         }
     }
 
-    pub(crate) fn debug_road<I: Into<String>>(&self, r: RoadID, label: I) {
-        if let Some(step) = self.debug_steps.borrow_mut().last_mut() {
+    pub(crate) fn debug_road<I: Into<String>>(&mut self, r: RoadID, label: I) {
+        if let Some(step) = self.debug_steps.last_mut() {
             step.polylines
                 .push((self.roads[&r].center_line.clone(), label.into()));
         }
     }
 
-    pub(crate) fn debug_point<I: Into<String>>(&self, pt: Pt2D, label: I) {
-        if let Some(step) = self.debug_steps.borrow_mut().last_mut() {
+    pub(crate) fn debug_point<I: Into<String>>(&mut self, pt: Pt2D, label: I) {
+        if let Some(step) = self.debug_steps.last_mut() {
             step.points.push((pt, label.into()));
         }
     }
@@ -219,4 +218,16 @@ impl RestrictionType {
             None
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    // Check at compile-time if StreetNetwork can be shared across a thread. If a RefCell or
+    // something sneaks in anywhere, this'll fail.
+    #[test]
+    fn test_sync() {
+        must_be_sync(super::StreetNetwork::blank());
+    }
+
+    fn must_be_sync<T: Sync>(_x: T) {}
 }

--- a/osm2streets/src/transform/dual_carriageways.rs
+++ b/osm2streets/src/transform/dual_carriageways.rs
@@ -90,7 +90,7 @@ impl MultiConnection {
         None
     }
 
-    fn debug(&self, streets: &StreetNetwork) {
+    fn debug(&self, streets: &mut StreetNetwork) {
         streets.debug_intersection(self.i, "join/split that isnt DC");
         streets.debug_road(self.side1, "side1 of failed DC");
         streets.debug_road(self.side2, "side2 of failed DC");
@@ -150,7 +150,7 @@ impl DualCarriagewayPt1 {
         None
     }
 
-    fn debug(&self, streets: &StreetNetwork) {
+    fn debug(&self, streets: &mut StreetNetwork) {
         streets.debug_intersection(self.src_i, format!("start of {}", self.road_name));
         streets.debug_intersection(self.dst_i, "end");
         for (idx, r) in self.side1.iter().enumerate() {
@@ -322,7 +322,7 @@ impl DualCarriagewayPt2 {
         (branches, bridges)
     }
 
-    fn debug(&self, streets: &StreetNetwork) {
+    fn debug(&self, streets: &mut StreetNetwork) {
         streets.debug_intersection(self.src_i, format!("start of {}", self.road_name));
         streets.debug_intersection(self.dst_i, "end");
         for (idx, r) in self.side1.iter().enumerate() {

--- a/osm2streets/src/transform/separate_cycletracks.rs
+++ b/osm2streets/src/transform/separate_cycletracks.rs
@@ -37,7 +37,7 @@ struct Cycleway {
 }
 
 impl Cycleway {
-    fn debug(&self, streets: &StreetNetwork) {
+    fn debug(&self, streets: &mut StreetNetwork) {
         streets.debug_road(self.cycleway, format!("cycleway {}", self.debug_idx));
         streets.debug_intersection(self.main_road_src_i, format!("src_i of {}", self.debug_idx));
         streets.debug_intersection(self.main_road_dst_i, format!("dst_i of {}", self.debug_idx));


### PR DESCRIPTION
become Send. #179

I first did this the hard way in https://github.com/a-b-street/osm2streets/tree/debug_sendsync, splitting out a separate `Debugger` type. But as I was opening that PR, I asked myself why couldn't all the `debug_` methods just take `&mut`, and... turns out they can. Anywhere that's modifying streets and wants to record interesting debug stuff already has a mutable reference.