### PR TITLE
Parse and paint turn arrows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "driving-side"
 version = "0.1.0"
 source = "git+https://github.com/a-b-street/osm2lanes#997d5ed09c4ec5775111d3dcd306d83aaf50696a"
@@ -253,6 +287,28 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4da76b3b6116d758c7ba93f7ec6a35d2e2cf24feda76c6e38a375f4d5c59f2"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumset"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -320,6 +376,12 @@ checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-err"
@@ -455,6 +517,12 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -707,6 +775,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "anyhow",
+ "enumset",
  "geo",
  "geom",
  "itertools",

--- a/osm2streets/Cargo.toml
+++ b/osm2streets/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.66"
 [dependencies]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = { workspace = true }
+enumset = { version = "1.0.12", features=["serde"] }
 geo = "0.23.0"
 geom = { git = "https://github.com/a-b-street/abstreet" }
 itertools = "0.10.5"

--- a/osm2streets/src/edit/add_bike_lanes.rs
+++ b/osm2streets/src/edit/add_bike_lanes.rs
@@ -81,7 +81,7 @@ impl LaneSpec {
                     lt: LaneType::Biking,
                     dir,
                     width: LaneSpec::typical_lane_width(LaneType::Biking),
-                    turn_restrictions: Vec::new(),
+                    allowed_turns: Default::default(),
                 };
                 if let Some(buffer) = buffer_type {
                     side.insert(
@@ -90,7 +90,7 @@ impl LaneSpec {
                             lt: LaneType::Buffer(buffer),
                             dir,
                             width: LaneSpec::typical_lane_width(LaneType::Buffer(buffer)),
-                            turn_restrictions: Vec::new(),
+                            allowed_turns: Default::default(),
                         },
                     );
                 }

--- a/osm2streets/src/edit/add_new_lane.rs
+++ b/osm2streets/src/edit/add_new_lane.rs
@@ -101,7 +101,7 @@ impl LaneSpec {
                 lt,
                 dir,
                 width: LaneSpec::typical_lane_widths(lt, highway_type)[0].0,
-                turn_restrictions: Vec::new(),
+                allowed_turns: Default::default(),
             },
         );
         idx

--- a/osm2streets/src/edit/mod.rs
+++ b/osm2streets/src/edit/mod.rs
@@ -26,7 +26,7 @@ impl LaneSpec {
                 },
                 // Dummy
                 width: Distance::ZERO,
-                turn_restrictions: Vec::new(),
+                allowed_turns: Default::default(),
             })
             .collect()
     }

--- a/osm2streets/src/geometry/mod.rs
+++ b/osm2streets/src/geometry/mod.rs
@@ -61,7 +61,7 @@ impl InputRoad {
                 lt: crate::LaneType::Driving,
                 dir: crate::Direction::Fwd,
                 width: self.total_width,
-                turn_restrictions: Vec::new(),
+                allowed_turns: Default::default(),
             }],
             // Mostly dummy values, except for what selfEdge::calculate needs
             osm_ids: Vec::new(),

--- a/osm2streets/src/lanes/mod.rs
+++ b/osm2streets/src/lanes/mod.rs
@@ -5,7 +5,7 @@ mod placement;
 mod tests;
 mod turns;
 
-use enumset::EnumSet;
+use enumset::{EnumSet, EnumSetType};
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -264,7 +264,8 @@ pub struct LaneSpec {
     pub lt: LaneType,
     pub dir: Direction,
     pub width: Distance,
-    /// Turn restrictions for this lane. An empty set indicates no indicated restrictions (though
+    /// Turn restrictions for this lane. An empty set represents that no restrictions are indicated
+    /// (though local rules might still dictate restrictions).
     /// Turns for specific vehicle types (`turn:bus:lanes` and such) are not yet captured.
     pub allowed_turns: EnumSet<TurnDirection>,
 }
@@ -435,20 +436,23 @@ impl fmt::Display for Direction {
     }
 }
 
-pub type TurnDirections = EnumSet<TurnDirection>;
-
 /// A turn direction as defined by <https://wiki.openstreetmap.org/wiki/Key:turn>.
-#[derive(Debug, enumset::EnumSetType)]
+#[derive(Debug, EnumSetType)]
 pub enum TurnDirection {
     Through,
     Left,
     Right,
+    /// A turn to the left of less than 90 degrees. Not to be confused with a merge or a highway exit.
     SlightLeft,
+    /// A turn to the right of less than 90 degrees. Not to be confused with a merge or a highway exit.
     SlightRight,
     SharpLeft,
     SharpRight,
+    /// A merge one lane to the left, or a highway exit on the left.
     MergeLeft,
+    /// A merge one lane to the right, or a highway exit on the right.
     MergeRight,
+    /// A full 180 degree turn, aka a U-turn.
     Reverse,
 }
 

--- a/osm2streets/src/lanes/mod.rs
+++ b/osm2streets/src/lanes/mod.rs
@@ -3,7 +3,9 @@ mod osm2lanes;
 mod placement;
 #[cfg(test)]
 mod tests;
+mod turns;
 
+use enumset::EnumSet;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -262,10 +264,9 @@ pub struct LaneSpec {
     pub lt: LaneType,
     pub dir: Direction,
     pub width: Distance,
-    /// Turn indications specific to this lane, from
-    /// <https://wiki.openstreetmap.org/wiki/Key:turn>. Turns for specific vehicle types
-    /// (`turn:bus:lanes` and such) are not yet captured.
-    pub turn_restrictions: Vec<String>,
+    /// Turn restrictions for this lane. An empty set indicates no indicated restrictions (though
+    /// Turns for specific vehicle types (`turn:bus:lanes` and such) are not yet captured.
+    pub allowed_turns: EnumSet<TurnDirection>,
 }
 
 impl LaneSpec {
@@ -432,6 +433,23 @@ impl fmt::Display for Direction {
             Direction::Back => write!(f, "backwards"),
         }
     }
+}
+
+pub type TurnDirections = EnumSet<TurnDirection>;
+
+/// A turn direction as defined by <https://wiki.openstreetmap.org/wiki/Key:turn>.
+#[derive(Debug, enumset::EnumSetType)]
+pub enum TurnDirection {
+    Through,
+    Left,
+    Right,
+    SlightLeft,
+    SlightRight,
+    SharpLeft,
+    SharpRight,
+    MergeLeft,
+    MergeRight,
+    Reverse,
 }
 
 /// Refers to a lane by its left-to-right position among all lanes in that direction. Backward

--- a/osm2streets/src/lanes/osm2lanes.rs
+++ b/osm2streets/src/lanes/osm2lanes.rs
@@ -17,7 +17,7 @@ pub fn get_lane_specs_ltr_experimental(orig_tags: &Tags, cfg: &MapConfig) -> Vec
             lt: LaneType::LightRail,
             dir: Direction::Fwd,
             width: LaneSpec::typical_lane_width(LaneType::LightRail),
-            turn_restrictions: Vec::new(),
+            allowed_turns: Default::default(),
         }];
     }
 
@@ -33,7 +33,7 @@ pub fn get_lane_specs_ltr_experimental(orig_tags: &Tags, cfg: &MapConfig) -> Vec
                 lt: LaneType::Driving,
                 dir: Direction::Fwd,
                 width: Distance::meters(1.0),
-                turn_restrictions: Vec::new(),
+                allowed_turns: Default::default(),
             }]
         }
     }
@@ -205,7 +205,7 @@ fn transform_lane(
             lt,
             dir,
             width,
-            turn_restrictions: Vec::new(),
+            allowed_turns: Default::default(),
         }])
     };
 
@@ -283,13 +283,13 @@ fn bidirectional_lane(lt: LaneType, total_width: Distance, cfg: &MapConfig) -> V
             lt,
             dir: dir1,
             width: total_width / 2.0,
-            turn_restrictions: Vec::new(),
+            allowed_turns: Default::default(),
         },
         LaneSpec {
             lt,
             dir: dir2,
             width: total_width / 2.0,
-            turn_restrictions: Vec::new(),
+            allowed_turns: Default::default(),
         },
     ]
 }

--- a/osm2streets/src/lanes/turns.rs
+++ b/osm2streets/src/lanes/turns.rs
@@ -1,10 +1,30 @@
 use anyhow::Result;
 use enumset::EnumSet;
+use geom::Angle;
 
 use super::{TurnDirection, TurnDirection::*};
 
 impl TurnDirection {
-    pub fn tag_value(self) -> &'static str {
+    pub fn turn_angle(&self) -> Angle {
+        match self {
+            Through => Angle::degrees(0.),
+            SlightRight => Angle::degrees(45.),
+            SlightLeft => Angle::degrees(-45.),
+            MergeRight => Angle::degrees(45.),
+            MergeLeft => Angle::degrees(-45.),
+            Right => Angle::degrees(90.),
+            Left => Angle::degrees(-90.),
+            SharpRight => Angle::degrees(135.),
+            SharpLeft => Angle::degrees(-135.),
+            Reverse => Angle::degrees(180.),
+        }
+    }
+
+    pub fn is_merge(&self) -> bool {
+        matches!(self, MergeLeft | MergeRight)
+    }
+
+    pub fn tag_value(&self) -> &'static str {
         match self {
             Through => "through",
             Left => "left",

--- a/osm2streets/src/lanes/turns.rs
+++ b/osm2streets/src/lanes/turns.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use enumset::EnumSet;
+
+use super::{TurnDirection, TurnDirection::*};
+
+impl TurnDirection {
+    pub fn tag_value(self) -> &'static str {
+        match self {
+            Through => "through",
+            Left => "left",
+            Right => "right",
+            SlightLeft => "slight_left",
+            SlightRight => "slight_right",
+            SharpLeft => "sharp_left",
+            SharpRight => "sharp_right",
+            MergeLeft => "merge_left",
+            MergeRight => "merge_right",
+            Reverse => "reverse",
+        }
+    }
+
+    /// Tries to parse a single turn direction from an osm tag value as per the `turn` scheme,
+    /// defined at <https://wiki.openstreetmap.org/wiki/Key:turn>.
+    pub fn parse(value: &str) -> Result<Option<Self>> {
+        match value {
+            "" | "none" => Ok(None),
+            "through" => Ok(Some(Through)),
+            "left" => Ok(Some(Left)),
+            "right" => Ok(Some(Right)),
+            "slight_left" => Ok(Some(SlightLeft)),
+            "slight_right" => Ok(Some(SlightRight)),
+            "sharp_left" => Ok(Some(SharpLeft)),
+            "sharp_right" => Ok(Some(SharpRight)),
+            "merge_to_left" => Ok(Some(MergeLeft)),
+            "merge_to_right" => Ok(Some(MergeRight)),
+            "reverse" => Ok(Some(Reverse)),
+            _ => bail!("unknown turn direction: {value}"),
+        }
+    }
+
+    /// Tries to parse a set of turn directions from an OSM tag value according to the `turn` scheme
+    /// defined at <https://wiki.openstreetmap.org/wiki/Key:turn>.
+    pub fn parse_set(value: &str) -> Result<EnumSet<Self>> {
+        let mut result = EnumSet::new();
+        for dir_str in value.split(';') {
+            if let Some(dir) = TurnDirection::parse(dir_str)? {
+                result.insert(dir);
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    use crate::lanes::TurnDirection;
+    use crate::lanes::TurnDirection::*;
+    use enumset::EnumSet;
+
+    #[test]
+    fn turn_direction_parses() {
+        assert_eq!(TurnDirection::parse("").unwrap(), None);
+        assert_eq!(TurnDirection::parse("none").unwrap(), None);
+
+        for (input, expected) in [
+            ("through", Through),
+            ("left", Left),
+            ("right", Right),
+            ("slight_left", SlightLeft),
+            ("slight_right", SlightRight),
+            ("sharp_left", SharpLeft),
+            ("sharp_right", SharpRight),
+            ("merge_to_left", MergeLeft),
+            ("merge_to_right", MergeRight),
+            ("reverse", Reverse),
+        ] {
+            assert_eq!(TurnDirection::parse(input).unwrap(), Some(expected));
+        }
+
+        assert!(TurnDirection::parse("not_a_valid_turn").is_err());
+    }
+
+    #[test]
+    fn turn_directions_parses() {
+        assert_eq!(TurnDirection::parse_set("").unwrap(), EnumSet::empty());
+        assert_eq!(
+            TurnDirection::parse_set("through").unwrap(),
+            EnumSet::only(Through)
+        );
+        assert_eq!(
+            TurnDirection::parse_set("through;right").unwrap(),
+            Through | Right
+        );
+    }
+}

--- a/osm2streets/src/marking.rs
+++ b/osm2streets/src/marking.rs
@@ -13,7 +13,7 @@
 // We use geom and stay in map space. Output is done in latlon.
 use geom::{Angle, Line, PolyLine, Polygon, Pt2D};
 
-use crate::lanes::TrafficClass;
+use crate::lanes::{TrafficClass, TurnDirections};
 use crate::LaneType;
 
 /// A marking painted on the road surface to direct traffic.
@@ -63,29 +63,6 @@ pub enum Symbol {
     TrafficMode(TrafficClass),
     /// A marking indicating which turns may be performed.
     TurnArrow(TurnDirections),
-}
-
-/// A set of turn directions that are allowed.
-// TODO: move to lanes/mod.rs
-pub struct TurnDirections {
-    through: bool,
-    left: bool,
-    right: bool,
-    slight_left: bool,
-    slight_right: bool,
-    reverse: bool,
-}
-impl TurnDirections {
-    pub fn through() -> Self {
-        TurnDirections {
-            through: true,
-            left: false,
-            right: false,
-            slight_left: false,
-            slight_right: false,
-            reverse: false,
-        }
-    }
 }
 
 pub enum Area {

--- a/osm2streets/src/marking.rs
+++ b/osm2streets/src/marking.rs
@@ -10,10 +10,11 @@
 //! definitions so that they can distinguish all the distinct situations that OSM represents around
 //! the world that have distinct markings in one of the supported locales.
 
+use enumset::EnumSet;
 // We use geom and stay in map space. Output is done in latlon.
 use geom::{Angle, Line, PolyLine, Polygon, Pt2D};
 
-use crate::lanes::{TrafficClass, TurnDirections};
+use crate::lanes::{TrafficClass, TurnDirection};
 use crate::LaneType;
 
 /// A marking painted on the road surface to direct traffic.
@@ -62,7 +63,7 @@ pub enum Symbol {
     /// A marking indicating a mode of traffic that is allowed.
     TrafficMode(TrafficClass),
     /// A marking indicating which turns may be performed.
-    TurnArrow(TurnDirections),
+    TurnArrow(EnumSet<TurnDirection>),
 }
 
 pub enum Area {
@@ -80,7 +81,7 @@ impl RoadMarking {
         RoadMarking::Transverse(geometry, kind)
     }
 
-    pub fn turn_arrow(geometry: Pt2D, angle: Angle, turns: TurnDirections) -> Self {
+    pub fn turn_arrow(geometry: Pt2D, angle: Angle, turns: EnumSet<TurnDirection>) -> Self {
         RoadMarking::Symbol(geometry, angle, Symbol::TurnArrow(turns))
     }
 

--- a/osm2streets/src/output.rs
+++ b/osm2streets/src/output.rs
@@ -5,7 +5,7 @@ use geo::MapCoordsInPlace;
 use geom::{Distance, Line, Pt2D};
 
 use crate::lanes::{RoadPosition, TrafficClass};
-use crate::marking::{LongitudinalLine, RoadMarking, Transverse, TurnDirections};
+use crate::marking::{LongitudinalLine, RoadMarking, Transverse};
 use crate::paint::PaintArea;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -267,8 +267,7 @@ impl StreetNetwork {
                     markings.push(RoadMarking::turn_arrow(
                         pt,
                         rev_angle.opposite(),
-                        // TODO use lane.turn_restrictions
-                        TurnDirections::through(),
+                        lane.allowed_turns.clone(),
                     ))
                 }
             }

--- a/osm2streets/src/paint.rs
+++ b/osm2streets/src/paint.rs
@@ -208,8 +208,8 @@ impl Paint<(Pt2D, Angle)> for marking::Symbol {
                     ])
                     .dashed_arrow(
                         thickness,
-                        thickness * 2.0,
-                        thickness * 0.8,
+                        Distance::meters(0.5),
+                        Distance::meters(0.25),
                         geom::ArrowCap::Triangle,
                     );
                     arrow

--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -106,12 +106,11 @@ impl StreetNetwork {
                         ("width", lane.width.inner_meters().into()),
                         ("direction", format!("{:?}", lane.dir).into()),
                         (
-                            "turn_restrictions",
+                            "allowed_turns",
                             serde_json::Value::Array(
-                                lane.turn_restrictions
+                                lane.allowed_turns
                                     .iter()
-                                    .cloned()
-                                    .map(|x| x.into())
+                                    .map(|d| d.tag_value().into())
                                     .collect(),
                             ),
                         ),

--- a/osm2streets/src/transform/sausage_links.rs
+++ b/osm2streets/src/transform/sausage_links.rs
@@ -128,7 +128,7 @@ fn fix(streets: &mut StreetNetwork, id1: RoadID, id2: RoadID) {
                 lt: LaneType::Buffer(BufferType::Curb),
                 dir: Direction::Fwd,
                 width: LaneSpec::typical_lane_width(LaneType::Buffer(BufferType::Curb)),
-                turn_restrictions: Vec::new(),
+                allowed_turns: Default::default(),
             },
         );
 
@@ -149,7 +149,7 @@ fn fix(streets: &mut StreetNetwork, id1: RoadID, id2: RoadID) {
             lt: LaneType::Buffer(BufferType::Curb),
             dir: Direction::Fwd,
             width: LaneSpec::typical_lane_width(LaneType::Buffer(BufferType::Curb)),
-            turn_restrictions: Vec::new(),
+            allowed_turns: Default::default(),
         });
 
         for mut lane in road2.lane_specs_ltr {

--- a/osm2streets/src/transform/separate_cycletracks.rs
+++ b/osm2streets/src/transform/separate_cycletracks.rs
@@ -123,7 +123,7 @@ fn snap(streets: &mut StreetNetwork, input: Cycleway) {
         lt: LaneType::Buffer(BufferType::Planters),
         dir: Direction::Fwd,
         width: LaneSpec::typical_lane_width(LaneType::Buffer(BufferType::Planters)),
-        turn_restrictions: Vec::new(),
+        allowed_turns: Default::default(),
     };
 
     // For every main road segment corresponding to the cycleway, we need to insert these


### PR DESCRIPTION
The implicit arrows (drawn when there are no turn arrows specified) shown at the bottom need tweaking, but otherwise this looks serviceable!

`EnumSet` is super easy to use and very ergonomic.

![image](https://user-images.githubusercontent.com/3784591/218317727-05085558-c887-425d-ab99-6bbd51689094.png)
