### PR TITLE
Add turn movements

### DIFF
--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
-use geom::{Circle, Distance, Polygon, Pt2D};
+use geom::{Circle, Distance, PolyLine, Polygon, Pt2D};
 use serde::{Deserialize, Serialize};
 
+use crate::lanes::LtrLaneNum;
 use crate::{osm, DrivingSide, IntersectionID, RoadID, StreetNetwork};
 use TrafficConflict::*;
 
@@ -24,7 +25,7 @@ pub struct Intersection {
     /// All roads connected to this intersection. They may be incoming or outgoing relative to this
     /// intersection. They're ordered clockwise around the intersection.
     pub roads: Vec<RoadID>,
-    pub movements: Vec<Movement>,
+    pub turns: Vec<Turn>,
 
     // true if src_i matches this intersection (or the deleted/consolidated one, whatever)
     // TODO Store start/end trim distance on _every_ road
@@ -81,8 +82,29 @@ pub enum IntersectionControl {
     Construction,
 }
 
-/// The path that some group of adjacent lanes of traffic can take through an intersection.
-pub type Movement = (RoadID, RoadID);
+/// A manoeuvre that traffic can make through an intersection, from one road to another.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Turn {
+    pub from: RoadID,
+    pub to: RoadID,
+    pub via: IntersectionID,
+    // direction: TurnDirection,
+    /// The lane level movements, if they have been calculated.
+    pub movements: Option<Vec<TurnMovement>>,
+}
+
+/// A specific path that a vehicle can take through a turn.
+///
+/// Lane numbers are counted from the perspective of the direction of the turn.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TurnMovement {
+    /// The lane of the "from" road that the movement starts in.
+    pub from: LtrLaneNum,
+    /// The lane of the "to" road that the movement ends in.
+    pub to: LtrLaneNum,
+    /// The path of travel.
+    pub center_line: PolyLine,
+}
 
 impl Intersection {
     pub fn is_map_edge(&self) -> bool {
@@ -132,7 +154,7 @@ impl StreetNetwork {
                 control,
                 // Filled out later
                 roads: Vec::new(),
-                movements: Vec::new(),
+                turns: Vec::new(),
                 trim_roads_for_merging: BTreeMap::new(),
             },
         );
@@ -200,22 +222,22 @@ impl StreetNetwork {
     /// movements.
     pub fn update_i(&mut self, i: IntersectionID) {
         self.update_geometry(i);
-        self.update_movements(i);
+        self.update_turns(i);
     }
 
-    /// The kind and movements of a `MapEdge` are handled independently, so this method skips them.
-    pub(crate) fn update_movements(&mut self, i: IntersectionID) {
+    /// The kind and turns of a `MapEdge` are handled independently, so this method skips them.
+    pub(crate) fn update_turns(&mut self, i: IntersectionID) {
         if self.intersections[&i].kind == IntersectionKind::MapEdge {
             return;
         }
 
-        let (movements, kind) = self.calculate_movements_and_kind(i);
+        let (turns, kind) = self.calculate_turns_and_kind(i);
         let intersection = self.intersections.get_mut(&i).unwrap();
-        intersection.movements = movements;
+        intersection.turns = turns;
         intersection.kind = kind;
     }
 
-    fn calculate_movements_and_kind(&self, i: IntersectionID) -> (Vec<Movement>, IntersectionKind) {
+    fn calculate_turns_and_kind(&self, i: IntersectionID) -> (Vec<Turn>, IntersectionKind) {
         let roads: Vec<_> = self
             .roads_per_intersection(i)
             .into_iter()
@@ -227,7 +249,7 @@ impl StreetNetwork {
             return (Vec::new(), IntersectionKind::Terminus);
         }
 
-        // Calculate all the possible movements, (except U-turns, for now).
+        // Calculate all the possible turns, (except U-turns, for now).
         let mut connections = Vec::new();
         // Consider all pairs of roads, from s to d.
         // Identify them using their index in the list - which
@@ -250,7 +272,7 @@ impl StreetNetwork {
                     continue;
                 }
 
-                // TODO detect U-Turns that should be assumed forbidden.
+                // TODO detect U-Turns that should be assumed forbidden (though probably not here)
                 // if src and dst are oneway and
                 // adjacent on the intersection and
                 // ordered with the "insides" touching and
@@ -263,7 +285,7 @@ impl StreetNetwork {
             }
         }
 
-        // Calculate the highest level of conflict between movements.
+        // Calculate the highest level of conflict between turns.
         let mut worst_conflict = Uncontested;
         // Compare every unordered pair of connections. Use the order of the roads around the
         // intersection to detect if they diverge, merge, or cross.
@@ -285,7 +307,7 @@ impl StreetNetwork {
         (
             connections
                 .iter()
-                .map(|(s, d)| (roads[*s].id, roads[*d].id))
+                .map(|(s, d)| Turn::new(roads[*s].id, roads[*d].id, i))
                 .collect(),
             match worst_conflict {
                 Uncontested => IntersectionKind::Connection,
@@ -365,4 +387,15 @@ fn is_between(num: usize, range: &(usize, usize)) -> bool {
     let bot = std::cmp::min(range.0, range.1);
     let top = std::cmp::max(range.0, range.1);
     return bot < num && num < top;
+}
+
+impl Turn {
+    pub fn new(from: RoadID, to: RoadID, via: IntersectionID) -> Self {
+        Self {
+            from,
+            to,
+            via,
+            movements: None,
+        }
+    }
 }

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -14,7 +14,7 @@ pub use self::geometry::{intersection_polygon, InputRoad};
 pub(crate) use self::ids::RoadWithEndpoints;
 pub use self::ids::{CommonEndpoint, IntersectionID, LaneID, RoadID};
 pub use self::intersection::{
-    Intersection, IntersectionControl, IntersectionKind, Turn, TrafficConflict,
+    Intersection, IntersectionControl, IntersectionKind, TrafficConflict, Turn,
 };
 pub use self::lanes::{
     get_lane_specs_ltr, BufferType, Direction, LaneSpec, LaneType, Placement,
@@ -30,6 +30,7 @@ mod ids;
 mod intersection;
 mod lanes;
 mod marking;
+mod movements;
 mod operations;
 pub mod osm;
 mod output;

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -14,7 +14,7 @@ pub use self::geometry::{intersection_polygon, InputRoad};
 pub(crate) use self::ids::RoadWithEndpoints;
 pub use self::ids::{CommonEndpoint, IntersectionID, LaneID, RoadID};
 pub use self::intersection::{
-    Intersection, IntersectionControl, IntersectionKind, Movement, TrafficConflict,
+    Intersection, IntersectionControl, IntersectionKind, Turn, TrafficConflict,
 };
 pub use self::lanes::{
     get_lane_specs_ltr, BufferType, Direction, LaneSpec, LaneType, Placement,

--- a/osm2streets/src/movements.rs
+++ b/osm2streets/src/movements.rs
@@ -1,0 +1,134 @@
+use crate::intersection::TurnMovement;
+use crate::lanes::{LtrLaneNum, RoadPosition};
+use crate::road::{Road, RoadEnd};
+use crate::{Direction, DrivingSide, LaneID};
+use geom::{PolyLine, Pt2D};
+
+pub fn from_placement(
+    (src_road, src_end): (&Road, RoadEnd),
+    (dst_road, dst_end): (&Road, RoadEnd),
+) -> Option<Vec<TurnMovement>> {
+    let src_pos = src_road.reference_line_placement.road_position_at(src_end);
+    let dst_pos = dst_road.reference_line_placement.road_position_at(dst_end);
+    if let (Some(RoadPosition::MiddleOf(src_lane)), Some(RoadPosition::MiddleOf(dst_lane))) =
+        (src_pos, dst_pos)
+    {
+        with_matched_lanes((src_road, src_end, src_lane), (dst_road, dst_end, dst_lane))
+    } else if let (Some(Some(src_lane)), Some(Some(dst_lane))) = (
+        src_pos.map(RoadPosition::left_of_lane),
+        dst_pos.map(RoadPosition::left_of_lane),
+    ) {
+        with_matched_lanes((src_road, src_end, src_lane), (dst_road, dst_end, dst_lane))
+    } else {
+        None
+    }
+}
+
+/// Generate the movements coming out of the src_end end of src_road into the dst_end end of
+/// dst_road, where src_lane matches up with dst_lane.
+///
+/// Lanes are paired up in order. Unpaired lanes fork from or merge into their closest partner lane.
+fn with_matched_lanes(
+    (src_road, src_end, src_lane): (&Road, RoadEnd, LtrLaneNum),
+    (dst_road, dst_end, dst_lane): (&Road, RoadEnd, LtrLaneNum),
+) -> Option<Vec<TurnMovement>> {
+    None
+    // match (src_end, src_lane, dst_end, dst_lane) {
+    //     (RoadEnd::End, LtrLaneNum::Forward(s), RoadEnd::Start, LtrLaneNum::Forward(d)) => {
+    //         Some(Vec::new())
+    //     },
+    //     (RoadEnd::Start, LtrLaneNum::Backward(s), RoadEnd::End, LtrLaneNum::Backward(d)) => {
+    //         Some(Vec::new())
+    //     },
+    //     _ => None
+    // }
+}
+
+/// Limitations: ignores both ways lanes
+pub fn default(
+    (src_road, src_end): (&Road, RoadEnd),
+    (dst_road, dst_end): (&Road, RoadEnd),
+    driving_side: DrivingSide,
+) -> Option<Vec<TurnMovement>> {
+    let mut result = Vec::new();
+
+    // Figure out which lanes (left-to-right) are involved in driving from src to dst.
+    let mut src_lanes = match src_end {
+        RoadEnd::End => driving_lane_endpoints(src_road, Direction::Fwd, RoadEnd::End),
+        RoadEnd::Start => driving_lane_endpoints(src_road, Direction::Back, RoadEnd::Start),
+    };
+    let mut dst_lanes = match dst_end {
+        RoadEnd::Start => driving_lane_endpoints(dst_road, Direction::Fwd, RoadEnd::Start),
+        RoadEnd::End => driving_lane_endpoints(dst_road, Direction::Back, RoadEnd::End),
+    };
+
+    if src_lanes.is_empty() || dst_lanes.is_empty() {
+        return Some(result);
+    }
+
+    // Order the lanes inside-to-outside.
+    if driving_side == DrivingSide::Left {
+        src_lanes.reverse();
+        dst_lanes.reverse();
+    }
+
+    let src_len = src_lanes.len();
+    let dst_len = dst_lanes.len();
+    let mut dst_i: usize = 0;
+    let mut src_i: usize = 0;
+
+    // Pair up the lanes, matching the inside lanes to each other.
+    loop {
+        let (src_lane, src_pt) = src_lanes[src_i];
+        let (dst_lane, dst_pt) = dst_lanes[dst_i];
+        result.push(TurnMovement {
+            from: src_lane,
+            to: dst_lane,
+            path: PolyLine::new(vec![src_pt, dst_pt])
+                .unwrap_or_else(|_| PolyLine::must_new(vec![src_pt, Pt2D::new(0.0, 0.0), dst_pt])),
+        });
+
+        // If either road is out of lanes, don't advance the counter, reuse the last lane.
+        let mut advanced = false;
+        if src_i + 1 < src_len {
+            src_i += 1;
+            advanced = true;
+        }
+        if dst_i + 1 < dst_len {
+            dst_i += 1;
+            advanced = true;
+        }
+        if !advanced {
+            break;
+        }
+    }
+
+    Some(result)
+}
+
+/// Returns the driving lanes in the given direction (left-to-right when facing that direction) and
+/// their endpoints at the given end.
+fn driving_lane_endpoints(road: &Road, dir: Direction, end: RoadEnd) -> Vec<(LaneID, Pt2D)> {
+    let lanes_ltr = road
+        .lane_specs_ltr
+        .iter()
+        .zip(road.get_lane_end_points(end))
+        .enumerate()
+        .filter_map(|(index, (lane, pt))| {
+            if lane.lt.is_tagged_by_lanes_suffix() && lane.dir == dir {
+                Some((
+                    LaneID {
+                        road: road.id,
+                        index,
+                    },
+                    pt,
+                ))
+            } else {
+                None
+            }
+        });
+    match dir {
+        Direction::Fwd => lanes_ltr.collect(),
+        Direction::Back => lanes_ltr.rev().collect(),
+    }
+}

--- a/osm2streets/src/paint.rs
+++ b/osm2streets/src/paint.rs
@@ -83,7 +83,11 @@ impl Paint<PolyLine> for marking::Longitudinal {
                         if overtake_left {
                             rings.append(
                                 &mut right_line
-                                    .dashed_lines(LINE_WIDTH, DASH_LENGTH_LONG, DASH_GAP_LONG)
+                                    .exact_dashed_polygons(
+                                        LINE_WIDTH,
+                                        DASH_LENGTH_LONG,
+                                        DASH_GAP_LONG,
+                                    )
                                     .into_iter()
                                     .map(|x| x.into_outer_ring())
                                     .collect(),
@@ -96,7 +100,11 @@ impl Paint<PolyLine> for marking::Longitudinal {
                         if overtake_right {
                             rings.append(
                                 &mut left_line
-                                    .dashed_lines(LINE_WIDTH, DASH_LENGTH_LONG, DASH_GAP_LONG)
+                                    .exact_dashed_polygons(
+                                        LINE_WIDTH,
+                                        DASH_LENGTH_LONG,
+                                        DASH_GAP_LONG,
+                                    )
                                     .into_iter()
                                     .map(|x| x.into_outer_ring())
                                     .collect(),
@@ -110,7 +118,11 @@ impl Paint<PolyLine> for marking::Longitudinal {
                     if overtake_left || overtake_right {
                         rings.append(
                             &mut separator
-                                .dashed_lines(LINE_WIDTH_THIN, DASH_LENGTH_LONG, DASH_GAP_LONG)
+                                .exact_dashed_polygons(
+                                    LINE_WIDTH_THIN,
+                                    DASH_LENGTH_LONG,
+                                    DASH_GAP_LONG,
+                                )
                                 .into_iter()
                                 .map(|x| x.into_outer_ring())
                                 .collect(),
@@ -129,7 +141,7 @@ impl Paint<PolyLine> for marking::Longitudinal {
                     if merge_left || merge_right {
                         rings.append(
                             &mut separator
-                                .dashed_lines(LINE_WIDTH, DASH_LENGTH_LONG, DASH_GAP_LONG)
+                                .exact_dashed_polygons(LINE_WIDTH, DASH_LENGTH_LONG, DASH_GAP_LONG)
                                 .into_iter()
                                 .map(|x| x.into_outer_ring())
                                 .collect(),
@@ -150,7 +162,7 @@ impl Paint<PolyLine> for marking::Longitudinal {
             marking::LongitudinalLine::Continuity => {
                 rings.append(
                     &mut separator
-                        .dashed_lines(LINE_WIDTH, DASH_LENGTH_SHORT, DASH_GAP_SHORT)
+                        .exact_dashed_polygons(LINE_WIDTH, DASH_LENGTH_SHORT, DASH_GAP_SHORT)
                         .into_iter()
                         .map(|x| x.into_outer_ring())
                         .collect(),
@@ -159,7 +171,7 @@ impl Paint<PolyLine> for marking::Longitudinal {
             marking::LongitudinalLine::Turn => {
                 rings.append(
                     &mut separator
-                        .dashed_lines(LINE_WIDTH, DASH_LENGTH_LONG, DASH_GAP_SHORT)
+                        .exact_dashed_polygons(LINE_WIDTH, DASH_LENGTH_SHORT, DASH_GAP_SHORT / 2.0)
                         .into_iter()
                         .map(|x| x.into_outer_ring())
                         .collect(),

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -66,6 +66,22 @@ pub enum RoadEnd {
     End,
 }
 
+impl RoadEnd {
+    pub fn direction_from(&self) -> Direction {
+        match self {
+            Self::Start => Direction::Fwd,
+            Self::End => Direction::Back,
+        }
+    }
+
+    pub fn direction_towards(&self) -> Direction {
+        match self {
+            Self::Start => Direction::Back,
+            Self::End => Direction::Fwd,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StopLine {
     /// Relative to the road's reference_line. Stop lines at the start of the road will have low

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use abstutil::Tags;
-use geom::{Angle, Distance, PolyLine};
+use geom::{Angle, Distance, PolyLine, Pt2D};
 
 use crate::lanes::RoadPosition;
 use crate::{
@@ -57,6 +57,13 @@ pub struct Road {
 
     pub stop_line_start: StopLine,
     pub stop_line_end: StopLine,
+}
+
+/// Identifies one end of a road.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RoadEnd {
+    Start,
+    End,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -447,6 +454,31 @@ impl Road {
         output
     }
 
+    /// Returns a list of lane center line endpoints at the requested end.
+    pub(crate) fn get_lane_end_points(&self, end: RoadEnd) -> Vec<Pt2D> {
+        let (pt, angle) = match end {
+            RoadEnd::Start => (
+                self.center_line.first_pt(),
+                self.center_line.first_line().angle(),
+            ),
+            RoadEnd::End => (
+                self.center_line.last_pt(),
+                self.center_line.last_line().angle(),
+            ),
+        };
+        let half_width = self.total_width() / 2.0;
+        let project_angle = angle.rotate_degs(90.0);
+
+        let mut width_so_far = Distance::ZERO;
+        let mut output = Vec::new();
+        for lane in &self.lane_specs_ltr {
+            width_so_far += lane.width / 2.0;
+            output.push(pt.project_away(width_so_far - half_width, project_angle));
+            width_so_far += lane.width / 2.0;
+        }
+        output
+    }
+
     /// Returns the untrimmed left and right side of the road, oriented in the same direction of
     /// the road
     pub fn get_untrimmed_sides(&self, driving_side: DrivingSide) -> Result<(PolyLine, PolyLine)> {
@@ -465,6 +497,23 @@ impl Road {
             .reference_line
             .shift_from_center(total_width, total_width - ref_offset)?;
         Ok((left, right))
+    }
+
+    pub fn intersection_at(&self, end: RoadEnd) -> IntersectionID {
+        match end {
+            RoadEnd::Start => self.src_i,
+            RoadEnd::End => self.dst_i,
+        }
+    }
+
+    pub fn end_of(&self, i: IntersectionID) -> Option<RoadEnd> {
+        if i == self.src_i {
+            Some(RoadEnd::Start)
+        } else if i == self.dst_i {
+            Some(RoadEnd::End)
+        } else {
+            None
+        }
     }
 
     pub fn endpoints(&self) -> Vec<IntersectionID> {

--- a/osm2streets/src/validate.rs
+++ b/osm2streets/src/validate.rs
@@ -1,4 +1,4 @@
-use crate::StreetNetwork;
+use crate::{StreetNetwork, Turn};
 
 impl StreetNetwork {
     /// Validates various things are true about the StreetNetwork, panicking if not.
@@ -33,18 +33,18 @@ impl StreetNetwork {
                 );
             }
 
-            for (r1, r2) in &i.movements {
+            for Turn { from, to, .. } in &i.turns {
                 assert!(
-                    i.roads.contains(r1),
-                    "{} has a movement for the wrong road {}",
+                    i.roads.contains(from),
+                    "{} has a turn for the wrong road {}",
                     i.describe(),
-                    r1
+                    from
                 );
                 assert!(
-                    i.roads.contains(r2),
-                    "{} has a movement for the wrong road {}",
+                    i.roads.contains(to),
+                    "{} has a turn for the wrong road {}",
                     i.describe(),
-                    r2
+                    to
                 );
             }
         }

--- a/tests/src/arizona_highways/geometry.json
+++ b/tests/src/arizona_highways/geometry.json
@@ -3642,12 +3642,12 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #8 -> Road #0",
-          "Road #8 -> Road #65"
-        ],
         "osm_node_ids": [
           257973235
+        ],
+        "turns": [
+          "Road #8 -> Road #0",
+          "Road #8 -> Road #65"
         ],
         "type": "intersection"
       },
@@ -3689,12 +3689,12 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #3 -> Road #1",
-          "Road #3 -> Road #68"
-        ],
         "osm_node_ids": [
           257973659
+        ],
+        "turns": [
+          "Road #3 -> Road #1",
+          "Road #3 -> Road #68"
         ],
         "type": "intersection"
       },
@@ -3732,11 +3732,11 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #52 -> Road #2"
-        ],
         "osm_node_ids": [
           1131443242
+        ],
+        "turns": [
+          "Road #52 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -3774,8 +3774,8 @@
         "control": "Uncontrolled",
         "id": 5,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3812,8 +3812,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3850,11 +3850,11 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #76 -> Road #4"
-        ],
         "osm_node_ids": [
           1224380077
+        ],
+        "turns": [
+          "Road #76 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -3892,11 +3892,11 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #57"
-        ],
         "osm_node_ids": [
           4341085381
+        ],
+        "turns": [
+          "Road #4 -> Road #57"
         ],
         "type": "intersection"
       },
@@ -3934,11 +3934,11 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #63 -> Road #5"
-        ],
         "osm_node_ids": [
           257970996
+        ],
+        "turns": [
+          "Road #63 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -3976,8 +3976,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4014,11 +4014,11 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #77 -> Road #6"
-        ],
         "osm_node_ids": [
           257964183
+        ],
+        "turns": [
+          "Road #77 -> Road #6"
         ],
         "type": "intersection"
       },
@@ -4056,11 +4056,11 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #6 -> Road #58"
-        ],
         "osm_node_ids": [
           4341085384
+        ],
+        "turns": [
+          "Road #6 -> Road #58"
         ],
         "type": "intersection"
       },
@@ -4098,8 +4098,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4140,12 +4140,12 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #7 -> Road #59",
-          "Road #7 -> Road #62"
-        ],
         "osm_node_ids": [
           4341085386
+        ],
+        "turns": [
+          "Road #7 -> Road #59",
+          "Road #7 -> Road #62"
         ],
         "type": "intersection"
       },
@@ -4183,8 +4183,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4225,12 +4225,12 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #73 -> Road #74",
-          "Road #73 -> Road #9"
-        ],
         "osm_node_ids": [
           2454728514
+        ],
+        "turns": [
+          "Road #73 -> Road #74",
+          "Road #73 -> Road #9"
         ],
         "type": "intersection"
       },
@@ -4268,11 +4268,11 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #9 -> Road #85"
-        ],
         "osm_node_ids": [
           1950975900
+        ],
+        "turns": [
+          "Road #9 -> Road #85"
         ],
         "type": "intersection"
       },
@@ -4322,13 +4322,13 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          1950975921
+        ],
+        "turns": [
           "Road #53 -> Road #73",
           "Road #53 -> Road #10",
           "Road #10 -> Road #73"
-        ],
-        "osm_node_ids": [
-          1950975921
         ],
         "type": "intersection"
       },
@@ -4366,8 +4366,8 @@
         "control": "Uncontrolled",
         "id": 19,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4404,8 +4404,8 @@
         "control": "Uncontrolled",
         "id": 20,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4450,16 +4450,16 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2391008638
+        ],
+        "turns": [
           "Road #10 -> Road #14",
           "Road #10 -> Road #11",
           "Road #14 -> Road #10",
           "Road #14 -> Road #11",
           "Road #11 -> Road #10",
           "Road #11 -> Road #14"
-        ],
-        "osm_node_ids": [
-          2391008638
         ],
         "type": "intersection"
       },
@@ -4497,8 +4497,8 @@
         "control": "Uncontrolled",
         "id": 22,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4539,14 +4539,14 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2391018451
+        ],
+        "turns": [
           "Road #14 -> Road #13",
           "Road #13 -> Road #14",
           "Road #15 -> Road #14",
           "Road #15 -> Road #13"
-        ],
-        "osm_node_ids": [
-          2391018451
         ],
         "type": "intersection"
       },
@@ -4588,16 +4588,16 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2391018415
+        ],
+        "turns": [
           "Road #19 -> Road #18",
           "Road #19 -> Road #16",
           "Road #18 -> Road #19",
           "Road #18 -> Road #16",
           "Road #16 -> Road #19",
           "Road #16 -> Road #18"
-        ],
-        "osm_node_ids": [
-          2391018415
         ],
         "type": "intersection"
       },
@@ -4635,8 +4635,8 @@
         "control": "Uncontrolled",
         "id": 25,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4673,8 +4673,8 @@
         "control": "Uncontrolled",
         "id": 26,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4715,16 +4715,16 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2391018413
+        ],
+        "turns": [
           "Road #17 -> Road #20",
           "Road #17 -> Road #19",
           "Road #20 -> Road #17",
           "Road #20 -> Road #19",
           "Road #19 -> Road #17",
           "Road #19 -> Road #20"
-        ],
-        "osm_node_ids": [
-          2391018413
         ],
         "type": "intersection"
       },
@@ -4762,8 +4762,8 @@
         "control": "Uncontrolled",
         "id": 28,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4808,16 +4808,16 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2391018412
+        ],
+        "turns": [
           "Road #13 -> Road #20",
           "Road #13 -> Road #12",
           "Road #20 -> Road #13",
           "Road #20 -> Road #12",
           "Road #12 -> Road #13",
           "Road #12 -> Road #20"
-        ],
-        "osm_node_ids": [
-          2391018412
         ],
         "type": "intersection"
       },
@@ -4871,13 +4871,13 @@
         "control": "Signalled",
         "id": 31,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1950975953
+        ],
+        "turns": [
           "Road #69 -> Road #38",
           "Road #23 -> Road #28",
           "Road #23 -> Road #38"
-        ],
-        "osm_node_ids": [
-          1950975953
         ],
         "type": "intersection"
       },
@@ -4935,14 +4935,14 @@
         "control": "Signalled",
         "id": 32,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1950975946
+        ],
+        "turns": [
           "Road #81 -> Road #39",
           "Road #81 -> Road #36",
           "Road #81 -> Road #24",
           "Road #37 -> Road #39"
-        ],
-        "osm_node_ids": [
-          1950975946
         ],
         "type": "intersection"
       },
@@ -5000,15 +5000,15 @@
         "control": "Signalled",
         "id": 33,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #24 -> Road #22",
-          "Road #24 -> Road #49",
-          "Road #24 -> Road #45"
-        ],
         "osm_node_ids": [
           608494024,
           2454435301,
           2457540692
+        ],
+        "turns": [
+          "Road #24 -> Road #22",
+          "Road #24 -> Road #49",
+          "Road #24 -> Road #45"
         ],
         "type": "intersection"
       },
@@ -5062,13 +5062,13 @@
         "control": "Signalled",
         "id": 34,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          256990200
+        ],
+        "turns": [
           "Road #26 -> Road #37",
           "Road #26 -> Road #30",
           "Road #66 -> Road #37"
-        ],
-        "osm_node_ids": [
-          256990200
         ],
         "type": "intersection"
       },
@@ -5106,11 +5106,11 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #29 -> Road #82"
-        ],
         "osm_node_ids": [
           5748112416
+        ],
+        "turns": [
+          "Road #29 -> Road #82"
         ],
         "type": "intersection"
       },
@@ -5148,8 +5148,8 @@
         "control": "Uncontrolled",
         "id": 37,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5202,12 +5202,12 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #40 -> Road #46",
-          "Road #35 -> Road #41"
-        ],
         "osm_node_ids": [
           2457540691
+        ],
+        "turns": [
+          "Road #40 -> Road #46",
+          "Road #35 -> Road #41"
         ],
         "type": "intersection"
       },
@@ -5309,7 +5309,14 @@
         "control": "Signalled",
         "id": 41,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2457540690,
+          41643290,
+          2454435296,
+          2454435293,
+          2457540689
+        ],
+        "turns": [
           "Road #38 -> Road #89",
           "Road #45 -> Road #47",
           "Road #71 -> Road #40",
@@ -5317,13 +5324,6 @@
           "Road #71 -> Road #25",
           "Road #71 -> Road #50",
           "Road #71 -> Road #35"
-        ],
-        "osm_node_ids": [
-          2457540690,
-          41643290,
-          2454435296,
-          2454435293,
-          2457540689
         ],
         "type": "intersection"
       },
@@ -5373,13 +5373,13 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          608494028
+        ],
+        "turns": [
           "Road #84 -> Road #52",
           "Road #39 -> Road #52",
           "Road #49 -> Road #52"
-        ],
-        "osm_node_ids": [
-          608494028
         ],
         "type": "intersection"
       },
@@ -5425,12 +5425,12 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #22 -> Road #23",
-          "Road #46 -> Road #23"
-        ],
         "osm_node_ids": [
           2457540697
+        ],
+        "turns": [
+          "Road #22 -> Road #23",
+          "Road #46 -> Road #23"
         ],
         "type": "intersection"
       },
@@ -5476,12 +5476,12 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #25 -> Road #26",
-          "Road #47 -> Road #26"
-        ],
         "osm_node_ids": [
           2457540685
+        ],
+        "turns": [
+          "Road #25 -> Road #26",
+          "Road #47 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -5523,12 +5523,12 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #65 -> Road #66",
-          "Road #65 -> Road #48"
-        ],
         "osm_node_ids": [
           2457540680
+        ],
+        "turns": [
+          "Road #65 -> Road #66",
+          "Road #65 -> Road #48"
         ],
         "type": "intersection"
       },
@@ -5570,12 +5570,12 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #48 -> Road #31",
-          "Road #30 -> Road #31"
-        ],
         "osm_node_ids": [
           2457540684
+        ],
+        "turns": [
+          "Road #48 -> Road #31",
+          "Road #30 -> Road #31"
         ],
         "type": "intersection"
       },
@@ -5621,12 +5621,12 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #90 -> Road #64",
-          "Road #50 -> Road #64"
-        ],
         "osm_node_ids": [
           257973558
+        ],
+        "turns": [
+          "Road #90 -> Road #64",
+          "Road #50 -> Road #64"
         ],
         "type": "intersection"
       },
@@ -5668,12 +5668,12 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #68 -> Road #69",
-          "Road #68 -> Road #51"
-        ],
         "osm_node_ids": [
           2457540707
+        ],
+        "turns": [
+          "Road #68 -> Road #69",
+          "Road #68 -> Road #51"
         ],
         "type": "intersection"
       },
@@ -5715,12 +5715,12 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #51 -> Road #29",
-          "Road #28 -> Road #29"
-        ],
         "osm_node_ids": [
           2457540699
+        ],
+        "turns": [
+          "Road #51 -> Road #29",
+          "Road #28 -> Road #29"
         ],
         "type": "intersection"
       },
@@ -5758,8 +5758,8 @@
         "control": "Uncontrolled",
         "id": 50,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5796,8 +5796,8 @@
         "control": "Uncontrolled",
         "id": 51,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5834,8 +5834,8 @@
         "control": "Uncontrolled",
         "id": 52,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5880,12 +5880,12 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #58 -> Road #79",
-          "Road #57 -> Road #79"
-        ],
         "osm_node_ids": [
           5134463770
+        ],
+        "turns": [
+          "Road #58 -> Road #79",
+          "Road #57 -> Road #79"
         ],
         "type": "intersection"
       },
@@ -5923,11 +5923,11 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #59 -> Road #61"
-        ],
         "osm_node_ids": [
           4341085382
+        ],
+        "turns": [
+          "Road #59 -> Road #61"
         ],
         "type": "intersection"
       },
@@ -5965,11 +5965,11 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #79 -> Road #60"
-        ],
         "osm_node_ids": [
           257964186
+        ],
+        "turns": [
+          "Road #79 -> Road #60"
         ],
         "type": "intersection"
       },
@@ -6007,8 +6007,8 @@
         "control": "Uncontrolled",
         "id": 56,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6045,11 +6045,11 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #61 -> Road #75"
-        ],
         "osm_node_ids": [
           1224380089
+        ],
+        "turns": [
+          "Road #61 -> Road #75"
         ],
         "type": "intersection"
       },
@@ -6087,11 +6087,11 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #62 -> Road #63"
-        ],
         "osm_node_ids": [
           4341085388
+        ],
+        "turns": [
+          "Road #62 -> Road #63"
         ],
         "type": "intersection"
       },
@@ -6129,8 +6129,8 @@
         "control": "Uncontrolled",
         "id": 59,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6171,12 +6171,12 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #85 -> Road #67",
-          "Road #89 -> Road #67"
-        ],
         "osm_node_ids": [
           1950975867
+        ],
+        "turns": [
+          "Road #85 -> Road #67",
+          "Road #89 -> Road #67"
         ],
         "type": "intersection"
       },
@@ -6214,11 +6214,11 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #67 -> Road #90"
-        ],
         "osm_node_ids": [
           5766999736
+        ],
+        "turns": [
+          "Road #67 -> Road #90"
         ],
         "type": "intersection"
       },
@@ -6480,11 +6480,11 @@
         "control": "Signed",
         "id": 62,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #83 -> Road #70"
-        ],
         "osm_node_ids": [
           4351379654
+        ],
+        "turns": [
+          "Road #83 -> Road #70"
         ],
         "type": "intersection"
       },
@@ -6522,8 +6522,8 @@
         "control": "Uncontrolled",
         "id": 63,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6560,11 +6560,11 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #74 -> Road #71"
-        ],
         "osm_node_ids": [
           4351379653
+        ],
+        "turns": [
+          "Road #74 -> Road #71"
         ],
         "type": "intersection"
       },
@@ -6606,14 +6606,14 @@
         "control": "Signed",
         "id": 65,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3715211173
+        ],
+        "turns": [
           "Road #55 -> Road #72",
           "Road #55 -> Road #56",
           "Road #56 -> Road #55",
           "Road #56 -> Road #72"
-        ],
-        "osm_node_ids": [
-          3715211173
         ],
         "type": "intersection"
       },
@@ -6655,14 +6655,14 @@
         "control": "Signed",
         "id": 66,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4982224185
+        ],
+        "turns": [
           "Road #55 -> Road #54",
           "Road #54 -> Road #55",
           "Road #72 -> Road #55",
           "Road #72 -> Road #54"
-        ],
-        "osm_node_ids": [
-          4982224185
         ],
         "type": "intersection"
       },
@@ -6700,8 +6700,8 @@
         "control": "Uncontrolled",
         "id": 67,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6738,8 +6738,8 @@
         "control": "Uncontrolled",
         "id": 68,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6776,11 +6776,11 @@
         "control": "Signalled",
         "id": 69,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #78 -> Road #77"
-        ],
         "osm_node_ids": [
           5134463771
+        ],
+        "turns": [
+          "Road #78 -> Road #77"
         ],
         "type": "intersection"
       },
@@ -6818,8 +6818,8 @@
         "control": "Uncontrolled",
         "id": 70,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6856,8 +6856,8 @@
         "control": "Uncontrolled",
         "id": 73,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6894,8 +6894,8 @@
         "control": "Uncontrolled",
         "id": 74,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6932,8 +6932,8 @@
         "control": "Uncontrolled",
         "id": 76,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6974,13 +6974,13 @@
         "control": "Signed",
         "id": 77,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          6228919924
+        ],
+        "turns": [
           "Road #86 -> Road #83",
           "Road #82 -> Road #83",
           "Road #82 -> Road #86"
-        ],
-        "osm_node_ids": [
-          6228919924
         ],
         "type": "intersection"
       },
@@ -7022,16 +7022,16 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6228919911
+        ],
+        "turns": [
           "Road #91 -> Road #87",
           "Road #91 -> Road #86",
           "Road #87 -> Road #91",
           "Road #87 -> Road #86",
           "Road #86 -> Road #91",
           "Road #86 -> Road #87"
-        ],
-        "osm_node_ids": [
-          6228919911
         ],
         "type": "intersection"
       },
@@ -7069,8 +7069,8 @@
         "control": "Uncontrolled",
         "id": 79,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7107,8 +7107,8 @@
         "control": "Uncontrolled",
         "id": 80,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7145,8 +7145,8 @@
         "control": "Uncontrolled",
         "id": 81,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/aurora_sausage_link/geometry.json
+++ b/tests/src/aurora_sausage_link/geometry.json
@@ -2103,16 +2103,16 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          429692074
+        ],
+        "turns": [
           "Road #4 -> Road #0",
           "Road #4 -> Road #64",
           "Road #0 -> Road #4",
           "Road #0 -> Road #64",
           "Road #64 -> Road #4",
           "Road #64 -> Road #0"
-        ],
-        "osm_node_ids": [
-          429692074
         ],
         "type": "intersection"
       },
@@ -2150,8 +2150,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2192,12 +2192,12 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #10 -> Road #2",
-          "Road #2 -> Road #13"
-        ],
         "osm_node_ids": [
           7404463396
+        ],
+        "turns": [
+          "Road #10 -> Road #2",
+          "Road #2 -> Road #13"
         ],
         "type": "intersection"
       },
@@ -2235,8 +2235,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2273,8 +2273,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2311,8 +2311,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2349,8 +2349,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2395,13 +2395,13 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          7404463398
+        ],
+        "turns": [
           "Road #7 -> Road #15",
           "Road #14 -> Road #15",
           "Road #14 -> Road #7"
-        ],
-        "osm_node_ids": [
-          7404463398
         ],
         "type": "intersection"
       },
@@ -2439,8 +2439,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2489,13 +2489,13 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          53122087
+        ],
+        "turns": [
           "Road #12 -> Road #9",
           "Road #12 -> Road #67",
           "Road #67 -> Road #9"
-        ],
-        "osm_node_ids": [
-          53122087
         ],
         "type": "intersection"
       },
@@ -2537,12 +2537,12 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #65 -> Road #11",
-          "Road #16 -> Road #65"
-        ],
         "osm_node_ids": [
           7404463397
+        ],
+        "turns": [
+          "Road #65 -> Road #11",
+          "Road #16 -> Road #65"
         ],
         "type": "intersection"
       },
@@ -2580,8 +2580,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2618,8 +2618,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2656,8 +2656,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2694,8 +2694,8 @@
         "control": "Uncontrolled",
         "id": 16,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2736,10 +2736,10 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686194
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2784,10 +2784,10 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686191
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2828,10 +2828,10 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686195
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2872,10 +2872,10 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686196
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2928,12 +2928,12 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #3 -> Road #4",
-          "Road #4 -> Road #3"
-        ],
         "osm_node_ids": [
           7654686200
+        ],
+        "turns": [
+          "Road #3 -> Road #4",
+          "Road #4 -> Road #3"
         ],
         "type": "intersection"
       },
@@ -2991,12 +2991,12 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #0 -> Road #1",
-          "Road #1 -> Road #0"
-        ],
         "osm_node_ids": [
           7654686198
+        ],
+        "turns": [
+          "Road #0 -> Road #1",
+          "Road #1 -> Road #0"
         ],
         "type": "intersection"
       },
@@ -3046,10 +3046,10 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686202
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3094,10 +3094,10 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686203
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3142,11 +3142,11 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686205,
           7654649171
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3199,12 +3199,12 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #8 -> Road #7",
-          "Road #7 -> Road #8"
-        ],
         "osm_node_ids": [
           7654686280
+        ],
+        "turns": [
+          "Road #8 -> Road #7",
+          "Road #7 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -3242,8 +3242,8 @@
         "control": "Uncontrolled",
         "id": 35,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3288,10 +3288,10 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686204
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3328,8 +3328,8 @@
         "control": "Uncontrolled",
         "id": 37,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3374,10 +3374,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686213
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3418,10 +3418,10 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686214
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3462,10 +3462,10 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686215
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3502,8 +3502,8 @@
         "control": "Uncontrolled",
         "id": 45,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3552,10 +3552,10 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7654686216
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3592,8 +3592,8 @@
         "control": "Uncontrolled",
         "id": 47,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3646,11 +3646,11 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #15 -> Road #16"
-        ],
         "osm_node_ids": [
           7654686242
+        ],
+        "turns": [
+          "Road #15 -> Road #16"
         ],
         "type": "intersection"
       },
@@ -3704,11 +3704,11 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #13 -> Road #14"
-        ],
         "osm_node_ids": [
           7654686243
+        ],
+        "turns": [
+          "Road #13 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -3762,11 +3762,11 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #9 -> Road #10"
-        ],
         "osm_node_ids": [
           7654686240
+        ],
+        "turns": [
+          "Road #9 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -3820,11 +3820,11 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #11 -> Road #12"
-        ],
         "osm_node_ids": [
           7654686241
+        ],
+        "turns": [
+          "Road #11 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -3874,12 +3874,12 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #64 -> Road #65",
-          "Road #65 -> Road #64"
-        ],
         "osm_node_ids": [
           7654686199
+        ],
+        "turns": [
+          "Road #64 -> Road #65",
+          "Road #65 -> Road #64"
         ],
         "type": "intersection"
       },
@@ -3917,8 +3917,8 @@
         "control": "Uncontrolled",
         "id": 57,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3979,13 +3979,13 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #67 -> Road #66",
-          "Road #66 -> Road #67"
-        ],
         "osm_node_ids": [
           7654686239,
           7654649173
+        ],
+        "turns": [
+          "Road #67 -> Road #66",
+          "Road #66 -> Road #67"
         ],
         "type": "intersection"
       },

--- a/tests/src/borough_sausage_links/geometry.json
+++ b/tests/src/borough_sausage_links/geometry.json
@@ -3678,8 +3678,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3724,13 +3724,13 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          60007209
+        ],
+        "turns": [
           "Road #0 -> Road #4",
           "Road #69 -> Road #4",
           "Road #69 -> Road #0"
-        ],
-        "osm_node_ids": [
-          60007209
         ],
         "type": "intersection"
       },
@@ -3776,12 +3776,12 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #50 -> Road #51",
-          "Road #51 -> Road #50"
-        ],
         "osm_node_ids": [
           347413549
+        ],
+        "turns": [
+          "Road #50 -> Road #51",
+          "Road #51 -> Road #50"
         ],
         "type": "intersection"
       },
@@ -3819,8 +3819,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3857,11 +3857,11 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #68"
-        ],
         "osm_node_ids": [
           5220719472
+        ],
+        "turns": [
+          "Road #4 -> Road #68"
         ],
         "type": "intersection"
       },
@@ -3899,8 +3899,8 @@
         "control": "Uncontrolled",
         "id": 5,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4161,10 +4161,10 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5220760621
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4209,10 +4209,10 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1165070926
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4249,8 +4249,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4287,10 +4287,10 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1165070941
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4331,10 +4331,10 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1165071010
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4371,10 +4371,10 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1165071161
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4419,10 +4419,10 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1165071364
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4467,10 +4467,10 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1165070964
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4507,8 +4507,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4549,12 +4549,12 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #17 -> Road #29",
-          "Road #85 -> Road #17"
-        ],
         "osm_node_ids": [
           352928523
+        ],
+        "turns": [
+          "Road #17 -> Road #29",
+          "Road #85 -> Road #17"
         ],
         "type": "intersection"
       },
@@ -4596,12 +4596,12 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #18 -> Road #75",
-          "Road #32 -> Road #18"
-        ],
         "osm_node_ids": [
           5220719428
+        ],
+        "turns": [
+          "Road #18 -> Road #75",
+          "Road #32 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -4643,12 +4643,12 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #27 -> Road #18",
-          "Road #18 -> Road #62"
-        ],
         "osm_node_ids": [
           5220719463
+        ],
+        "turns": [
+          "Road #27 -> Road #18",
+          "Road #18 -> Road #62"
         ],
         "type": "intersection"
       },
@@ -4706,7 +4706,11 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5220776408,
+          5220776403
+        ],
+        "turns": [
           "Road #89 -> Road #81",
           "Road #89 -> Road #19",
           "Road #89 -> Road #78",
@@ -4720,10 +4724,6 @@
           "Road #21 -> Road #81",
           "Road #21 -> Road #19",
           "Road #21 -> Road #78"
-        ],
-        "osm_node_ids": [
-          5220776408,
-          5220776403
         ],
         "type": "intersection"
       },
@@ -4765,12 +4765,12 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #19 -> Road #82",
-          "Road #57 -> Road #19"
-        ],
         "osm_node_ids": [
           5220776411
+        ],
+        "turns": [
+          "Road #19 -> Road #82",
+          "Road #57 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -4812,12 +4812,12 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #79 -> Road #80",
-          "Road #80 -> Road #20"
-        ],
         "osm_node_ids": [
           2217388387
+        ],
+        "turns": [
+          "Road #79 -> Road #80",
+          "Road #80 -> Road #20"
         ],
         "type": "intersection"
       },
@@ -4859,12 +4859,12 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #52 -> Road #22",
-          "Road #87 -> Road #52"
-        ],
         "osm_node_ids": [
           25497966
+        ],
+        "turns": [
+          "Road #52 -> Road #22",
+          "Road #87 -> Road #52"
         ],
         "type": "intersection"
       },
@@ -4906,13 +4906,13 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          5220776401
+        ],
+        "turns": [
           "Road #23 -> Road #86",
           "Road #23 -> Road #81",
           "Road #81 -> Road #86"
-        ],
-        "osm_node_ids": [
-          5220776401
         ],
         "type": "intersection"
       },
@@ -4950,12 +4950,12 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #24 -> Road #53",
-          "Road #53 -> Road #24"
-        ],
         "osm_node_ids": [
           25500014
+        ],
+        "turns": [
+          "Road #24 -> Road #53",
+          "Road #53 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -4993,12 +4993,12 @@
         "control": "Signalled",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #73 -> Road #24",
-          "Road #24 -> Road #73"
-        ],
         "osm_node_ids": [
           5220719448
+        ],
+        "turns": [
+          "Road #73 -> Road #24",
+          "Road #24 -> Road #73"
         ],
         "type": "intersection"
       },
@@ -5040,12 +5040,12 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #64 -> Road #72",
-          "Road #72 -> Road #25"
-        ],
         "osm_node_ids": [
           31349035
+        ],
+        "turns": [
+          "Road #64 -> Road #72",
+          "Road #72 -> Road #25"
         ],
         "type": "intersection"
       },
@@ -5087,12 +5087,12 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #30 -> Road #89",
-          "Road #89 -> Road #84"
-        ],
         "osm_node_ids": [
           5220776402
+        ],
+        "turns": [
+          "Road #30 -> Road #89",
+          "Road #89 -> Road #84"
         ],
         "type": "intersection"
       },
@@ -5142,12 +5142,12 @@
         "control": "Signalled",
         "id": 29,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #34 -> Road #31",
-          "Road #58 -> Road #31"
-        ],
         "osm_node_ids": [
           2217412073
+        ],
+        "turns": [
+          "Road #34 -> Road #31",
+          "Road #58 -> Road #31"
         ],
         "type": "intersection"
       },
@@ -5193,12 +5193,12 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #83 -> Road #34",
-          "Road #83 -> Road #33"
-        ],
         "osm_node_ids": [
           2217412069
+        ],
+        "turns": [
+          "Road #83 -> Road #34",
+          "Road #83 -> Road #33"
         ],
         "type": "intersection"
       },
@@ -5248,13 +5248,13 @@
         "control": "Signalled",
         "id": 31,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5220719456
+        ],
+        "turns": [
           "Road #33 -> Road #88",
           "Road #88 -> Road #56",
           "Road #88 -> Road #58"
-        ],
-        "osm_node_ids": [
-          5220719456
         ],
         "type": "intersection"
       },
@@ -5308,12 +5308,12 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #31 -> Road #32"
-        ],
         "osm_node_ids": [
           2217442429,
           2217388368
+        ],
+        "turns": [
+          "Road #31 -> Road #32"
         ],
         "type": "intersection"
       },
@@ -5359,13 +5359,13 @@
         "control": "Signalled",
         "id": 35,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #29 -> Road #30"
-        ],
         "osm_node_ids": [
           4506516726,
           2217388394,
           5737788455
+        ],
+        "turns": [
+          "Road #29 -> Road #30"
         ],
         "type": "intersection"
       },
@@ -5419,12 +5419,12 @@
         "control": "Signalled",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #56 -> Road #57"
-        ],
         "osm_node_ids": [
           4506516720,
           2217388386
+        ],
+        "turns": [
+          "Road #56 -> Road #57"
         ],
         "type": "intersection"
       },
@@ -5462,10 +5462,10 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4506516718
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5518,11 +5518,11 @@
         "control": "Signalled",
         "id": 41,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #20 -> Road #21"
-        ],
         "osm_node_ids": [
           2217388385
+        ],
+        "turns": [
+          "Road #20 -> Road #21"
         ],
         "type": "intersection"
       },
@@ -5568,12 +5568,12 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #86 -> Road #87"
-        ],
         "osm_node_ids": [
           4506516728,
           2217388363
+        ],
+        "turns": [
+          "Road #86 -> Road #87"
         ],
         "type": "intersection"
       },
@@ -5623,11 +5623,11 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2317365390,
           1165071224
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5672,10 +5672,10 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2317365395
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5728,10 +5728,10 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2217475460
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5768,10 +5768,10 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2217442436
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5808,8 +5808,8 @@
         "control": "Uncontrolled",
         "id": 50,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5846,8 +5846,8 @@
         "control": "Uncontrolled",
         "id": 51,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5904,12 +5904,12 @@
         "control": "Signed",
         "id": 52,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #26 -> Road #27",
-          "Road #74 -> Road #27"
-        ],
         "osm_node_ids": [
           2217388361
+        ],
+        "turns": [
+          "Road #26 -> Road #27",
+          "Road #74 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -5979,12 +5979,12 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #62 -> Road #63"
-        ],
         "osm_node_ids": [
           5220719449,
           2217475451
+        ],
+        "turns": [
+          "Road #62 -> Road #63"
         ],
         "type": "intersection"
       },
@@ -6026,11 +6026,11 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #25 -> Road #26"
-        ],
         "osm_node_ids": [
           5220719468
+        ],
+        "turns": [
+          "Road #25 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -6292,10 +6292,10 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2217475464
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6336,14 +6336,14 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5220719437
+        ],
+        "turns": [
           "Road #53 -> Road #61",
           "Road #53 -> Road #54",
           "Road #54 -> Road #53",
           "Road #54 -> Road #61"
-        ],
-        "osm_node_ids": [
-          5220719437
         ],
         "type": "intersection"
       },
@@ -6381,11 +6381,11 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #61 -> Road #108"
-        ],
         "osm_node_ids": [
           9733253134
+        ],
+        "turns": [
+          "Road #61 -> Road #108"
         ],
         "type": "intersection"
       },
@@ -6435,11 +6435,11 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #63 -> Road #64"
-        ],
         "osm_node_ids": [
           5220719471
+        ],
+        "turns": [
+          "Road #63 -> Road #64"
         ],
         "type": "intersection"
       },
@@ -6477,11 +6477,11 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #108 -> Road #65"
-        ],
         "osm_node_ids": [
           5220719447
+        ],
+        "turns": [
+          "Road #108 -> Road #65"
         ],
         "type": "intersection"
       },
@@ -6519,11 +6519,11 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #65 -> Road #69"
-        ],
         "osm_node_ids": [
           5220719469
+        ],
+        "turns": [
+          "Road #65 -> Road #69"
         ],
         "type": "intersection"
       },
@@ -6561,11 +6561,11 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #68 -> Road #74"
-        ],
         "osm_node_ids": [
           5220719466
+        ],
+        "turns": [
+          "Road #68 -> Road #74"
         ],
         "type": "intersection"
       },
@@ -6603,8 +6603,8 @@
         "control": "Uncontrolled",
         "id": 66,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6645,14 +6645,14 @@
         "control": "Signed",
         "id": 67,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5220719432
+        ],
+        "turns": [
           "Road #88 -> Road #73",
           "Road #76 -> Road #88",
           "Road #76 -> Road #73",
           "Road #73 -> Road #88"
-        ],
-        "osm_node_ids": [
-          5220719432
         ],
         "type": "intersection"
       },
@@ -6690,10 +6690,10 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           872828485
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6730,8 +6730,8 @@
         "control": "Uncontrolled",
         "id": 69,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6780,11 +6780,11 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #84 -> Road #85"
-        ],
         "osm_node_ids": [
           2217388358
+        ],
+        "turns": [
+          "Road #84 -> Road #85"
         ],
         "type": "intersection"
       },
@@ -6822,10 +6822,10 @@
         "control": "Signed",
         "id": 73,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4506516727
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6878,11 +6878,11 @@
         "control": "Signed",
         "id": 76,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #82 -> Road #83"
-        ],
         "osm_node_ids": [
           2217388371
+        ],
+        "turns": [
+          "Road #82 -> Road #83"
         ],
         "type": "intersection"
       },
@@ -6932,12 +6932,12 @@
         "control": "Signalled",
         "id": 79,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #78 -> Road #79"
-        ],
         "osm_node_ids": [
           2217388377,
           4506516719
+        ],
+        "turns": [
+          "Road #78 -> Road #79"
         ],
         "type": "intersection"
       },
@@ -6999,12 +6999,12 @@
         "control": "Signalled",
         "id": 81,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #22 -> Road #23"
-        ],
         "osm_node_ids": [
           2217388404,
           2217475492
+        ],
+        "turns": [
+          "Road #22 -> Road #23"
         ],
         "type": "intersection"
       },
@@ -7050,12 +7050,12 @@
         "control": "Signalled",
         "id": 82,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #75 -> Road #76"
-        ],
         "osm_node_ids": [
           2217388407,
           4506516722
+        ],
+        "turns": [
+          "Road #75 -> Road #76"
         ],
         "type": "intersection"
       },
@@ -7097,12 +7097,12 @@
         "control": "Signed",
         "id": 86,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #51 -> Road #52",
-          "Road #52 -> Road #51"
-        ],
         "osm_node_ids": [
           5220776406
+        ],
+        "turns": [
+          "Road #51 -> Road #52",
+          "Road #52 -> Road #51"
         ],
         "type": "intersection"
       },

--- a/tests/src/bristol_contraflow_cycleway/geometry.json
+++ b/tests/src/bristol_contraflow_cycleway/geometry.json
@@ -1182,8 +1182,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1220,8 +1220,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1258,8 +1258,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1304,16 +1304,16 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          260742831
+        ],
+        "turns": [
           "Road #11 -> Road #6",
           "Road #11 -> Road #16",
           "Road #6 -> Road #11",
           "Road #6 -> Road #16",
           "Road #16 -> Road #11",
           "Road #16 -> Road #6"
-        ],
-        "osm_node_ids": [
-          260742831
         ],
         "type": "intersection"
       },
@@ -1351,8 +1351,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1389,8 +1389,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1427,10 +1427,10 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           282231403
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1467,8 +1467,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1513,13 +1513,13 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          260742833
+        ],
+        "turns": [
           "Road #13 -> Road #22",
           "Road #21 -> Road #13",
           "Road #21 -> Road #22"
-        ],
-        "osm_node_ids": [
-          260742833
         ],
         "type": "intersection"
       },
@@ -1557,8 +1557,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1595,10 +1595,10 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           1223212748
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1643,13 +1643,13 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          1223212928
+        ],
+        "turns": [
           "Road #14 -> Road #21",
           "Road #20 -> Road #14",
           "Road #20 -> Road #21"
-        ],
-        "osm_node_ids": [
-          1223212928
         ],
         "type": "intersection"
       },
@@ -1707,15 +1707,15 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          260742852,
+          2847905819
+        ],
+        "turns": [
           "Road #6 -> Road #20",
           "Road #6 -> Road #7",
           "Road #7 -> Road #6",
           "Road #7 -> Road #20"
-        ],
-        "osm_node_ids": [
-          260742852,
-          2847905819
         ],
         "type": "intersection"
       },
@@ -1753,8 +1753,8 @@
         "control": "Uncontrolled",
         "id": 16,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2015,10 +2015,10 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           2208694229
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2055,8 +2055,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2105,18 +2105,18 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2847905817,
+          282229032,
+          2847905816
+        ],
+        "turns": [
           "Road #9 -> Road #11",
           "Road #9 -> Road #5",
           "Road #11 -> Road #9",
           "Road #11 -> Road #5",
           "Road #5 -> Road #9",
           "Road #5 -> Road #11"
-        ],
-        "osm_node_ids": [
-          2847905817,
-          282229032,
-          2847905816
         ],
         "type": "intersection"
       },
@@ -2158,12 +2158,12 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #1 -> Road #0",
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           260742941
+        ],
+        "turns": [
+          "Road #1 -> Road #0",
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -2209,12 +2209,12 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #30 -> Road #31",
-          "Road #31 -> Road #30"
-        ],
         "osm_node_ids": [
           8411724268
+        ],
+        "turns": [
+          "Road #30 -> Road #31",
+          "Road #31 -> Road #30"
         ],
         "type": "intersection"
       },
@@ -2260,10 +2260,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8411724259
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2324,7 +2324,11 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8411977276,
+          21310516
+        ],
+        "turns": [
           "Road #3 -> Road #30",
           "Road #3 -> Road #1",
           "Road #30 -> Road #3",
@@ -2334,10 +2338,6 @@
           "Road #23 -> Road #3",
           "Road #23 -> Road #30",
           "Road #23 -> Road #1"
-        ],
-        "osm_node_ids": [
-          8411977276,
-          21310516
         ],
         "type": "intersection"
       },
@@ -2379,12 +2379,12 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #8",
-          "Road #8 -> Road #7"
-        ],
         "osm_node_ids": [
           1316486883
+        ],
+        "turns": [
+          "Road #7 -> Road #8",
+          "Road #8 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -2430,13 +2430,13 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          8411977306
+        ],
+        "turns": [
           "Road #28 -> Road #23",
           "Road #22 -> Road #28",
           "Road #22 -> Road #23"
-        ],
-        "osm_node_ids": [
-          8411977306
         ],
         "type": "intersection"
       },
@@ -2474,10 +2474,10 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           8411977307
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2514,8 +2514,8 @@
         "control": "Uncontrolled",
         "id": 29,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/bristol_sausage_links/geometry.json
+++ b/tests/src/bristol_sausage_links/geometry.json
@@ -1324,8 +1324,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1366,13 +1366,13 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          21257313
+        ],
+        "turns": [
           "Road #0 -> Road #20",
           "Road #22 -> Road #0",
           "Road #22 -> Road #20"
-        ],
-        "osm_node_ids": [
-          21257313
         ],
         "type": "intersection"
       },
@@ -1410,8 +1410,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1464,7 +1464,10 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1316487047
+        ],
+        "turns": [
           "Road #19 -> Road #21",
           "Road #19 -> Road #1",
           "Road #19 -> Road #11",
@@ -1472,9 +1475,6 @@
           "Road #1 -> Road #19",
           "Road #11 -> Road #21",
           "Road #11 -> Road #19"
-        ],
-        "osm_node_ids": [
-          1316487047
         ],
         "type": "intersection"
       },
@@ -1512,8 +1512,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1558,13 +1558,13 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          21310567
+        ],
+        "turns": [
           "Road #31 -> Road #32",
           "Road #2 -> Road #31",
           "Road #2 -> Road #32"
-        ],
-        "osm_node_ids": [
-          21310567
         ],
         "type": "intersection"
       },
@@ -1602,8 +1602,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1648,10 +1648,10 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1695906751
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1688,8 +1688,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1726,8 +1726,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1772,10 +1772,10 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           154650255
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1820,13 +1820,13 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          4740760678
+        ],
+        "turns": [
           "Road #10 -> Road #11",
           "Road #10 -> Road #7",
           "Road #11 -> Road #7"
-        ],
-        "osm_node_ids": [
-          4740760678
         ],
         "type": "intersection"
       },
@@ -1868,13 +1868,13 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          4740760680
+        ],
+        "turns": [
           "Road #8 -> Road #9",
           "Road #8 -> Road #13",
           "Road #13 -> Road #9"
-        ],
-        "osm_node_ids": [
-          4740760680
         ],
         "type": "intersection"
       },
@@ -1912,8 +1912,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1954,11 +1954,11 @@
         "control": "Signalled",
         "id": 14,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #9 -> Road #10"
-        ],
         "osm_node_ids": [
           4053743721
+        ],
+        "turns": [
+          "Road #9 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -2008,11 +2008,11 @@
         "control": "Signalled",
         "id": 15,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #8"
-        ],
         "osm_node_ids": [
           4740760681
+        ],
+        "turns": [
+          "Road #7 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -2070,14 +2070,14 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4740760689
+        ],
+        "turns": [
           "Road #30 -> Road #15",
           "Road #30 -> Road #19",
           "Road #18 -> Road #19",
           "Road #19 -> Road #15"
-        ],
-        "osm_node_ids": [
-          4740760689
         ],
         "type": "intersection"
       },
@@ -2123,13 +2123,13 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          1316486886
+        ],
+        "turns": [
           "Road #16 -> Road #31",
           "Road #16 -> Road #17",
           "Road #31 -> Road #17"
-        ],
-        "osm_node_ids": [
-          1316486886
         ],
         "type": "intersection"
       },
@@ -2183,11 +2183,11 @@
         "control": "Signalled",
         "id": 18,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #20 -> Road #30"
-        ],
         "osm_node_ids": [
           4740760690
+        ],
+        "turns": [
+          "Road #20 -> Road #30"
         ],
         "type": "intersection"
       },
@@ -2229,11 +2229,11 @@
         "control": "Signalled",
         "id": 19,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #17 -> Road #18"
-        ],
         "osm_node_ids": [
           4740760693
+        ],
+        "turns": [
+          "Road #17 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -2275,11 +2275,11 @@
         "control": "Signalled",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #15 -> Road #16"
-        ],
         "osm_node_ids": [
           4883724668
+        ],
+        "turns": [
+          "Road #15 -> Road #16"
         ],
         "type": "intersection"
       },
@@ -2329,13 +2329,13 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #13 -> Road #12",
-          "Road #12 -> Road #13"
-        ],
         "osm_node_ids": [
           4883724685,
           9207824223
+        ],
+        "turns": [
+          "Road #13 -> Road #12",
+          "Road #12 -> Road #13"
         ],
         "type": "intersection"
       },
@@ -2393,11 +2393,11 @@
         "control": "Signalled",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #21 -> Road #22"
-        ],
         "osm_node_ids": [
           9207824224
+        ],
+        "turns": [
+          "Road #21 -> Road #22"
         ],
         "type": "intersection"
       },
@@ -2435,8 +2435,8 @@
         "control": "Uncontrolled",
         "id": 27,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/cycleway_rejoin_road/geometry.json
+++ b/tests/src/cycleway_rejoin_road/geometry.json
@@ -2969,16 +2969,16 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1691695883
+        ],
+        "turns": [
           "Road #0 -> Road #13",
           "Road #0 -> Road #62",
           "Road #13 -> Road #0",
           "Road #13 -> Road #62",
           "Road #62 -> Road #0",
           "Road #62 -> Road #13"
-        ],
-        "osm_node_ids": [
-          1691695883
         ],
         "type": "intersection"
       },
@@ -3016,8 +3016,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3062,14 +3062,14 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25502890
+        ],
+        "turns": [
           "Road #32 -> Road #3",
           "Road #32 -> Road #1",
           "Road #3 -> Road #32",
           "Road #3 -> Road #1"
-        ],
-        "osm_node_ids": [
-          25502890
         ],
         "type": "intersection"
       },
@@ -3127,15 +3127,15 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25502651
+        ],
+        "turns": [
           "Road #27 -> Road #12",
           "Road #27 -> Road #16",
           "Road #1 -> Road #12",
           "Road #1 -> Road #16",
           "Road #12 -> Road #16"
-        ],
-        "osm_node_ids": [
-          25502651
         ],
         "type": "intersection"
       },
@@ -3173,8 +3173,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3215,14 +3215,14 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25502684
+        ],
+        "turns": [
           "Road #39 -> Road #4",
           "Road #39 -> Road #15",
           "Road #15 -> Road #39",
           "Road #15 -> Road #4"
-        ],
-        "osm_node_ids": [
-          25502684
         ],
         "type": "intersection"
       },
@@ -3268,13 +3268,13 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4967069559
+        ],
+        "turns": [
           "Road #4 -> Road #23",
           "Road #4 -> Road #42",
           "Road #42 -> Road #23"
-        ],
-        "osm_node_ids": [
-          4967069559
         ],
         "type": "intersection"
       },
@@ -3320,12 +3320,12 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #28 -> Road #5",
-          "Road #28 -> Road #29"
-        ],
         "osm_node_ids": [
           25504033
+        ],
+        "turns": [
+          "Road #28 -> Road #5",
+          "Road #28 -> Road #29"
         ],
         "type": "intersection"
       },
@@ -3363,11 +3363,11 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #5 -> Road #24"
-        ],
         "osm_node_ids": [
           4967088337
+        ],
+        "turns": [
+          "Road #5 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -3409,16 +3409,16 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2246184959
+        ],
+        "turns": [
           "Road #35 -> Road #6",
           "Road #35 -> Road #34",
           "Road #6 -> Road #35",
           "Road #6 -> Road #34",
           "Road #34 -> Road #35",
           "Road #34 -> Road #6"
-        ],
-        "osm_node_ids": [
-          2246184959
         ],
         "type": "intersection"
       },
@@ -3456,8 +3456,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3502,16 +3502,16 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          21511934
+        ],
+        "turns": [
           "Road #34 -> Road #9",
           "Road #34 -> Road #33",
           "Road #9 -> Road #34",
           "Road #9 -> Road #33",
           "Road #33 -> Road #34",
           "Road #33 -> Road #9"
-        ],
-        "osm_node_ids": [
-          21511934
         ],
         "type": "intersection"
       },
@@ -3549,8 +3549,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3587,8 +3587,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3625,11 +3625,11 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #16 -> Road #28"
-        ],
         "osm_node_ids": [
           5739261533
+        ],
+        "turns": [
+          "Road #16 -> Road #28"
         ],
         "type": "intersection"
       },
@@ -3667,8 +3667,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3709,12 +3709,12 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #40 -> Road #39",
-          "Road #39 -> Road #40"
-        ],
         "osm_node_ids": [
           9150256922
+        ],
+        "turns": [
+          "Road #40 -> Road #39",
+          "Road #39 -> Road #40"
         ],
         "type": "intersection"
       },
@@ -3760,13 +3760,13 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          4673133618
+        ],
+        "turns": [
           "Road #29 -> Road #18",
           "Road #29 -> Road #30",
           "Road #18 -> Road #30"
-        ],
-        "osm_node_ids": [
-          4673133618
         ],
         "type": "intersection"
       },
@@ -3804,10 +3804,10 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4673133620
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3848,11 +3848,11 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #22 -> Road #36"
-        ],
         "osm_node_ids": [
           4957735651
+        ],
+        "turns": [
+          "Road #22 -> Road #36"
         ],
         "type": "intersection"
       },
@@ -3890,11 +3890,11 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #41 -> Road #22"
-        ],
         "osm_node_ids": [
           4957735652
+        ],
+        "turns": [
+          "Road #41 -> Road #22"
         ],
         "type": "intersection"
       },
@@ -3932,11 +3932,11 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #23 -> Road #27"
-        ],
         "osm_node_ids": [
           4967088341
+        ],
+        "turns": [
+          "Road #23 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -3978,14 +3978,14 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          730856862
+        ],
+        "turns": [
           "Road #14 -> Road #13",
           "Road #26 -> Road #14",
           "Road #26 -> Road #13",
           "Road #13 -> Road #14"
-        ],
-        "osm_node_ids": [
-          730856862
         ],
         "type": "intersection"
       },
@@ -4023,8 +4023,8 @@
         "control": "Uncontrolled",
         "id": 24,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4073,12 +4073,12 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #33 -> Road #32",
-          "Road #32 -> Road #33"
-        ],
         "osm_node_ids": [
           5739261534
+        ],
+        "turns": [
+          "Road #33 -> Road #32",
+          "Road #32 -> Road #33"
         ],
         "type": "intersection"
       },
@@ -4132,15 +4132,15 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8013569055,
+          25502865
+        ],
+        "turns": [
           "Road #61 -> Road #35",
           "Road #35 -> Road #61",
           "Road #37 -> Road #61",
           "Road #37 -> Road #35"
-        ],
-        "osm_node_ids": [
-          8013569055,
-          25502865
         ],
         "type": "intersection"
       },
@@ -4178,8 +4178,8 @@
         "control": "Uncontrolled",
         "id": 28,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4220,10 +4220,10 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           10207672238
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4264,10 +4264,10 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136344009
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4312,12 +4312,12 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #3 -> Road #2",
-          "Road #2 -> Road #3"
-        ],
         "osm_node_ids": [
           9136344010
+        ],
+        "turns": [
+          "Road #3 -> Road #2",
+          "Road #2 -> Road #3"
         ],
         "type": "intersection"
       },
@@ -4355,8 +4355,8 @@
         "control": "Uncontrolled",
         "id": 32,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4401,12 +4401,12 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #11 -> Road #10",
-          "Road #10 -> Road #11"
-        ],
         "osm_node_ids": [
           9136383829
+        ],
+        "turns": [
+          "Road #11 -> Road #10",
+          "Road #10 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -4444,8 +4444,8 @@
         "control": "Uncontrolled",
         "id": 34,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4486,12 +4486,12 @@
         "control": "Signed",
         "id": 35,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #8 -> Road #7",
-          "Road #7 -> Road #8"
-        ],
         "osm_node_ids": [
           9136383834
+        ],
+        "turns": [
+          "Road #8 -> Road #7",
+          "Road #7 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -4529,8 +4529,8 @@
         "control": "Uncontrolled",
         "id": 36,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4571,10 +4571,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136383836
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4611,10 +4611,10 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136383837
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4651,10 +4651,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136383839
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4691,8 +4691,8 @@
         "control": "Uncontrolled",
         "id": 40,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4729,10 +4729,10 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136383851
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4785,17 +4785,17 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9150217904,
+          10169626560
+        ],
+        "turns": [
           "Road #56 -> Road #41",
           "Road #56 -> Road #40",
           "Road #41 -> Road #56",
           "Road #41 -> Road #40",
           "Road #40 -> Road #56",
           "Road #40 -> Road #41"
-        ],
-        "osm_node_ids": [
-          9150217904,
-          10169626560
         ],
         "type": "intersection"
       },
@@ -4833,8 +4833,8 @@
         "control": "Uncontrolled",
         "id": 43,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4871,8 +4871,8 @@
         "control": "Uncontrolled",
         "id": 44,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4921,16 +4921,16 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9150256917
+        ],
+        "turns": [
           "Road #57 -> Road #15",
           "Road #57 -> Road #14",
           "Road #15 -> Road #57",
           "Road #15 -> Road #14",
           "Road #14 -> Road #57",
           "Road #14 -> Road #15"
-        ],
-        "osm_node_ids": [
-          9150256917
         ],
         "type": "intersection"
       },
@@ -4968,10 +4968,10 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           9150276535
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5012,11 +5012,11 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #25 -> Road #26"
-        ],
         "osm_node_ids": [
           9150276536
+        ],
+        "turns": [
+          "Road #25 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -5058,11 +5058,11 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #24 -> Road #25"
-        ],
         "osm_node_ids": [
           9150276546
+        ],
+        "turns": [
+          "Road #24 -> Road #25"
         ],
         "type": "intersection"
       },
@@ -5100,8 +5100,8 @@
         "control": "Uncontrolled",
         "id": 50,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5138,8 +5138,8 @@
         "control": "Uncontrolled",
         "id": 51,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5176,8 +5176,8 @@
         "control": "Uncontrolled",
         "id": 52,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5214,8 +5214,8 @@
         "control": "Uncontrolled",
         "id": 53,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5256,12 +5256,12 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #18 -> Road #19",
-          "Road #19 -> Road #18"
-        ],
         "osm_node_ids": [
           10145051473
+        ],
+        "turns": [
+          "Road #18 -> Road #19",
+          "Road #19 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -5299,10 +5299,10 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           10145051488
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5339,8 +5339,8 @@
         "control": "Uncontrolled",
         "id": 56,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5377,8 +5377,8 @@
         "control": "Uncontrolled",
         "id": 57,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5415,8 +5415,8 @@
         "control": "Uncontrolled",
         "id": 58,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5453,10 +5453,10 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           10169626556
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5505,10 +5505,10 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           10169626558
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5573,12 +5573,12 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #36 -> Road #37"
-        ],
         "osm_node_ids": [
           7330281378,
           10169626557
+        ],
+        "turns": [
+          "Road #36 -> Road #37"
         ],
         "type": "intersection"
       },
@@ -5616,8 +5616,8 @@
         "control": "Uncontrolled",
         "id": 65,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5654,8 +5654,8 @@
         "control": "Uncontrolled",
         "id": 66,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5696,10 +5696,10 @@
         "control": "Signed",
         "id": 67,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           10207672237
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5756,12 +5756,12 @@
         "control": "Signed",
         "id": 69,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #10 -> Road #9",
-          "Road #9 -> Road #10"
-        ],
         "osm_node_ids": [
           10207672241
+        ],
+        "turns": [
+          "Road #10 -> Road #9",
+          "Road #9 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -5815,14 +5815,14 @@
         "control": "Signed",
         "id": 71,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #6",
-          "Road #6 -> Road #7"
-        ],
         "osm_node_ids": [
           10212498582,
           10169626565,
           10212498587
+        ],
+        "turns": [
+          "Road #7 -> Road #6",
+          "Road #6 -> Road #7"
         ],
         "type": "intersection"
       },

--- a/tests/src/fremantle_placement/geometry.json
+++ b/tests/src/fremantle_placement/geometry.json
@@ -2525,12 +2525,12 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #56 -> Road #0",
-          "Road #56 -> Road #48"
-        ],
         "osm_node_ids": [
           9635256628
+        ],
+        "turns": [
+          "Road #56 -> Road #0",
+          "Road #56 -> Road #48"
         ],
         "type": "intersection"
       },
@@ -2572,12 +2572,12 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #26 -> Road #43",
-          "Road #1 -> Road #43"
-        ],
         "osm_node_ids": [
           25647208
+        ],
+        "turns": [
+          "Road #26 -> Road #43",
+          "Road #1 -> Road #43"
         ],
         "type": "intersection"
       },
@@ -2619,12 +2619,12 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #62 -> Road #32",
-          "Road #62 -> Road #2"
-        ],
         "osm_node_ids": [
           3257026803
+        ],
+        "turns": [
+          "Road #62 -> Road #32",
+          "Road #62 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -2678,14 +2678,14 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25647205
+        ],
+        "turns": [
           "Road #18 -> Road #52",
           "Road #18 -> Road #54",
           "Road #2 -> Road #52",
           "Road #2 -> Road #54"
-        ],
-        "osm_node_ids": [
-          25647205
         ],
         "type": "intersection"
       },
@@ -2723,8 +2723,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2769,12 +2769,12 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #44 -> Road #11",
-          "Road #3 -> Road #11"
-        ],
         "osm_node_ids": [
           25647203
+        ],
+        "turns": [
+          "Road #44 -> Road #11",
+          "Road #3 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -2816,13 +2816,13 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1851424562
+        ],
+        "turns": [
           "Road #11 -> Road #4",
           "Road #11 -> Road #12",
           "Road #4 -> Road #12"
-        ],
-        "osm_node_ids": [
-          1851424562
         ],
         "type": "intersection"
       },
@@ -2860,8 +2860,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2898,8 +2898,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2952,11 +2952,11 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           3022417536
+        ],
+        "turns": [
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -2998,10 +2998,10 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2955385143
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3054,7 +3054,10 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25647202
+        ],
+        "turns": [
           "Road #30 -> Road #31",
           "Road #30 -> Road #45",
           "Road #12 -> Road #30",
@@ -3064,9 +3067,6 @@
           "Road #31 -> Road #45",
           "Road #45 -> Road #30",
           "Road #45 -> Road #31"
-        ],
-        "osm_node_ids": [
-          25647202
         ],
         "type": "intersection"
       },
@@ -3108,12 +3108,12 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #39 -> Road #13",
-          "Road #39 -> Road #37"
-        ],
         "osm_node_ids": [
           25647198
+        ],
+        "turns": [
+          "Road #39 -> Road #13",
+          "Road #39 -> Road #37"
         ],
         "type": "intersection"
       },
@@ -3167,11 +3167,11 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #13 -> Road #14"
-        ],
         "osm_node_ids": [
           3022414626
+        ],
+        "turns": [
+          "Road #13 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -3213,12 +3213,12 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #46 -> Road #47",
-          "Road #14 -> Road #47"
-        ],
         "osm_node_ids": [
           2955383906
+        ],
+        "turns": [
+          "Road #46 -> Road #47",
+          "Road #14 -> Road #47"
         ],
         "type": "intersection"
       },
@@ -3272,13 +3272,13 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3022414627
+        ],
+        "turns": [
           "Road #20 -> Road #15",
           "Road #20 -> Road #23",
           "Road #38 -> Road #23"
-        ],
-        "osm_node_ids": [
-          3022414627
         ],
         "type": "intersection"
       },
@@ -3320,12 +3320,12 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #33 -> Road #17",
-          "Road #33 -> Road #34"
-        ],
         "osm_node_ids": [
           2955383912
+        ],
+        "turns": [
+          "Road #33 -> Road #17",
+          "Road #33 -> Road #34"
         ],
         "type": "intersection"
       },
@@ -3371,12 +3371,12 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #17 -> Road #19",
-          "Road #28 -> Road #19"
-        ],
         "osm_node_ids": [
           2955383914
+        ],
+        "turns": [
+          "Road #17 -> Road #19",
+          "Road #28 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -3418,12 +3418,12 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #50 -> Road #29",
-          "Road #50 -> Road #18"
-        ],
         "osm_node_ids": [
           3257026787
+        ],
+        "turns": [
+          "Road #50 -> Road #29",
+          "Road #50 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -3461,8 +3461,8 @@
         "control": "Uncontrolled",
         "id": 21,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3515,13 +3515,13 @@
         "control": "Signalled",
         "id": 22,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3022414631
+        ],
+        "turns": [
           "Road #24 -> Road #20",
           "Road #24 -> Road #25",
           "Road #48 -> Road #20"
-        ],
-        "osm_node_ids": [
-          3022414631
         ],
         "type": "intersection"
       },
@@ -3567,12 +3567,12 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #21 -> Road #22",
-          "Road #21 -> Road #24"
-        ],
         "osm_node_ids": [
           3022414624
+        ],
+        "turns": [
+          "Road #21 -> Road #22",
+          "Road #21 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -3610,8 +3610,8 @@
         "control": "Uncontrolled",
         "id": 25,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3668,11 +3668,11 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #25 -> Road #26"
-        ],
         "osm_node_ids": [
           3022414632
+        ],
+        "turns": [
+          "Road #25 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -3714,13 +3714,13 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3257026807
+        ],
+        "turns": [
           "Road #29 -> Road #62",
           "Road #29 -> Road #30",
           "Road #30 -> Road #62"
-        ],
-        "osm_node_ids": [
-          3257026807
         ],
         "type": "intersection"
       },
@@ -3758,8 +3758,8 @@
         "control": "Uncontrolled",
         "id": 29,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3800,12 +3800,12 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #54 -> Road #49",
-          "Road #32 -> Road #49"
-        ],
         "osm_node_ids": [
           3257026791
+        ],
+        "turns": [
+          "Road #54 -> Road #49",
+          "Road #32 -> Road #49"
         ],
         "type": "intersection"
       },
@@ -3843,8 +3843,8 @@
         "control": "Uncontrolled",
         "id": 31,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3897,11 +3897,11 @@
         "control": "Signalled",
         "id": 32,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #37 -> Road #38"
-        ],
         "osm_node_ids": [
           3022414628
+        ],
+        "turns": [
+          "Road #37 -> Road #38"
         ],
         "type": "intersection"
       },
@@ -3939,11 +3939,11 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #63 -> Road #39"
-        ],
         "osm_node_ids": [
           1851424557
+        ],
+        "turns": [
+          "Road #63 -> Road #39"
         ],
         "type": "intersection"
       },
@@ -3997,15 +3997,15 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25647197
+        ],
+        "turns": [
           "Road #41 -> Road #63",
           "Road #41 -> Road #40",
           "Road #51 -> Road #41",
           "Road #51 -> Road #63",
           "Road #51 -> Road #40"
-        ],
-        "osm_node_ids": [
-          25647197
         ],
         "type": "intersection"
       },
@@ -4059,14 +4059,14 @@
         "control": "Signed",
         "id": 35,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25647204
+        ],
+        "turns": [
           "Road #40 -> Road #44",
           "Road #40 -> Road #50",
           "Road #43 -> Road #44",
           "Road #43 -> Road #50"
-        ],
-        "osm_node_ids": [
-          25647204
         ],
         "type": "intersection"
       },
@@ -4104,8 +4104,8 @@
         "control": "Uncontrolled",
         "id": 36,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4142,8 +4142,8 @@
         "control": "Uncontrolled",
         "id": 37,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4184,12 +4184,12 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #52 -> Road #53",
-          "Road #42 -> Road #53"
-        ],
         "osm_node_ids": [
           3257026785
+        ],
+        "turns": [
+          "Road #52 -> Road #53",
+          "Road #42 -> Road #53"
         ],
         "type": "intersection"
       },
@@ -4227,8 +4227,8 @@
         "control": "Uncontrolled",
         "id": 39,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4265,8 +4265,8 @@
         "control": "Uncontrolled",
         "id": 40,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4303,8 +4303,8 @@
         "control": "Uncontrolled",
         "id": 41,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4341,11 +4341,11 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #53 -> Road #51"
-        ],
         "osm_node_ids": [
           6285614021
+        ],
+        "turns": [
+          "Road #53 -> Road #51"
         ],
         "type": "intersection"
       },
@@ -4383,8 +4383,8 @@
         "control": "Uncontrolled",
         "id": 43,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4421,8 +4421,8 @@
         "control": "Uncontrolled",
         "id": 44,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4459,8 +4459,8 @@
         "control": "Uncontrolled",
         "id": 46,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4513,11 +4513,11 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #15 -> Road #46"
-        ],
         "osm_node_ids": [
           9776457609
+        ],
+        "turns": [
+          "Road #15 -> Road #46"
         ],
         "type": "intersection"
       },
@@ -4591,15 +4591,15 @@
         "control": "Signalled",
         "id": 48,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9776457608,
+          3022414623
+        ],
+        "turns": [
           "Road #34 -> Road #27",
           "Road #34 -> Road #21",
           "Road #23 -> Road #27",
           "Road #23 -> Road #21"
-        ],
-        "osm_node_ids": [
-          9776457608,
-          3022414623
         ],
         "type": "intersection"
       },
@@ -4653,11 +4653,11 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #27 -> Road #28"
-        ],
         "osm_node_ids": [
           9776457606
+        ],
+        "turns": [
+          "Road #27 -> Road #28"
         ],
         "type": "intersection"
       },

--- a/tests/src/i5_exit_ramp/geometry.json
+++ b/tests/src/i5_exit_ramp/geometry.json
@@ -4308,12 +4308,12 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #4 -> Road #8",
-          "Road #4 -> Road #0"
-        ],
         "osm_node_ids": [
           29484936
+        ],
+        "turns": [
+          "Road #4 -> Road #8",
+          "Road #4 -> Road #0"
         ],
         "type": "intersection"
       },
@@ -4351,8 +4351,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4393,12 +4393,12 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #28 -> Road #1",
-          "Road #102 -> Road #1"
-        ],
         "osm_node_ids": [
           1864943558
+        ],
+        "turns": [
+          "Road #28 -> Road #1",
+          "Road #102 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -4436,8 +4436,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4474,11 +4474,11 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #25 -> Road #2"
-        ],
         "osm_node_ids": [
           29545440
+        ],
+        "turns": [
+          "Road #25 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -4516,10 +4516,10 @@
         "control": "Signalled",
         "id": 5,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           29545412
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4556,8 +4556,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4598,11 +4598,11 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #51 -> Road #5"
-        ],
         "osm_node_ids": [
           29545445
+        ],
+        "turns": [
+          "Road #51 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -4640,11 +4640,11 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #5 -> Road #25"
-        ],
         "osm_node_ids": [
           1222221757
+        ],
+        "turns": [
+          "Road #5 -> Road #25"
         ],
         "type": "intersection"
       },
@@ -4682,12 +4682,12 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #85 -> Road #6",
-          "Road #6 -> Road #85"
-        ],
         "osm_node_ids": [
           3588212119
+        ],
+        "turns": [
+          "Road #85 -> Road #6",
+          "Road #6 -> Road #85"
         ],
         "type": "intersection"
       },
@@ -4725,8 +4725,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4763,8 +4763,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4801,11 +4801,11 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #26"
-        ],
         "osm_node_ids": [
           31428567
+        ],
+        "turns": [
+          "Road #7 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -4843,8 +4843,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4881,8 +4881,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4931,16 +4931,16 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          32178812
+        ],
+        "turns": [
           "Road #114 -> Road #31",
           "Road #114 -> Road #9",
           "Road #31 -> Road #114",
           "Road #31 -> Road #9",
           "Road #9 -> Road #114",
           "Road #9 -> Road #31"
-        ],
-        "osm_node_ids": [
-          32178812
         ],
         "type": "intersection"
       },
@@ -4986,14 +4986,14 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53149325
+        ],
+        "turns": [
           "Road #16 -> Road #15",
           "Road #12 -> Road #16",
           "Road #12 -> Road #15",
           "Road #15 -> Road #16"
-        ],
-        "osm_node_ids": [
-          53149325
         ],
         "type": "intersection"
       },
@@ -5039,16 +5039,16 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53163625
+        ],
+        "turns": [
           "Road #13 -> Road #36",
           "Road #13 -> Road #35",
           "Road #36 -> Road #13",
           "Road #36 -> Road #35",
           "Road #35 -> Road #13",
           "Road #35 -> Road #36"
-        ],
-        "osm_node_ids": [
-          53163625
         ],
         "type": "intersection"
       },
@@ -5086,8 +5086,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5124,10 +5124,10 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           8041388888
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5192,14 +5192,14 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #29 -> Road #18",
-          "Road #29 -> Road #20",
-          "Road #18 -> Road #20"
-        ],
         "osm_node_ids": [
           5766863606,
           5766863609
+        ],
+        "turns": [
+          "Road #29 -> Road #18",
+          "Road #29 -> Road #20",
+          "Road #18 -> Road #20"
         ],
         "type": "intersection"
       },
@@ -5237,10 +5237,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           400020830
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5277,10 +5277,10 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           400020831
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5317,8 +5317,8 @@
         "control": "Uncontrolled",
         "id": 25,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5355,10 +5355,10 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           32259207
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5403,10 +5403,10 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2672451447
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5443,12 +5443,12 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #22 -> Road #83",
-          "Road #83 -> Road #22"
-        ],
         "osm_node_ids": [
           4789275355
+        ],
+        "turns": [
+          "Road #22 -> Road #83",
+          "Road #83 -> Road #22"
         ],
         "type": "intersection"
       },
@@ -5486,12 +5486,12 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #38 -> Road #24",
-          "Road #24 -> Road #38"
-        ],
         "osm_node_ids": [
           1841897176
+        ],
+        "turns": [
+          "Road #38 -> Road #24",
+          "Road #24 -> Road #38"
         ],
         "type": "intersection"
       },
@@ -5529,8 +5529,8 @@
         "control": "Uncontrolled",
         "id": 30,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5567,8 +5567,8 @@
         "control": "Uncontrolled",
         "id": 31,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5605,8 +5605,8 @@
         "control": "Uncontrolled",
         "id": 32,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5643,10 +5643,10 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           631370102
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5683,8 +5683,8 @@
         "control": "Uncontrolled",
         "id": 34,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5721,8 +5721,8 @@
         "control": "Uncontrolled",
         "id": 35,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5763,10 +5763,10 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           29937543
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5811,10 +5811,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2672451455
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5859,10 +5859,10 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3670717205
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5903,10 +5903,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3670717206
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5951,16 +5951,16 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3814693397
+        ],
+        "turns": [
           "Road #32 -> Road #45",
           "Road #32 -> Road #31",
           "Road #45 -> Road #32",
           "Road #45 -> Road #31",
           "Road #31 -> Road #32",
           "Road #31 -> Road #45"
-        ],
-        "osm_node_ids": [
-          3814693397
         ],
         "type": "intersection"
       },
@@ -5998,8 +5998,8 @@
         "control": "Uncontrolled",
         "id": 41,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6052,10 +6052,10 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9454517093
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6092,8 +6092,8 @@
         "control": "Uncontrolled",
         "id": 44,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6134,16 +6134,16 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4696563247
+        ],
+        "turns": [
           "Road #18 -> Road #15",
           "Road #18 -> Road #14",
           "Road #15 -> Road #18",
           "Road #15 -> Road #14",
           "Road #14 -> Road #18",
           "Road #14 -> Road #15"
-        ],
-        "osm_node_ids": [
-          4696563247
         ],
         "type": "intersection"
       },
@@ -6181,8 +6181,8 @@
         "control": "Uncontrolled",
         "id": 46,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6223,16 +6223,16 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          30101230
+        ],
+        "turns": [
           "Road #83 -> Road #84",
           "Road #83 -> Road #50",
           "Road #84 -> Road #83",
           "Road #84 -> Road #50",
           "Road #50 -> Road #83",
           "Road #50 -> Road #84"
-        ],
-        "osm_node_ids": [
-          30101230
         ],
         "type": "intersection"
       },
@@ -6270,8 +6270,8 @@
         "control": "Uncontrolled",
         "id": 48,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6316,10 +6316,10 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695101034
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6356,10 +6356,10 @@
         "control": "Signed",
         "id": 51,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695102711
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6396,10 +6396,10 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695101088
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6448,10 +6448,10 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8819376815
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6488,8 +6488,8 @@
         "control": "Uncontrolled",
         "id": 55,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6534,10 +6534,10 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4696563264
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6582,10 +6582,10 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4696568156
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6630,10 +6630,10 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4696563265
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6670,8 +6670,8 @@
         "control": "Uncontrolled",
         "id": 59,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6708,10 +6708,10 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4696568150
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6760,12 +6760,12 @@
         "control": "Signed",
         "id": 63,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #3 -> Road #2",
-          "Road #2 -> Road #3"
-        ],
         "osm_node_ids": [
           4696568145
+        ],
+        "turns": [
+          "Road #3 -> Road #2",
+          "Road #2 -> Road #3"
         ],
         "type": "intersection"
       },
@@ -6815,11 +6815,11 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #10 -> Road #11"
-        ],
         "osm_node_ids": [
           4696568143
+        ],
+        "turns": [
+          "Road #10 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -6873,11 +6873,11 @@
         "control": "Signed",
         "id": 65,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #11 -> Road #12"
-        ],
         "osm_node_ids": [
           4696568144
+        ],
+        "turns": [
+          "Road #11 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -6927,12 +6927,12 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #14 -> Road #13",
-          "Road #13 -> Road #14"
-        ],
         "osm_node_ids": [
           4696568147
+        ],
+        "turns": [
+          "Road #14 -> Road #13",
+          "Road #13 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -6974,10 +6974,10 @@
         "control": "Signed",
         "id": 70,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4696568160
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7030,10 +7030,10 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4696568153
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7078,10 +7078,10 @@
         "control": "Signed",
         "id": 74,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695101039
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7138,12 +7138,12 @@
         "control": "Signed",
         "id": 75,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #37 -> Road #38",
-          "Road #38 -> Road #37"
-        ],
         "osm_node_ids": [
           1726056700
+        ],
+        "turns": [
+          "Road #37 -> Road #38",
+          "Road #38 -> Road #37"
         ],
         "type": "intersection"
       },
@@ -7197,12 +7197,12 @@
         "control": "Signed",
         "id": 76,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #24 -> Road #23",
-          "Road #23 -> Road #24"
-        ],
         "osm_node_ids": [
           32176581
+        ],
+        "turns": [
+          "Road #24 -> Road #23",
+          "Road #23 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -7240,10 +7240,10 @@
         "control": "Signed",
         "id": 77,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695101028
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7280,10 +7280,10 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829697989
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7328,12 +7328,12 @@
         "control": "Signed",
         "id": 79,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #33 -> Road #34",
-          "Road #34 -> Road #33"
-        ],
         "osm_node_ids": [
           4964465428
+        ],
+        "turns": [
+          "Road #33 -> Road #34",
+          "Road #34 -> Road #33"
         ],
         "type": "intersection"
       },
@@ -7371,10 +7371,10 @@
         "control": "Signed",
         "id": 80,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5757451241
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7415,10 +7415,10 @@
         "control": "Signed",
         "id": 81,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5757451243
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7455,10 +7455,10 @@
         "control": "Signed",
         "id": 82,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5757451242
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7503,12 +7503,12 @@
         "control": "Signed",
         "id": 83,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #84 -> Road #85",
-          "Road #85 -> Road #84"
-        ],
         "osm_node_ids": [
           5766736926
+        ],
+        "turns": [
+          "Road #84 -> Road #85",
+          "Road #85 -> Road #84"
         ],
         "type": "intersection"
       },
@@ -7550,10 +7550,10 @@
         "control": "Signed",
         "id": 84,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5757451262
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7590,8 +7590,8 @@
         "control": "Uncontrolled",
         "id": 85,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7628,8 +7628,8 @@
         "control": "Uncontrolled",
         "id": 86,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7666,10 +7666,10 @@
         "control": "Signed",
         "id": 87,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5766863607
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7718,10 +7718,10 @@
         "control": "Signed",
         "id": 89,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5766863608
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7758,8 +7758,8 @@
         "control": "Uncontrolled",
         "id": 90,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7796,8 +7796,8 @@
         "control": "Uncontrolled",
         "id": 91,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7834,8 +7834,8 @@
         "control": "Uncontrolled",
         "id": 92,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7872,8 +7872,8 @@
         "control": "Uncontrolled",
         "id": 94,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7910,8 +7910,8 @@
         "control": "Uncontrolled",
         "id": 95,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7952,16 +7952,16 @@
         "control": "Signed",
         "id": 96,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          59713406
+        ],
+        "turns": [
           "Road #36 -> Road #103",
           "Road #36 -> Road #37",
           "Road #103 -> Road #36",
           "Road #103 -> Road #37",
           "Road #37 -> Road #36",
           "Road #37 -> Road #103"
-        ],
-        "osm_node_ids": [
-          59713406
         ],
         "type": "intersection"
       },
@@ -8015,12 +8015,12 @@
         "control": "Signed",
         "id": 97,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #17 -> Road #103",
-          "Road #103 -> Road #17"
-        ],
         "osm_node_ids": [
           4696568146
+        ],
+        "turns": [
+          "Road #17 -> Road #103",
+          "Road #103 -> Road #17"
         ],
         "type": "intersection"
       },
@@ -8282,10 +8282,10 @@
         "control": "Signed",
         "id": 98,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8041342867
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8326,10 +8326,10 @@
         "control": "Signed",
         "id": 99,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8041342866
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8366,10 +8366,10 @@
         "control": "Signed",
         "id": 100,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8041342868
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8414,16 +8414,16 @@
         "control": "Signed",
         "id": 101,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          668468707
+        ],
+        "turns": [
           "Road #107 -> Road #33",
           "Road #107 -> Road #32",
           "Road #33 -> Road #107",
           "Road #33 -> Road #32",
           "Road #32 -> Road #107",
           "Road #32 -> Road #33"
-        ],
-        "osm_node_ids": [
-          668468707
         ],
         "type": "intersection"
       },
@@ -8465,10 +8465,10 @@
         "control": "Signed",
         "id": 103,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           8819376814
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8505,10 +8505,10 @@
         "control": "Signed",
         "id": 105,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2672451456
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8553,12 +8553,12 @@
         "control": "Signed",
         "id": 106,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #23 -> Road #22",
-          "Road #22 -> Road #23"
-        ],
         "osm_node_ids": [
           978142408
+        ],
+        "turns": [
+          "Road #23 -> Road #22",
+          "Road #22 -> Road #23"
         ],
         "type": "intersection"
       },

--- a/tests/src/kingsway_junction/geometry.json
+++ b/tests/src/kingsway_junction/geometry.json
@@ -6024,12 +6024,12 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #129 -> Road #0"
-        ],
         "osm_node_ids": [
           9298401799,
           9298401787
+        ],
+        "turns": [
+          "Road #129 -> Road #0"
         ],
         "type": "intersection"
       },
@@ -6075,12 +6075,12 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #0 -> Road #127",
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           7218399545
+        ],
+        "turns": [
+          "Road #0 -> Road #127",
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -6122,12 +6122,12 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #135 -> Road #4",
-          "Road #135 -> Road #94"
-        ],
         "osm_node_ids": [
           31287525
+        ],
+        "turns": [
+          "Road #135 -> Road #4",
+          "Road #135 -> Road #94"
         ],
         "type": "intersection"
       },
@@ -6177,15 +6177,15 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2918402992
+        ],
+        "turns": [
           "Road #131 -> Road #65",
           "Road #131 -> Road #21",
           "Road #5 -> Road #65",
           "Road #5 -> Road #21",
           "Road #65 -> Road #21"
-        ],
-        "osm_node_ids": [
-          2918402992
         ],
         "type": "intersection"
       },
@@ -6227,12 +6227,12 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #74 -> Road #6",
-          "Road #74 -> Road #25"
-        ],
         "osm_node_ids": [
           32025961
+        ],
+        "turns": [
+          "Road #74 -> Road #6",
+          "Road #74 -> Road #25"
         ],
         "type": "intersection"
       },
@@ -6278,12 +6278,12 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #9 -> Road #27",
-          "Road #7 -> Road #27"
-        ],
         "osm_node_ids": [
           32025947
+        ],
+        "turns": [
+          "Road #9 -> Road #27",
+          "Road #7 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -6353,18 +6353,18 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          21653578,
+          31287524,
+          6137128386
+        ],
+        "turns": [
           "Road #121 -> Road #132",
           "Road #121 -> Road #111",
           "Road #121 -> Road #8",
           "Road #113 -> Road #132",
           "Road #113 -> Road #111",
           "Road #113 -> Road #8"
-        ],
-        "osm_node_ids": [
-          21653578,
-          31287524,
-          6137128386
         ],
         "type": "intersection"
       },
@@ -6402,8 +6402,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6440,10 +6440,10 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           955165930
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6492,11 +6492,11 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #14 -> Road #11"
-        ],
         "osm_node_ids": [
           743547964
+        ],
+        "turns": [
+          "Road #14 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -6534,8 +6534,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6580,12 +6580,12 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #133 -> Road #14",
-          "Road #133 -> Road #134"
-        ],
         "osm_node_ids": [
           743548189
+        ],
+        "turns": [
+          "Road #133 -> Road #14",
+          "Road #133 -> Road #134"
         ],
         "type": "intersection"
       },
@@ -6631,13 +6631,13 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          743548139
+        ],
+        "turns": [
           "Road #15 -> Road #13",
           "Road #12 -> Road #13",
           "Road #12 -> Road #15"
-        ],
-        "osm_node_ids": [
-          743548139
         ],
         "type": "intersection"
       },
@@ -6675,8 +6675,8 @@
         "control": "Uncontrolled",
         "id": 16,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6713,8 +6713,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6763,16 +6763,16 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          745988281
+        ],
+        "turns": [
           "Road #29 -> Road #126",
           "Road #29 -> Road #16",
           "Road #126 -> Road #29",
           "Road #126 -> Road #16",
           "Road #16 -> Road #29",
           "Road #16 -> Road #126"
-        ],
-        "osm_node_ids": [
-          745988281
         ],
         "type": "intersection"
       },
@@ -6814,16 +6814,16 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          745988253
+        ],
+        "turns": [
           "Road #159 -> Road #17",
           "Road #159 -> Road #158",
           "Road #17 -> Road #159",
           "Road #17 -> Road #158",
           "Road #158 -> Road #159",
           "Road #158 -> Road #17"
-        ],
-        "osm_node_ids": [
-          745988253
         ],
         "type": "intersection"
       },
@@ -6861,8 +6861,8 @@
         "control": "Uncontrolled",
         "id": 20,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6903,13 +6903,13 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          955166004
+        ],
+        "turns": [
           "Road #91 -> Road #19",
           "Road #91 -> Road #109",
           "Road #19 -> Road #109"
-        ],
-        "osm_node_ids": [
-          955166004
         ],
         "type": "intersection"
       },
@@ -6947,8 +6947,8 @@
         "control": "Uncontrolled",
         "id": 22,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6985,11 +6985,11 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #21 -> Road #122"
-        ],
         "osm_node_ids": [
           6480352128
+        ],
+        "turns": [
+          "Road #21 -> Road #122"
         ],
         "type": "intersection"
       },
@@ -7083,20 +7083,20 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #111 -> Road #113",
-          "Road #111 -> Road #130",
-          "Road #111 -> Road #89",
-          "Road #2 -> Road #113",
-          "Road #2 -> Road #130",
-          "Road #2 -> Road #89"
-        ],
         "osm_node_ids": [
           31287523,
           21653579,
           6480352153,
           6137128398,
           2918379027
+        ],
+        "turns": [
+          "Road #111 -> Road #113",
+          "Road #111 -> Road #130",
+          "Road #111 -> Road #89",
+          "Road #2 -> Road #113",
+          "Road #2 -> Road #130",
+          "Road #2 -> Road #89"
         ],
         "type": "intersection"
       },
@@ -7134,8 +7134,8 @@
         "control": "Uncontrolled",
         "id": 27,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7176,10 +7176,10 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           929679768
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7224,10 +7224,10 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           955166153
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7264,10 +7264,10 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           955165990
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7304,10 +7304,10 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           955166172
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7352,10 +7352,10 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           955166067
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7392,8 +7392,8 @@
         "control": "Uncontrolled",
         "id": 34,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7430,8 +7430,8 @@
         "control": "Uncontrolled",
         "id": 36,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7468,11 +7468,11 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #42 -> Road #39"
-        ],
         "osm_node_ids": [
           31287503
+        ],
+        "turns": [
+          "Road #42 -> Road #39"
         ],
         "type": "intersection"
       },
@@ -7510,11 +7510,11 @@
         "control": "Signalled",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #39 -> Road #129"
-        ],
         "osm_node_ids": [
           1277766621
+        ],
+        "turns": [
+          "Road #39 -> Road #129"
         ],
         "type": "intersection"
       },
@@ -7552,11 +7552,11 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #124 -> Road #40"
-        ],
         "osm_node_ids": [
           1277766809
+        ],
+        "turns": [
+          "Road #124 -> Road #40"
         ],
         "type": "intersection"
       },
@@ -7594,11 +7594,11 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #40 -> Road #123"
-        ],
         "osm_node_ids": [
           1277766903
+        ],
+        "turns": [
+          "Road #40 -> Road #123"
         ],
         "type": "intersection"
       },
@@ -7636,8 +7636,8 @@
         "control": "Uncontrolled",
         "id": 41,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7682,10 +7682,10 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401802
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7726,11 +7726,11 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #11 -> Road #12"
-        ],
         "osm_node_ids": [
           2790145018
+        ],
+        "turns": [
+          "Road #11 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -7768,10 +7768,10 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           2790145014
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7808,8 +7808,8 @@
         "control": "Uncontrolled",
         "id": 46,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7854,10 +7854,10 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153421
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7894,10 +7894,10 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153427
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7934,10 +7934,10 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153430
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7974,10 +7974,10 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153418
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8014,10 +8014,10 @@
         "control": "Signed",
         "id": 51,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153400
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8058,10 +8058,10 @@
         "control": "Signed",
         "id": 52,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153452
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8102,10 +8102,10 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153455
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8142,10 +8142,10 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2913567877
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8182,10 +8182,10 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2913567879
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8230,10 +8230,10 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153398
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8274,10 +8274,10 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153411
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8322,10 +8322,10 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6480352136
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8382,11 +8382,11 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           955166125,
           4140571229
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8423,10 +8423,10 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2913629004
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8463,10 +8463,10 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9169444979
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8503,8 +8503,8 @@
         "control": "Uncontrolled",
         "id": 62,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8549,10 +8549,10 @@
         "control": "Signed",
         "id": 63,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8778698139
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8593,10 +8593,10 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2918402993
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8633,10 +8633,10 @@
         "control": "Signed",
         "id": 65,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           2918402990
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8673,8 +8673,8 @@
         "control": "Uncontrolled",
         "id": 66,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8751,14 +8751,14 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #38 -> Road #42",
-          "Road #41 -> Road #42",
-          "Road #41 -> Road #38"
-        ],
         "osm_node_ids": [
           6439595293,
           4145063897
+        ],
+        "turns": [
+          "Road #38 -> Road #42",
+          "Road #41 -> Road #42",
+          "Road #41 -> Road #38"
         ],
         "type": "intersection"
       },
@@ -8796,8 +8796,8 @@
         "control": "Uncontrolled",
         "id": 69,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8834,8 +8834,8 @@
         "control": "Uncontrolled",
         "id": 70,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8876,10 +8876,10 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401791
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8932,11 +8932,11 @@
         "control": "Signalled",
         "id": 73,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #1 -> Road #2"
-        ],
         "osm_node_ids": [
           5401617906
+        ],
+        "turns": [
+          "Road #1 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -8986,10 +8986,10 @@
         "control": "Signed",
         "id": 74,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6137128074
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9034,10 +9034,10 @@
         "control": "Signed",
         "id": 75,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6480352137
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9094,11 +9094,11 @@
         "control": "Signalled",
         "id": 76,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #5"
-        ],
         "osm_node_ids": [
           1279849947
+        ],
+        "turns": [
+          "Road #4 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -9140,10 +9140,10 @@
         "control": "Signed",
         "id": 77,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298570028
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9180,8 +9180,8 @@
         "control": "Uncontrolled",
         "id": 78,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9234,11 +9234,11 @@
         "control": "Signalled",
         "id": 79,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #87 -> Road #88"
-        ],
         "osm_node_ids": [
           6137128082
+        ],
+        "turns": [
+          "Road #87 -> Road #88"
         ],
         "type": "intersection"
       },
@@ -9292,15 +9292,15 @@
         "control": "Signed",
         "id": 80,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6137128391,
+          8672774809
+        ],
+        "turns": [
           "Road #75 -> Road #74",
           "Road #75 -> Road #92",
           "Road #72 -> Road #74",
           "Road #72 -> Road #92"
-        ],
-        "osm_node_ids": [
-          6137128391,
-          8672774809
         ],
         "type": "intersection"
       },
@@ -9358,11 +9358,11 @@
         "control": "Signalled",
         "id": 81,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #94 -> Road #95"
-        ],
         "osm_node_ids": [
           6137128076
+        ],
+        "turns": [
+          "Road #94 -> Road #95"
         ],
         "type": "intersection"
       },
@@ -9412,10 +9412,10 @@
         "control": "Signed",
         "id": 82,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6137128071
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9472,11 +9472,11 @@
         "control": "Signalled",
         "id": 84,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #92 -> Road #93"
-        ],
         "osm_node_ids": [
           6137128401
+        ],
+        "turns": [
+          "Road #92 -> Road #93"
         ],
         "type": "intersection"
       },
@@ -9534,11 +9534,11 @@
         "control": "Signalled",
         "id": 85,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #25 -> Road #26"
-        ],
         "osm_node_ids": [
           6137128402
+        ],
+        "turns": [
+          "Road #25 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -9584,10 +9584,10 @@
         "control": "Signed",
         "id": 86,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6137128407
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9632,10 +9632,10 @@
         "control": "Signed",
         "id": 87,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6480352130
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9688,11 +9688,11 @@
         "control": "Signed",
         "id": 88,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #8 -> Road #9"
-        ],
         "osm_node_ids": [
           6137128411
+        ],
+        "turns": [
+          "Road #8 -> Road #9"
         ],
         "type": "intersection"
       },
@@ -9746,11 +9746,11 @@
         "control": "Signalled",
         "id": 89,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #6 -> Road #7"
-        ],
         "osm_node_ids": [
           6137128405
+        ],
+        "turns": [
+          "Road #6 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -9788,10 +9788,10 @@
         "control": "Signed",
         "id": 90,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6137128408
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9828,8 +9828,8 @@
         "control": "Uncontrolled",
         "id": 91,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9882,12 +9882,12 @@
         "control": "Signed",
         "id": 94,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #63 -> Road #65",
-          "Road #65 -> Road #63"
-        ],
         "osm_node_ids": [
           6480352139
+        ],
+        "turns": [
+          "Road #63 -> Road #65",
+          "Road #65 -> Road #63"
         ],
         "type": "intersection"
       },
@@ -9925,8 +9925,8 @@
         "control": "Uncontrolled",
         "id": 95,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9963,10 +9963,10 @@
         "control": "Signed",
         "id": 98,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2790153424
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10003,8 +10003,8 @@
         "control": "Uncontrolled",
         "id": 99,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10041,8 +10041,8 @@
         "control": "Uncontrolled",
         "id": 100,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10095,11 +10095,11 @@
         "control": "Signalled",
         "id": 101,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #120 -> Road #121"
-        ],
         "osm_node_ids": [
           6137128410
+        ],
+        "turns": [
+          "Road #120 -> Road #121"
         ],
         "type": "intersection"
       },
@@ -10157,11 +10157,11 @@
         "control": "Signalled",
         "id": 102,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #122 -> Road #124"
-        ],
         "osm_node_ids": [
           2265010779
+        ],
+        "turns": [
+          "Road #122 -> Road #124"
         ],
         "type": "intersection"
       },
@@ -10199,8 +10199,8 @@
         "control": "Uncontrolled",
         "id": 103,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10257,11 +10257,11 @@
         "control": "Signalled",
         "id": 105,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #127 -> Road #128"
-        ],
         "osm_node_ids": [
           6137128073
+        ],
+        "turns": [
+          "Road #127 -> Road #128"
         ],
         "type": "intersection"
       },
@@ -10311,11 +10311,11 @@
         "control": "Signed",
         "id": 106,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #130 -> Road #131"
-        ],
         "osm_node_ids": [
           5401617909
+        ],
+        "turns": [
+          "Road #130 -> Road #131"
         ],
         "type": "intersection"
       },
@@ -10369,11 +10369,11 @@
         "control": "Signed",
         "id": 107,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #132 -> Road #133"
-        ],
         "osm_node_ids": [
           32025962
+        ],
+        "turns": [
+          "Road #132 -> Road #133"
         ],
         "type": "intersection"
       },
@@ -10411,8 +10411,8 @@
         "control": "Uncontrolled",
         "id": 108,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10449,8 +10449,8 @@
         "control": "Uncontrolled",
         "id": 109,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10503,11 +10503,11 @@
         "control": "Signed",
         "id": 110,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           955165980,
           955166095
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10544,8 +10544,8 @@
         "control": "Uncontrolled",
         "id": 111,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10590,11 +10590,11 @@
         "control": "Signed",
         "id": 112,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #90 -> Road #91"
-        ],
         "osm_node_ids": [
           9298401795
+        ],
+        "turns": [
+          "Road #90 -> Road #91"
         ],
         "type": "intersection"
       },
@@ -10632,10 +10632,10 @@
         "control": "Signed",
         "id": 113,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401797
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10672,10 +10672,10 @@
         "control": "Signed",
         "id": 114,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401796
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10720,11 +10720,11 @@
         "control": "Signed",
         "id": 115,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #89 -> Road #90"
-        ],
         "osm_node_ids": [
           9298401798
+        ],
+        "turns": [
+          "Road #89 -> Road #90"
         ],
         "type": "intersection"
       },
@@ -10766,10 +10766,10 @@
         "control": "Signed",
         "id": 116,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401793
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10806,10 +10806,10 @@
         "control": "Signed",
         "id": 117,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401808
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10846,8 +10846,8 @@
         "control": "Uncontrolled",
         "id": 118,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10884,10 +10884,10 @@
         "control": "Signed",
         "id": 120,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401809
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10928,10 +10928,10 @@
         "control": "Signed",
         "id": 121,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9298401794
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10988,12 +10988,12 @@
         "control": "Signed",
         "id": 122,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #19 -> Road #20",
-          "Road #20 -> Road #19"
-        ],
         "osm_node_ids": [
           9298401919
+        ],
+        "turns": [
+          "Road #19 -> Road #20",
+          "Road #20 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -11031,8 +11031,8 @@
         "control": "Uncontrolled",
         "id": 123,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11069,8 +11069,8 @@
         "control": "Uncontrolled",
         "id": 124,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11107,8 +11107,8 @@
         "control": "Uncontrolled",
         "id": 126,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11145,8 +11145,8 @@
         "control": "Uncontrolled",
         "id": 127,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11195,7 +11195,10 @@
         "control": "Signed",
         "id": 128,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          745988091
+        ],
+        "turns": [
           "Road #158 -> Road #17",
           "Road #158 -> Road #160",
           "Road #158 -> Road #18",
@@ -11208,9 +11211,6 @@
           "Road #18 -> Road #158",
           "Road #18 -> Road #17",
           "Road #18 -> Road #160"
-        ],
-        "osm_node_ids": [
-          745988091
         ],
         "type": "intersection"
       },

--- a/tests/src/leeds_cycleway/geometry.json
+++ b/tests/src/leeds_cycleway/geometry.json
@@ -22220,12 +22220,12 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #541 -> Road #0",
-          "Road #541 -> Road #539"
-        ],
         "osm_node_ids": [
           26298423
+        ],
+        "turns": [
+          "Road #541 -> Road #0",
+          "Road #541 -> Road #539"
         ],
         "type": "intersection"
       },
@@ -22263,8 +22263,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22305,12 +22305,12 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #576 -> Road #2",
-          "Road #576 -> Road #349"
-        ],
         "osm_node_ids": [
           643945
+        ],
+        "turns": [
+          "Road #576 -> Road #2",
+          "Road #576 -> Road #349"
         ],
         "type": "intersection"
       },
@@ -22376,13 +22376,13 @@
         "control": "Signalled",
         "id": 4,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          643914
+        ],
+        "turns": [
           "Road #295 -> Road #4",
           "Road #276 -> Road #4",
           "Road #276 -> Road #498"
-        ],
-        "osm_node_ids": [
-          643914
         ],
         "type": "intersection"
       },
@@ -22432,12 +22432,12 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #5 -> Road #71",
-          "Road #23 -> Road #71"
-        ],
         "osm_node_ids": [
           301689321
+        ],
+        "turns": [
+          "Road #5 -> Road #71",
+          "Road #23 -> Road #71"
         ],
         "type": "intersection"
       },
@@ -22479,12 +22479,12 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #535 -> Road #6",
-          "Road #535 -> Road #533"
-        ],
         "osm_node_ids": [
           26298420
+        ],
+        "turns": [
+          "Road #535 -> Road #6",
+          "Road #535 -> Road #533"
         ],
         "type": "intersection"
       },
@@ -22526,12 +22526,12 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #6 -> Road #313",
-          "Road #240 -> Road #313"
-        ],
         "osm_node_ids": [
           1022749752
+        ],
+        "turns": [
+          "Road #6 -> Road #313",
+          "Road #240 -> Road #313"
         ],
         "type": "intersection"
       },
@@ -22581,12 +22581,12 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #347 -> Road #348",
-          "Road #348 -> Road #347"
-        ],
         "osm_node_ids": [
           301689309
+        ],
+        "turns": [
+          "Road #347 -> Road #348",
+          "Road #348 -> Road #347"
         ],
         "type": "intersection"
       },
@@ -22624,8 +22624,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22674,14 +22674,14 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          26661450
+        ],
+        "turns": [
           "Road #200 -> Road #9",
           "Road #200 -> Road #199",
           "Road #199 -> Road #9",
           "Road #199 -> Road #200"
-        ],
-        "osm_node_ids": [
-          26661450
         ],
         "type": "intersection"
       },
@@ -22723,11 +22723,11 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #10 -> Road #523"
-        ],
         "osm_node_ids": [
           5506378793
+        ],
+        "turns": [
+          "Road #10 -> Road #523"
         ],
         "type": "intersection"
       },
@@ -22769,10 +22769,10 @@
         "control": "Signalled",
         "id": 12,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5728993713
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22825,14 +22825,14 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5728993689
+        ],
+        "turns": [
           "Road #11 -> Road #622",
           "Road #11 -> Road #624",
           "Road #287 -> Road #622",
           "Road #287 -> Road #624"
-        ],
-        "osm_node_ids": [
-          5728993689
         ],
         "type": "intersection"
       },
@@ -22874,12 +22874,12 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #271 -> Road #12",
-          "Road #271 -> Road #277"
-        ],
         "osm_node_ids": [
           26298430
+        ],
+        "turns": [
+          "Road #271 -> Road #12",
+          "Road #271 -> Road #277"
         ],
         "type": "intersection"
       },
@@ -22917,8 +22917,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22955,8 +22955,8 @@
         "control": "Uncontrolled",
         "id": 16,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22993,8 +22993,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23031,10 +23031,10 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           26298442
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23071,8 +23071,8 @@
         "control": "Uncontrolled",
         "id": 19,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23109,10 +23109,10 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           60197213
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23149,10 +23149,10 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           60197210
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23189,8 +23189,8 @@
         "control": "Uncontrolled",
         "id": 22,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23231,12 +23231,12 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #273 -> Road #21",
-          "Road #273 -> Road #275"
-        ],
         "osm_node_ids": [
           643911
+        ],
+        "turns": [
+          "Road #273 -> Road #21",
+          "Road #273 -> Road #275"
         ],
         "type": "intersection"
       },
@@ -23278,14 +23278,14 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9791722
+        ],
+        "turns": [
           "Road #24 -> Road #230",
           "Road #230 -> Road #24",
           "Road #55 -> Road #24",
           "Road #55 -> Road #230"
-        ],
-        "osm_node_ids": [
-          9791722
         ],
         "type": "intersection"
       },
@@ -23323,8 +23323,8 @@
         "control": "Uncontrolled",
         "id": 25,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23377,12 +23377,12 @@
         "control": "Signalled",
         "id": 26,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #315 -> Road #27",
-          "Road #377 -> Road #27"
-        ],
         "osm_node_ids": [
           5452444899
+        ],
+        "turns": [
+          "Road #315 -> Road #27",
+          "Road #377 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -23424,10 +23424,10 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           342579517
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23464,8 +23464,8 @@
         "control": "Uncontrolled",
         "id": 29,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23506,11 +23506,11 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #80 -> Road #81"
-        ],
         "osm_node_ids": [
           26661442
+        ],
+        "turns": [
+          "Road #80 -> Road #81"
         ],
         "type": "intersection"
       },
@@ -23552,13 +23552,13 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          26661452
+        ],
+        "turns": [
           "Road #9 -> Road #30",
           "Road #9 -> Road #10",
           "Road #30 -> Road #10"
-        ],
-        "osm_node_ids": [
-          26661452
         ],
         "type": "intersection"
       },
@@ -23596,10 +23596,10 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           342529328
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23660,12 +23660,12 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #72 -> Road #530",
-          "Road #72 -> Road #377"
-        ],
         "osm_node_ids": [
           5452444896
+        ],
+        "turns": [
+          "Road #72 -> Road #530",
+          "Road #72 -> Road #377"
         ],
         "type": "intersection"
       },
@@ -23707,11 +23707,11 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #430 -> Road #428"
-        ],
         "osm_node_ids": [
           342579667
+        ],
+        "turns": [
+          "Road #430 -> Road #428"
         ],
         "type": "intersection"
       },
@@ -23765,7 +23765,10 @@
         "control": "Signed",
         "id": 35,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          342579565
+        ],
+        "turns": [
           "Road #36 -> Road #58",
           "Road #36 -> Road #57",
           "Road #58 -> Road #36",
@@ -23775,9 +23778,6 @@
           "Road #211 -> Road #57",
           "Road #57 -> Road #36",
           "Road #57 -> Road #58"
-        ],
-        "osm_node_ids": [
-          342579565
         ],
         "type": "intersection"
       },
@@ -23815,10 +23815,10 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7241259895
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23859,12 +23859,12 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #12 -> Road #13",
-          "Road #12 -> Road #37"
-        ],
         "osm_node_ids": [
           342579576
+        ],
+        "turns": [
+          "Road #12 -> Road #13",
+          "Road #12 -> Road #37"
         ],
         "type": "intersection"
       },
@@ -23910,12 +23910,12 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #37 -> Road #52",
-          "Road #51 -> Road #52"
-        ],
         "osm_node_ids": [
           342579578
+        ],
+        "turns": [
+          "Road #37 -> Road #52",
+          "Road #51 -> Road #52"
         ],
         "type": "intersection"
       },
@@ -23961,13 +23961,13 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          342579580
+        ],
+        "turns": [
           "Road #38 -> Road #55",
           "Road #54 -> Road #55",
           "Road #54 -> Road #38"
-        ],
-        "osm_node_ids": [
-          342579580
         ],
         "type": "intersection"
       },
@@ -24005,10 +24005,10 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           342579596
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24049,16 +24049,16 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          342579586
+        ],
+        "turns": [
           "Road #40 -> Road #39",
           "Road #40 -> Road #38",
           "Road #39 -> Road #40",
           "Road #39 -> Road #38",
           "Road #38 -> Road #40",
           "Road #38 -> Road #39"
-        ],
-        "osm_node_ids": [
-          342579586
         ],
         "type": "intersection"
       },
@@ -24096,10 +24096,10 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           342579609
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24140,12 +24140,12 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #291 -> Road #42",
-          "Road #157 -> Road #42"
-        ],
         "osm_node_ids": [
           26109191
+        ],
+        "turns": [
+          "Road #291 -> Road #42",
+          "Road #157 -> Road #42"
         ],
         "type": "intersection"
       },
@@ -24187,11 +24187,11 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #43 -> Road #430"
-        ],
         "osm_node_ids": [
           342579538
+        ],
+        "turns": [
+          "Road #43 -> Road #430"
         ],
         "type": "intersection"
       },
@@ -24245,12 +24245,12 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #630 -> Road #347",
-          "Road #347 -> Road #630"
-        ],
         "osm_node_ids": [
           342579666
+        ],
+        "turns": [
+          "Road #630 -> Road #347",
+          "Road #347 -> Road #630"
         ],
         "type": "intersection"
       },
@@ -24292,12 +24292,12 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #536 -> Road #47",
-          "Road #536 -> Road #537"
-        ],
         "osm_node_ids": [
           643946
+        ],
+        "turns": [
+          "Road #536 -> Road #47",
+          "Road #536 -> Road #537"
         ],
         "type": "intersection"
       },
@@ -24335,10 +24335,10 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           342579557
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24375,8 +24375,8 @@
         "control": "Uncontrolled",
         "id": 49,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24441,15 +24441,15 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          342628235
+        ],
+        "turns": [
           "Road #117 -> Road #274",
           "Road #117 -> Road #59",
           "Road #498 -> Road #284",
           "Road #498 -> Road #274",
           "Road #498 -> Road #59"
-        ],
-        "osm_node_ids": [
-          342628235
         ],
         "type": "intersection"
       },
@@ -24503,12 +24503,12 @@
         "control": "Signed",
         "id": 51,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #59 -> Road #499",
-          "Road #433 -> Road #499"
-        ],
         "osm_node_ids": [
           5728993836
+        ],
+        "turns": [
+          "Road #59 -> Road #499",
+          "Road #433 -> Road #499"
         ],
         "type": "intersection"
       },
@@ -24550,11 +24550,11 @@
         "control": "Signed",
         "id": 52,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #289 -> Road #222"
-        ],
         "osm_node_ids": [
           358204009
+        ],
+        "turns": [
+          "Road #289 -> Road #222"
         ],
         "type": "intersection"
       },
@@ -24592,10 +24592,10 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           358204012
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24660,12 +24660,12 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #128 -> Road #103",
-          "Road #237 -> Road #103"
-        ],
         "osm_node_ids": [
           3381506666
+        ],
+        "turns": [
+          "Road #128 -> Road #103",
+          "Road #237 -> Road #103"
         ],
         "type": "intersection"
       },
@@ -24751,12 +24751,12 @@
         "control": "Signalled",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3381506667,
           6211582997,
           1591373158
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24793,11 +24793,11 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #159 -> Road #62"
-        ],
         "osm_node_ids": [
           9823112
+        ],
+        "turns": [
+          "Road #159 -> Road #62"
         ],
         "type": "intersection"
       },
@@ -24839,12 +24839,12 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #62 -> Road #73",
-          "Road #62 -> Road #160"
-        ],
         "osm_node_ids": [
           370191920
+        ],
+        "turns": [
+          "Road #62 -> Road #73",
+          "Road #62 -> Road #160"
         ],
         "type": "intersection"
       },
@@ -24886,11 +24886,11 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #530 -> Road #63"
-        ],
         "osm_node_ids": [
           26660391
+        ],
+        "turns": [
+          "Road #530 -> Road #63"
         ],
         "type": "intersection"
       },
@@ -24932,12 +24932,12 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #534 -> Road #540",
-          "Road #66 -> Road #540"
-        ],
         "osm_node_ids": [
           643907
+        ],
+        "turns": [
+          "Road #534 -> Road #540",
+          "Road #66 -> Road #540"
         ],
         "type": "intersection"
       },
@@ -24983,12 +24983,12 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #64 -> Road #65",
-          "Road #67 -> Road #65"
-        ],
         "osm_node_ids": [
           26300437
+        ],
+        "turns": [
+          "Road #64 -> Road #65",
+          "Road #67 -> Road #65"
         ],
         "type": "intersection"
       },
@@ -25042,11 +25042,11 @@
         "control": "Signed",
         "id": 62,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           342579525,
           2275824778
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25091,11 +25091,11 @@
         "control": "Signalled",
         "id": 63,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #71 -> Road #72"
-        ],
         "osm_node_ids": [
           319558919
+        ],
+        "turns": [
+          "Road #71 -> Road #72"
         ],
         "type": "intersection"
       },
@@ -25133,8 +25133,8 @@
         "control": "Uncontrolled",
         "id": 64,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25171,8 +25171,8 @@
         "control": "Uncontrolled",
         "id": 65,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25209,8 +25209,8 @@
         "control": "Uncontrolled",
         "id": 66,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25251,11 +25251,11 @@
         "control": "Signed",
         "id": 67,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #75 -> Road #272"
-        ],
         "osm_node_ids": [
           1152092910
+        ],
+        "turns": [
+          "Road #75 -> Road #272"
         ],
         "type": "intersection"
       },
@@ -25297,10 +25297,10 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7261942276
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25353,11 +25353,11 @@
         "control": "Signalled",
         "id": 69,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           9319419251
+        ],
+        "turns": [
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -25395,10 +25395,10 @@
         "control": "Signed",
         "id": 70,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9319419252
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25439,13 +25439,13 @@
         "control": "Signalled",
         "id": 71,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          643951
+        ],
+        "turns": [
           "Road #104 -> Road #532",
           "Road #104 -> Road #79",
           "Road #532 -> Road #79"
-        ],
-        "osm_node_ids": [
-          643951
         ],
         "type": "intersection"
       },
@@ -25487,12 +25487,12 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #79 -> Road #322",
-          "Road #79 -> Road #319"
-        ],
         "osm_node_ids": [
           659971029
+        ],
+        "turns": [
+          "Road #79 -> Road #322",
+          "Road #79 -> Road #319"
         ],
         "type": "intersection"
       },
@@ -25530,8 +25530,8 @@
         "control": "Uncontrolled",
         "id": 73,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25584,11 +25584,11 @@
         "control": "Signalled",
         "id": 74,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #81 -> Road #295"
-        ],
         "osm_node_ids": [
           5728993833
+        ],
+        "turns": [
+          "Road #81 -> Road #295"
         ],
         "type": "intersection"
       },
@@ -25642,11 +25642,11 @@
         "control": "Signed",
         "id": 75,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #106 -> Road #107"
-        ],
         "osm_node_ids": [
           1591373175
+        ],
+        "turns": [
+          "Road #106 -> Road #107"
         ],
         "type": "intersection"
       },
@@ -25700,10 +25700,10 @@
         "control": "Signalled",
         "id": 76,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1591373161
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25756,11 +25756,11 @@
         "control": "Signalled",
         "id": 77,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #272 -> Road #223"
-        ],
         "osm_node_ids": [
           615978081
+        ],
+        "turns": [
+          "Road #272 -> Road #223"
         ],
         "type": "intersection"
       },
@@ -25814,12 +25814,12 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #102 -> Road #99",
-          "Road #99 -> Road #102"
-        ],
         "osm_node_ids": [
           1569761300
+        ],
+        "turns": [
+          "Road #102 -> Road #99",
+          "Road #99 -> Road #102"
         ],
         "type": "intersection"
       },
@@ -25861,16 +25861,16 @@
         "control": "Signed",
         "id": 79,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          26661448
+        ],
+        "turns": [
           "Road #202 -> Road #87",
           "Road #202 -> Road #201",
           "Road #87 -> Road #202",
           "Road #87 -> Road #201",
           "Road #201 -> Road #202",
           "Road #201 -> Road #87"
-        ],
-        "osm_node_ids": [
-          26661448
         ],
         "type": "intersection"
       },
@@ -25916,16 +25916,16 @@
         "control": "Signed",
         "id": 80,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          394143337
+        ],
+        "turns": [
           "Road #94 -> Road #93",
           "Road #94 -> Road #88",
           "Road #93 -> Road #94",
           "Road #93 -> Road #88",
           "Road #88 -> Road #94",
           "Road #88 -> Road #93"
-        ],
-        "osm_node_ids": [
-          394143337
         ],
         "type": "intersection"
       },
@@ -25971,16 +25971,16 @@
         "control": "Signed",
         "id": 81,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1296601330
+        ],
+        "turns": [
           "Road #99 -> Road #100",
           "Road #99 -> Road #89",
           "Road #100 -> Road #99",
           "Road #100 -> Road #89",
           "Road #89 -> Road #99",
           "Road #89 -> Road #100"
-        ],
-        "osm_node_ids": [
-          1296601330
         ],
         "type": "intersection"
       },
@@ -26026,12 +26026,12 @@
         "control": "Signed",
         "id": 82,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #487 -> Road #89",
-          "Road #89 -> Road #487"
-        ],
         "osm_node_ids": [
           7237437098
+        ],
+        "turns": [
+          "Road #487 -> Road #89",
+          "Road #89 -> Road #487"
         ],
         "type": "intersection"
       },
@@ -26069,8 +26069,8 @@
         "control": "Uncontrolled",
         "id": 83,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26107,10 +26107,10 @@
         "control": "Signed",
         "id": 84,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583011
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26175,12 +26175,12 @@
         "control": "Signalled",
         "id": 85,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #103 -> Road #104"
-        ],
         "osm_node_ids": [
           1591373154,
           1152092781
+        ],
+        "turns": [
+          "Road #103 -> Road #104"
         ],
         "type": "intersection"
       },
@@ -26218,8 +26218,8 @@
         "control": "Uncontrolled",
         "id": 86,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26256,10 +26256,10 @@
         "control": "Signed",
         "id": 87,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4361246658
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26296,8 +26296,8 @@
         "control": "Uncontrolled",
         "id": 88,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26342,16 +26342,16 @@
         "control": "Signed",
         "id": 89,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          342579559
+        ],
+        "turns": [
           "Road #57 -> Road #101",
           "Road #57 -> Road #56",
           "Road #101 -> Road #57",
           "Road #101 -> Road #56",
           "Road #56 -> Road #57",
           "Road #56 -> Road #101"
-        ],
-        "osm_node_ids": [
-          342579559
         ],
         "type": "intersection"
       },
@@ -26389,10 +26389,10 @@
         "control": "Signed",
         "id": 90,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           1591164975
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26441,14 +26441,14 @@
         "control": "Signed",
         "id": 91,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1569783677
+        ],
+        "turns": [
           "Road #223 -> Road #102",
           "Road #223 -> Road #531",
           "Road #102 -> Road #531",
           "Road #531 -> Road #102"
-        ],
-        "osm_node_ids": [
-          1569783677
         ],
         "type": "intersection"
       },
@@ -26486,8 +26486,8 @@
         "control": "Uncontrolled",
         "id": 92,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26528,12 +26528,12 @@
         "control": "Signed",
         "id": 93,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #125 -> Road #106",
-          "Road #125 -> Road #126"
-        ],
         "osm_node_ids": [
           1591373171
+        ],
+        "turns": [
+          "Road #125 -> Road #106",
+          "Road #125 -> Road #126"
         ],
         "type": "intersection"
       },
@@ -26571,8 +26571,8 @@
         "control": "Uncontrolled",
         "id": 94,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26609,8 +26609,8 @@
         "control": "Uncontrolled",
         "id": 95,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26655,10 +26655,10 @@
         "control": "Signed",
         "id": 96,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2014304901
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26711,7 +26711,6 @@
         "control": "Signalled",
         "id": 98,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1606819535,
           2275824763,
@@ -26721,6 +26720,7 @@
           7237437116,
           5452444894
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26761,10 +26761,10 @@
         "control": "Signed",
         "id": 99,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           342579521
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26817,7 +26817,11 @@
         "control": "Signed",
         "id": 100,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          26661454,
+          9740274255
+        ],
+        "turns": [
           "Road #118 -> Road #625",
           "Road #118 -> Road #525",
           "Road #523 -> Road #118",
@@ -26825,10 +26829,6 @@
           "Road #523 -> Road #525",
           "Road #625 -> Road #118",
           "Road #625 -> Road #525"
-        ],
-        "osm_node_ids": [
-          26661454,
-          9740274255
         ],
         "type": "intersection"
       },
@@ -26866,10 +26866,10 @@
         "control": "Signed",
         "id": 102,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6584937059
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26906,8 +26906,8 @@
         "control": "Uncontrolled",
         "id": 103,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26944,10 +26944,10 @@
         "control": "Signed",
         "id": 104,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1675168033
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26984,10 +26984,10 @@
         "control": "Signed",
         "id": 105,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1675168031
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27024,8 +27024,8 @@
         "control": "Uncontrolled",
         "id": 106,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27062,10 +27062,10 @@
         "control": "Signed",
         "id": 108,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1877939969
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27106,10 +27106,10 @@
         "control": "Signed",
         "id": 109,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1877939944
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27146,10 +27146,10 @@
         "control": "Signed",
         "id": 110,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1877939939
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27202,11 +27202,11 @@
         "control": "Signed",
         "id": 111,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #21 -> Road #22"
-        ],
         "osm_node_ids": [
           301689312
+        ],
+        "turns": [
+          "Road #21 -> Road #22"
         ],
         "type": "intersection"
       },
@@ -27260,10 +27260,10 @@
         "control": "Signalled",
         "id": 113,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8174077588
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27304,10 +27304,10 @@
         "control": "Signed",
         "id": 114,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1877939977
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27352,12 +27352,12 @@
         "control": "Signed",
         "id": 115,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #277 -> Road #139",
-          "Road #277 -> Road #278"
-        ],
         "osm_node_ids": [
           2014304918
+        ],
+        "turns": [
+          "Road #277 -> Road #139",
+          "Road #277 -> Road #278"
         ],
         "type": "intersection"
       },
@@ -27403,12 +27403,12 @@
         "control": "Signed",
         "id": 116,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #50 -> Road #51",
-          "Road #140 -> Road #51"
-        ],
         "osm_node_ids": [
           9791699
+        ],
+        "turns": [
+          "Road #50 -> Road #51",
+          "Road #140 -> Road #51"
         ],
         "type": "intersection"
       },
@@ -27454,10 +27454,10 @@
         "control": "Signed",
         "id": 117,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2014304864
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27502,11 +27502,11 @@
         "control": "Signalled",
         "id": 119,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #139 -> Road #140"
-        ],
         "osm_node_ids": [
           2014304923
+        ],
+        "turns": [
+          "Road #139 -> Road #140"
         ],
         "type": "intersection"
       },
@@ -27552,10 +27552,10 @@
         "control": "Signed",
         "id": 120,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2014304919
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27600,10 +27600,10 @@
         "control": "Signed",
         "id": 122,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2014304912
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27648,10 +27648,10 @@
         "control": "Signed",
         "id": 123,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2014304855
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27704,11 +27704,11 @@
         "control": "Signalled",
         "id": 124,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #65 -> Road #66"
-        ],
         "osm_node_ids": [
           2014304856
+        ],
+        "turns": [
+          "Road #65 -> Road #66"
         ],
         "type": "intersection"
       },
@@ -27758,10 +27758,10 @@
         "control": "Signed",
         "id": 125,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7261942269
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27810,11 +27810,11 @@
         "control": "Signed",
         "id": 126,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #49 -> Road #50"
-        ],
         "osm_node_ids": [
           2014304920
+        ],
+        "turns": [
+          "Road #49 -> Road #50"
         ],
         "type": "intersection"
       },
@@ -27864,10 +27864,10 @@
         "control": "Signed",
         "id": 128,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2014304895
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27904,10 +27904,10 @@
         "control": "Signed",
         "id": 129,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309394782
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27944,8 +27944,8 @@
         "control": "Uncontrolled",
         "id": 130,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27982,8 +27982,8 @@
         "control": "Uncontrolled",
         "id": 132,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28020,11 +28020,11 @@
         "control": "Signed",
         "id": 133,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #529 -> Road #159"
-        ],
         "osm_node_ids": [
           2165840661
+        ],
+        "turns": [
+          "Road #529 -> Road #159"
         ],
         "type": "intersection"
       },
@@ -28062,8 +28062,8 @@
         "control": "Uncontrolled",
         "id": 134,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28100,10 +28100,10 @@
         "control": "Signed",
         "id": 177,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2275824761
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28140,10 +28140,10 @@
         "control": "Signed",
         "id": 188,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2275824782
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28184,13 +28184,13 @@
         "control": "Signed",
         "id": 206,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          3181227677
+        ],
+        "turns": [
           "Road #199 -> Road #197",
           "Road #623 -> Road #199",
           "Road #623 -> Road #197"
-        ],
-        "osm_node_ids": [
-          3181227677
         ],
         "type": "intersection"
       },
@@ -28232,12 +28232,12 @@
         "control": "Signed",
         "id": 207,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #198 -> Road #283",
-          "Road #624 -> Road #283"
-        ],
         "osm_node_ids": [
           3181227681
+        ],
+        "turns": [
+          "Road #198 -> Road #283",
+          "Road #624 -> Road #283"
         ],
         "type": "intersection"
       },
@@ -28291,10 +28291,10 @@
         "control": "Signed",
         "id": 208,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           26661446
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28331,10 +28331,10 @@
         "control": "Signed",
         "id": 209,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3193487669
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28371,10 +28371,10 @@
         "control": "Signed",
         "id": 210,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3193487666
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28411,8 +28411,8 @@
         "control": "Uncontrolled",
         "id": 211,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28449,8 +28449,8 @@
         "control": "Uncontrolled",
         "id": 212,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28503,11 +28503,11 @@
         "control": "Signed",
         "id": 213,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3371780106,
           3371780107
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28560,13 +28560,13 @@
         "control": "Signed",
         "id": 215,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #16 -> Road #17",
-          "Road #17 -> Road #16"
-        ],
         "osm_node_ids": [
           3381506663,
           6211583000
+        ],
+        "turns": [
+          "Road #16 -> Road #17",
+          "Road #17 -> Road #16"
         ],
         "type": "intersection"
       },
@@ -28604,10 +28604,10 @@
         "control": "Signed",
         "id": 216,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3381506664
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28644,8 +28644,8 @@
         "control": "Uncontrolled",
         "id": 217,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28682,8 +28682,8 @@
         "control": "Uncontrolled",
         "id": 218,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28736,11 +28736,11 @@
         "control": "Signalled",
         "id": 219,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #197 -> Road #198"
-        ],
         "osm_node_ids": [
           3181227679
+        ],
+        "turns": [
+          "Road #197 -> Road #198"
         ],
         "type": "intersection"
       },
@@ -28790,10 +28790,10 @@
         "control": "Signed",
         "id": 220,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3672602007
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28834,10 +28834,10 @@
         "control": "Signed",
         "id": 221,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264670280
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28886,10 +28886,10 @@
         "control": "Signed",
         "id": 222,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3672604268
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28942,7 +28942,10 @@
         "control": "Signed",
         "id": 224,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4361246652
+        ],
+        "turns": [
           "Road #225 -> Road #88",
           "Road #225 -> Road #224",
           "Road #225 -> Road #87",
@@ -28955,9 +28958,6 @@
           "Road #87 -> Road #225",
           "Road #87 -> Road #88",
           "Road #87 -> Road #224"
-        ],
-        "osm_node_ids": [
-          4361246652
         ],
         "type": "intersection"
       },
@@ -28995,8 +28995,8 @@
         "control": "Uncontrolled",
         "id": 225,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29033,10 +29033,10 @@
         "control": "Signed",
         "id": 226,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5506378774
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29073,8 +29073,8 @@
         "control": "Uncontrolled",
         "id": 227,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29111,10 +29111,10 @@
         "control": "Signed",
         "id": 228,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4500478004
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29155,11 +29155,11 @@
         "control": "Signed",
         "id": 229,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #278 -> Road #279"
-        ],
         "osm_node_ids": [
           4500478005
+        ],
+        "turns": [
+          "Road #278 -> Road #279"
         ],
         "type": "intersection"
       },
@@ -29201,10 +29201,10 @@
         "control": "Signed",
         "id": 230,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7261942277
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29241,8 +29241,8 @@
         "control": "Uncontrolled",
         "id": 231,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29279,8 +29279,8 @@
         "control": "Uncontrolled",
         "id": 232,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29337,11 +29337,11 @@
         "control": "Signalled",
         "id": 233,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #236 -> Road #237"
-        ],
         "osm_node_ids": [
           1284137095
+        ],
+        "turns": [
+          "Road #236 -> Road #237"
         ],
         "type": "intersection"
       },
@@ -29387,10 +29387,10 @@
         "control": "Signed",
         "id": 234,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4833244387
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29467,12 +29467,12 @@
         "control": "Signalled",
         "id": 235,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #318 -> Road #240"
-        ],
         "osm_node_ids": [
           682218116,
           5452444914
+        ],
+        "turns": [
+          "Road #318 -> Road #240"
         ],
         "type": "intersection"
       },
@@ -29510,8 +29510,8 @@
         "control": "Uncontrolled",
         "id": 239,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29572,12 +29572,12 @@
         "control": "Signed",
         "id": 240,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #313 -> Road #314"
-        ],
         "osm_node_ids": [
           5452456321,
           5452456322
+        ],
+        "turns": [
+          "Road #313 -> Road #314"
         ],
         "type": "intersection"
       },
@@ -29615,10 +29615,10 @@
         "control": "Signed",
         "id": 242,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4361246660
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29655,8 +29655,8 @@
         "control": "Uncontrolled",
         "id": 243,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29701,16 +29701,16 @@
         "control": "Signed",
         "id": 245,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5506378752
+        ],
+        "turns": [
           "Road #203 -> Road #249",
           "Road #203 -> Road #202",
           "Road #249 -> Road #203",
           "Road #249 -> Road #202",
           "Road #202 -> Road #203",
           "Road #202 -> Road #249"
-        ],
-        "osm_node_ids": [
-          5506378752
         ],
         "type": "intersection"
       },
@@ -29764,17 +29764,17 @@
         "control": "Signed",
         "id": 246,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5506378775,
+          5506378754
+        ],
+        "turns": [
           "Road #227 -> Road #225",
           "Road #227 -> Road #249",
           "Road #225 -> Road #227",
           "Road #225 -> Road #249",
           "Road #249 -> Road #227",
           "Road #249 -> Road #225"
-        ],
-        "osm_node_ids": [
-          5506378775,
-          5506378754
         ],
         "type": "intersection"
       },
@@ -29816,10 +29816,10 @@
         "control": "Signed",
         "id": 247,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378761
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29864,10 +29864,10 @@
         "control": "Signed",
         "id": 248,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378757
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29912,11 +29912,11 @@
         "control": "Signed",
         "id": 249,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1675168038,
           9316506597
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29953,10 +29953,10 @@
         "control": "Signed",
         "id": 250,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9316506599
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29993,10 +29993,10 @@
         "control": "Signed",
         "id": 252,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378768
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30033,10 +30033,10 @@
         "control": "Signed",
         "id": 254,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378765
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30073,10 +30073,10 @@
         "control": "Signed",
         "id": 255,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378764
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30113,10 +30113,10 @@
         "control": "Signed",
         "id": 256,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378763
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30157,10 +30157,10 @@
         "control": "Signed",
         "id": 257,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378782
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30197,10 +30197,10 @@
         "control": "Signed",
         "id": 258,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378778
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30241,10 +30241,10 @@
         "control": "Signed",
         "id": 259,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378777
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30289,10 +30289,10 @@
         "control": "Signed",
         "id": 260,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378779
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30333,10 +30333,10 @@
         "control": "Signed",
         "id": 261,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5506378781
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30373,8 +30373,8 @@
         "control": "Uncontrolled",
         "id": 262,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30427,11 +30427,11 @@
         "control": "Signed",
         "id": 263,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #348 -> Road #273"
-        ],
         "osm_node_ids": [
           320943571
+        ],
+        "turns": [
+          "Road #348 -> Road #273"
         ],
         "type": "intersection"
       },
@@ -30493,12 +30493,12 @@
         "control": "Signed",
         "id": 264,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #274 -> Road #351",
-          "Road #274 -> Road #432"
-        ],
         "osm_node_ids": [
           5728993707
+        ],
+        "turns": [
+          "Road #274 -> Road #351",
+          "Road #274 -> Road #432"
         ],
         "type": "intersection"
       },
@@ -30548,11 +30548,11 @@
         "control": "Signed",
         "id": 265,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #275 -> Road #276"
-        ],
         "osm_node_ids": [
           1877939942
+        ],
+        "turns": [
+          "Road #275 -> Road #276"
         ],
         "type": "intersection"
       },
@@ -30602,11 +30602,11 @@
         "control": "Signalled",
         "id": 266,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #279 -> Road #280"
-        ],
         "osm_node_ids": [
           2014304915
+        ],
+        "turns": [
+          "Road #279 -> Road #280"
         ],
         "type": "intersection"
       },
@@ -30660,14 +30660,14 @@
         "control": "Signed",
         "id": 267,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1675168064
+        ],
+        "turns": [
           "Road #280 -> Road #49",
           "Road #280 -> Road #281",
           "Road #48 -> Road #49",
           "Road #48 -> Road #281"
-        ],
-        "osm_node_ids": [
-          1675168064
         ],
         "type": "intersection"
       },
@@ -30721,11 +30721,11 @@
         "control": "Signed",
         "id": 268,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #281 -> Road #282"
-        ],
         "osm_node_ids": [
           2014304914
+        ],
+        "turns": [
+          "Road #281 -> Road #282"
         ],
         "type": "intersection"
       },
@@ -30763,8 +30763,8 @@
         "control": "Uncontrolled",
         "id": 270,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30801,8 +30801,8 @@
         "control": "Uncontrolled",
         "id": 271,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -30839,11 +30839,11 @@
         "control": "Signed",
         "id": 272,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #396 -> Road #290"
-        ],
         "osm_node_ids": [
           6101189538
+        ],
+        "turns": [
+          "Road #396 -> Road #290"
         ],
         "type": "intersection"
       },
@@ -30885,12 +30885,12 @@
         "control": "Signed",
         "id": 273,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #540 -> Road #292",
-          "Road #540 -> Road #541"
-        ],
         "osm_node_ids": [
           6111971409
+        ],
+        "turns": [
+          "Road #540 -> Road #292",
+          "Road #540 -> Road #541"
         ],
         "type": "intersection"
       },
@@ -30944,12 +30944,12 @@
         "control": "Signalled",
         "id": 274,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #292 -> Road #384",
-          "Road #292 -> Road #383"
-        ],
         "osm_node_ids": [
           6584937015
+        ],
+        "turns": [
+          "Road #292 -> Road #384",
+          "Road #292 -> Road #383"
         ],
         "type": "intersection"
       },
@@ -30999,10 +30999,10 @@
         "control": "Signed",
         "id": 275,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5728993838
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31043,10 +31043,10 @@
         "control": "Signed",
         "id": 276,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583004
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31091,10 +31091,10 @@
         "control": "Signed",
         "id": 279,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583003
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31139,10 +31139,10 @@
         "control": "Signed",
         "id": 280,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583009
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31191,10 +31191,10 @@
         "control": "Signed",
         "id": 281,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583008
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31259,11 +31259,11 @@
         "control": "Signalled",
         "id": 282,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583002,
           6211582994
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31308,10 +31308,10 @@
         "control": "Signed",
         "id": 284,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211582998
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31372,11 +31372,11 @@
         "control": "Signalled",
         "id": 287,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #243 -> Road #244"
-        ],
         "osm_node_ids": [
           643950
+        ],
+        "turns": [
+          "Road #243 -> Road #244"
         ],
         "type": "intersection"
       },
@@ -31422,10 +31422,10 @@
         "control": "Signed",
         "id": 288,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6211583005
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31466,11 +31466,11 @@
         "control": "Signed",
         "id": 289,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #322 -> Road #318"
-        ],
         "osm_node_ids": [
           26298432
+        ],
+        "turns": [
+          "Road #322 -> Road #318"
         ],
         "type": "intersection"
       },
@@ -31516,10 +31516,10 @@
         "control": "Signed",
         "id": 290,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452444913
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31564,12 +31564,12 @@
         "control": "Signed",
         "id": 291,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #350 -> Road #535",
-          "Road #321 -> Road #535"
-        ],
         "osm_node_ids": [
           6211583013
+        ],
+        "turns": [
+          "Road #350 -> Road #535",
+          "Road #321 -> Road #535"
         ],
         "type": "intersection"
       },
@@ -31623,12 +31623,12 @@
         "control": "Signed",
         "id": 293,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #119 -> Road #118",
-          "Road #118 -> Road #119"
-        ],
         "osm_node_ids": [
           6596024424
+        ],
+        "turns": [
+          "Road #119 -> Road #118",
+          "Road #118 -> Road #119"
         ],
         "type": "intersection"
       },
@@ -31694,16 +31694,16 @@
         "control": "Signed",
         "id": 294,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1606959629
+        ],
+        "turns": [
           "Road #434 -> Road #404",
           "Road #434 -> Road #120",
           "Road #404 -> Road #434",
           "Road #404 -> Road #120",
           "Road #120 -> Road #434",
           "Road #120 -> Road #404"
-        ],
-        "osm_node_ids": [
-          1606959629
         ],
         "type": "intersection"
       },
@@ -31741,10 +31741,10 @@
         "control": "Signed",
         "id": 295,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264559096
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31785,10 +31785,10 @@
         "control": "Signed",
         "id": 296,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264559098
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31825,10 +31825,10 @@
         "control": "Signed",
         "id": 297,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264559102
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31869,10 +31869,10 @@
         "control": "Signed",
         "id": 298,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452444904
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31921,10 +31921,10 @@
         "control": "Signed",
         "id": 299,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6216919223
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -31981,10 +31981,10 @@
         "control": "Signed",
         "id": 300,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6596024418
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32025,10 +32025,10 @@
         "control": "Signed",
         "id": 301,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264670253
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32073,11 +32073,11 @@
         "control": "Signed",
         "id": 302,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #525 -> Road #521"
-        ],
         "osm_node_ids": [
           26661455
+        ],
+        "turns": [
+          "Road #525 -> Road #521"
         ],
         "type": "intersection"
       },
@@ -32115,10 +32115,10 @@
         "control": "Signalled",
         "id": 303,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7241259893
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32175,11 +32175,11 @@
         "control": "Signed",
         "id": 304,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #284 -> Road #285"
-        ],
         "osm_node_ids": [
           6905278495
+        ],
+        "turns": [
+          "Road #284 -> Road #285"
         ],
         "type": "intersection"
       },
@@ -32237,10 +32237,10 @@
         "control": "Signed",
         "id": 305,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5728993834
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32277,10 +32277,10 @@
         "control": "Signalled",
         "id": 306,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7241259894
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32321,10 +32321,10 @@
         "control": "Signed",
         "id": 307,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264670275
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32373,11 +32373,11 @@
         "control": "Signalled",
         "id": 308,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #349 -> Road #350"
-        ],
         "osm_node_ids": [
           250348721
+        ],
+        "turns": [
+          "Road #349 -> Road #350"
         ],
         "type": "intersection"
       },
@@ -32415,8 +32415,8 @@
         "control": "Uncontrolled",
         "id": 309,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32457,11 +32457,11 @@
         "control": "Signed",
         "id": 310,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #351 -> Road #352"
-        ],
         "osm_node_ids": [
           6309354601
+        ],
+        "turns": [
+          "Road #351 -> Road #352"
         ],
         "type": "intersection"
       },
@@ -32499,8 +32499,8 @@
         "control": "Uncontrolled",
         "id": 311,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32537,8 +32537,8 @@
         "control": "Uncontrolled",
         "id": 312,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32579,11 +32579,11 @@
         "control": "Signed",
         "id": 313,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #22 -> Road #23"
-        ],
         "osm_node_ids": [
           6309354656
+        ],
+        "turns": [
+          "Road #22 -> Road #23"
         ],
         "type": "intersection"
       },
@@ -32625,10 +32625,10 @@
         "control": "Signed",
         "id": 314,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6584936999
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32673,10 +32673,10 @@
         "control": "Signed",
         "id": 315,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309354639
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32733,10 +32733,10 @@
         "control": "Signed",
         "id": 316,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309354644
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32773,10 +32773,10 @@
         "control": "Signed",
         "id": 317,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309354645
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32817,10 +32817,10 @@
         "control": "Signed",
         "id": 318,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309354657
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32861,10 +32861,10 @@
         "control": "Signed",
         "id": 320,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1877939971
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32901,10 +32901,10 @@
         "control": "Signed",
         "id": 322,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309394776
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -32949,11 +32949,11 @@
         "control": "Signalled",
         "id": 323,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #314 -> Road #315"
-        ],
         "osm_node_ids": [
           8174077586
+        ],
+        "turns": [
+          "Road #314 -> Road #315"
         ],
         "type": "intersection"
       },
@@ -33007,12 +33007,12 @@
         "control": "Signalled",
         "id": 324,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #63 -> Road #64"
-        ],
         "osm_node_ids": [
           2014304851,
           1877939975
+        ],
+        "turns": [
+          "Road #63 -> Road #64"
         ],
         "type": "intersection"
       },
@@ -33058,10 +33058,10 @@
         "control": "Signed",
         "id": 325,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452444908
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33102,10 +33102,10 @@
         "control": "Signed",
         "id": 326,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309394888
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33146,10 +33146,10 @@
         "control": "Signed",
         "id": 327,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309394886
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33186,10 +33186,10 @@
         "control": "Signed",
         "id": 328,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           1606959655
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33226,10 +33226,10 @@
         "control": "Signed",
         "id": 329,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309407702
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33274,10 +33274,10 @@
         "control": "Signed",
         "id": 330,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452444895
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33330,10 +33330,10 @@
         "control": "Signed",
         "id": 331,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309354662
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33370,10 +33370,10 @@
         "control": "Signed",
         "id": 333,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6428423986
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33418,12 +33418,12 @@
         "control": "Signed",
         "id": 334,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #384 -> Road #397",
-          "Road #383 -> Road #397"
-        ],
         "osm_node_ids": [
           6584937084
+        ],
+        "turns": [
+          "Road #384 -> Road #397",
+          "Road #383 -> Road #397"
         ],
         "type": "intersection"
       },
@@ -33469,13 +33469,13 @@
         "control": "Signed",
         "id": 335,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          6584937048
+        ],
+        "turns": [
           "Road #602 -> Road #385",
           "Road #386 -> Road #602",
           "Road #386 -> Road #385"
-        ],
-        "osm_node_ids": [
-          6584937048
         ],
         "type": "intersection"
       },
@@ -33521,11 +33521,11 @@
         "control": "Signed",
         "id": 337,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #385 -> Road #386"
-        ],
         "osm_node_ids": [
           6584937053
+        ],
+        "turns": [
+          "Road #385 -> Road #386"
         ],
         "type": "intersection"
       },
@@ -33567,10 +33567,10 @@
         "control": "Signed",
         "id": 338,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6584827765
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33607,10 +33607,10 @@
         "control": "Signed",
         "id": 339,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           6584937067
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33647,8 +33647,8 @@
         "control": "Uncontrolled",
         "id": 340,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33689,16 +33689,16 @@
         "control": "Signed",
         "id": 341,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4361246651
+        ],
+        "turns": [
           "Road #201 -> Road #391",
           "Road #201 -> Road #200",
           "Road #391 -> Road #201",
           "Road #391 -> Road #200",
           "Road #200 -> Road #201",
           "Road #200 -> Road #391"
-        ],
-        "osm_node_ids": [
-          4361246651
         ],
         "type": "intersection"
       },
@@ -33740,16 +33740,16 @@
         "control": "Signed",
         "id": 342,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6584937069
+        ],
+        "turns": [
           "Road #391 -> Road #390",
           "Road #391 -> Road #389",
           "Road #390 -> Road #391",
           "Road #390 -> Road #389",
           "Road #389 -> Road #391",
           "Road #389 -> Road #390"
-        ],
-        "osm_node_ids": [
-          6584937069
         ],
         "type": "intersection"
       },
@@ -33787,8 +33787,8 @@
         "control": "Uncontrolled",
         "id": 343,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -33845,11 +33845,11 @@
         "control": "Signalled",
         "id": 344,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #115 -> Road #116"
-        ],
         "osm_node_ids": [
           643852
+        ],
+        "turns": [
+          "Road #115 -> Road #116"
         ],
         "type": "intersection"
       },
@@ -33903,11 +33903,11 @@
         "control": "Signed",
         "id": 345,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #5"
-        ],
         "osm_node_ids": [
           643906
+        ],
+        "turns": [
+          "Road #4 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -33953,11 +33953,11 @@
         "control": "Signed",
         "id": 346,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #116 -> Road #117"
-        ],
         "osm_node_ids": [
           6905278501
+        ],
+        "turns": [
+          "Road #116 -> Road #117"
         ],
         "type": "intersection"
       },
@@ -34007,10 +34007,10 @@
         "control": "Signed",
         "id": 347,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6905278494
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34051,12 +34051,12 @@
         "control": "Signed",
         "id": 348,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #120 -> Road #119",
-          "Road #119 -> Road #120"
-        ],
         "osm_node_ids": [
           6596024419
+        ],
+        "turns": [
+          "Road #120 -> Road #119",
+          "Road #119 -> Road #120"
         ],
         "type": "intersection"
       },
@@ -34094,10 +34094,10 @@
         "control": "Signed",
         "id": 350,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6596024422
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34134,10 +34134,10 @@
         "control": "Signed",
         "id": 351,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7105816301
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34202,13 +34202,13 @@
         "control": "Signed",
         "id": 352,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #242 -> Road #243"
-        ],
         "osm_node_ids": [
           9319419273,
           9319419274,
           4833244389
+        ],
+        "turns": [
+          "Road #242 -> Road #243"
         ],
         "type": "intersection"
       },
@@ -34262,11 +34262,11 @@
         "control": "Signed",
         "id": 353,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #288 -> Road #289"
-        ],
         "osm_node_ids": [
           6740104094
+        ],
+        "turns": [
+          "Road #288 -> Road #289"
         ],
         "type": "intersection"
       },
@@ -34344,15 +34344,15 @@
         "control": "Signed",
         "id": 354,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6935272506,
+          9823132
+        ],
+        "turns": [
           "Road #126 -> Road #245",
           "Road #126 -> Road #128",
           "Road #244 -> Road #245",
           "Road #244 -> Road #128"
-        ],
-        "osm_node_ids": [
-          6935272506,
-          9823132
         ],
         "type": "intersection"
       },
@@ -34422,12 +34422,12 @@
         "control": "Signed",
         "id": 355,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #245 -> Road #246"
-        ],
         "osm_node_ids": [
           6935272510,
           1284137007
+        ],
+        "turns": [
+          "Road #245 -> Road #246"
         ],
         "type": "intersection"
       },
@@ -34477,11 +34477,11 @@
         "control": "Signed",
         "id": 356,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #107 -> Road #108"
-        ],
         "osm_node_ids": [
           6935272509
+        ],
+        "turns": [
+          "Road #107 -> Road #108"
         ],
         "type": "intersection"
       },
@@ -34519,8 +34519,8 @@
         "control": "Uncontrolled",
         "id": 357,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34557,8 +34557,8 @@
         "control": "Uncontrolled",
         "id": 358,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34611,11 +34611,11 @@
         "control": "Signalled",
         "id": 359,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #412 -> Road #413"
-        ],
         "osm_node_ids": [
           632541753
+        ],
+        "turns": [
+          "Road #412 -> Road #413"
         ],
         "type": "intersection"
       },
@@ -34661,12 +34661,12 @@
         "control": "Signed",
         "id": 360,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #539 -> Road #536",
-          "Road #413 -> Road #536"
-        ],
         "osm_node_ids": [
           4540786888
+        ],
+        "turns": [
+          "Road #539 -> Road #536",
+          "Road #413 -> Road #536"
         ],
         "type": "intersection"
       },
@@ -34712,10 +34712,10 @@
         "control": "Signed",
         "id": 361,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6905278500
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34752,10 +34752,10 @@
         "control": "Signed",
         "id": 362,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6905278499
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34804,11 +34804,11 @@
         "control": "Signalled",
         "id": 363,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #428 -> Road #67"
-        ],
         "osm_node_ids": [
           8174077587
+        ],
+        "turns": [
+          "Road #428 -> Road #67"
         ],
         "type": "intersection"
       },
@@ -34846,8 +34846,8 @@
         "control": "Uncontrolled",
         "id": 364,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34888,10 +34888,10 @@
         "control": "Signed",
         "id": 365,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6979945559
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34928,8 +34928,8 @@
         "control": "Uncontrolled",
         "id": 366,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -34974,10 +34974,10 @@
         "control": "Signed",
         "id": 368,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6596024421
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35018,10 +35018,10 @@
         "control": "Signed",
         "id": 371,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1675168026
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35058,10 +35058,10 @@
         "control": "Signed",
         "id": 373,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237435069
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35102,10 +35102,10 @@
         "control": "Signed",
         "id": 374,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237435070
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35146,10 +35146,10 @@
         "control": "Signed",
         "id": 375,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437002
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35190,10 +35190,10 @@
         "control": "Signed",
         "id": 376,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237435066
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35262,13 +35262,13 @@
         "control": "Signed",
         "id": 377,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237435071,
           5506378766,
           4029217614,
           5506378767
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35313,10 +35313,10 @@
         "control": "Signed",
         "id": 380,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437091
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35361,10 +35361,10 @@
         "control": "Signed",
         "id": 381,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237436996
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35405,10 +35405,10 @@
         "control": "Signed",
         "id": 382,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237436997
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35449,10 +35449,10 @@
         "control": "Signed",
         "id": 383,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237436998
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35493,10 +35493,10 @@
         "control": "Signed",
         "id": 384,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237436999
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35549,10 +35549,10 @@
         "control": "Signed",
         "id": 385,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437001
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35593,10 +35593,10 @@
         "control": "Signed",
         "id": 386,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237435065
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35641,10 +35641,10 @@
         "control": "Signed",
         "id": 387,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437005
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -35701,11 +35701,11 @@
         "control": "Signalled",
         "id": 389,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #2 -> Road #241"
-        ],
         "osm_node_ids": [
           7237437075
+        ],
+        "turns": [
+          "Road #2 -> Road #241"
         ],
         "type": "intersection"
       },
@@ -35747,10 +35747,10 @@
         "control": "Signed",
         "id": 390,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437041
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36011,10 +36011,10 @@
         "control": "Signed",
         "id": 393,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437045
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36063,10 +36063,10 @@
         "control": "Signed",
         "id": 394,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309394779
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36115,10 +36115,10 @@
         "control": "Signed",
         "id": 395,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452444920
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36183,11 +36183,11 @@
         "control": "Signed",
         "id": 396,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6309394778,
           6309407701
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36228,10 +36228,10 @@
         "control": "Signed",
         "id": 397,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452444915
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36492,10 +36492,10 @@
         "control": "Signed",
         "id": 398,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437070
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36540,11 +36540,11 @@
         "control": "Signed",
         "id": 400,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #27 -> Road #28"
-        ],
         "osm_node_ids": [
           5452444905
+        ],
+        "turns": [
+          "Road #27 -> Road #28"
         ],
         "type": "intersection"
       },
@@ -36806,10 +36806,10 @@
         "control": "Signed",
         "id": 401,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437077
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36858,11 +36858,11 @@
         "control": "Signed",
         "id": 402,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #320 -> Road #321"
-        ],
         "osm_node_ids": [
           6211583020
+        ],
+        "turns": [
+          "Road #320 -> Road #321"
         ],
         "type": "intersection"
       },
@@ -36900,10 +36900,10 @@
         "control": "Signed",
         "id": 404,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7237437096
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -36952,12 +36952,12 @@
         "control": "Signed",
         "id": 405,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #486 -> Road #487",
-          "Road #487 -> Road #486"
-        ],
         "osm_node_ids": [
           7237437092
+        ],
+        "turns": [
+          "Road #486 -> Road #487",
+          "Road #487 -> Road #486"
         ],
         "type": "intersection"
       },
@@ -36999,10 +36999,10 @@
         "control": "Signed",
         "id": 406,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7237437093
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37047,12 +37047,12 @@
         "control": "Signed",
         "id": 407,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #485 -> Road #486",
-          "Road #486 -> Road #485"
-        ],
         "osm_node_ids": [
           7237437094
+        ],
+        "turns": [
+          "Road #485 -> Road #486",
+          "Road #486 -> Road #485"
         ],
         "type": "intersection"
       },
@@ -37094,10 +37094,10 @@
         "control": "Signed",
         "id": 411,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1601683577
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37134,8 +37134,8 @@
         "control": "Uncontrolled",
         "id": 412,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37172,8 +37172,8 @@
         "control": "Uncontrolled",
         "id": 413,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37226,10 +37226,10 @@
         "control": "Signed",
         "id": 414,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6264559097
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37290,12 +37290,12 @@
         "control": "Signalled",
         "id": 415,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #319 -> Road #320"
-        ],
         "osm_node_ids": [
           7237437048,
           6211583022
+        ],
+        "turns": [
+          "Road #319 -> Road #320"
         ],
         "type": "intersection"
       },
@@ -37365,12 +37365,12 @@
         "control": "Signalled",
         "id": 416,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #47 -> Road #48"
-        ],
         "osm_node_ids": [
           2014304911,
           7261942271
+        ],
+        "turns": [
+          "Road #47 -> Road #48"
         ],
         "type": "intersection"
       },
@@ -37416,10 +37416,10 @@
         "control": "Signed",
         "id": 418,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7261942252
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37468,10 +37468,10 @@
         "control": "Signed",
         "id": 419,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7261942265
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37520,11 +37520,11 @@
         "control": "Signed",
         "id": 420,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7261942266,
           2014304921
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37565,13 +37565,13 @@
         "control": "Signed",
         "id": 422,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          800488938
+        ],
+        "turns": [
           "Road #518 -> Road #53",
           "Road #52 -> Road #53",
           "Road #52 -> Road #518"
-        ],
-        "osm_node_ids": [
-          800488938
         ],
         "type": "intersection"
       },
@@ -37609,10 +37609,10 @@
         "control": "Signed",
         "id": 423,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7261942280
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37673,13 +37673,13 @@
         "control": "Signed",
         "id": 425,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #28 -> Road #115",
-          "Road #521 -> Road #115"
-        ],
         "osm_node_ids": [
           6264670255,
           26661432
+        ],
+        "turns": [
+          "Road #28 -> Road #115",
+          "Road #521 -> Road #115"
         ],
         "type": "intersection"
       },
@@ -37725,12 +37725,12 @@
         "control": "Signed",
         "id": 426,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #518 -> Road #519",
-          "Road #519 -> Road #518"
-        ],
         "osm_node_ids": [
           7261942264
+        ],
+        "turns": [
+          "Road #518 -> Road #519",
+          "Road #519 -> Road #518"
         ],
         "type": "intersection"
       },
@@ -37768,8 +37768,8 @@
         "control": "Uncontrolled",
         "id": 427,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -37822,12 +37822,12 @@
         "control": "Signalled",
         "id": 428,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #531 -> Road #532",
-          "Road #532 -> Road #531"
-        ],
         "osm_node_ids": [
           1152092841
+        ],
+        "turns": [
+          "Road #531 -> Road #532",
+          "Road #532 -> Road #531"
         ],
         "type": "intersection"
       },
@@ -37877,11 +37877,11 @@
         "control": "Signalled",
         "id": 429,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #533 -> Road #534"
-        ],
         "osm_node_ids": [
           2014304862
+        ],
+        "turns": [
+          "Road #533 -> Road #534"
         ],
         "type": "intersection"
       },
@@ -37939,13 +37939,13 @@
         "control": "Signalled",
         "id": 430,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #282 -> Road #576",
-          "Road #537 -> Road #576"
-        ],
         "osm_node_ids": [
           2014304908,
           8273166694
+        ],
+        "turns": [
+          "Road #282 -> Road #576",
+          "Road #537 -> Road #576"
         ],
         "type": "intersection"
       },
@@ -37987,10 +37987,10 @@
         "control": "Signed",
         "id": 431,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3672602005
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38043,11 +38043,11 @@
         "control": "Signed",
         "id": 432,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #285 -> Road #286"
-        ],
         "osm_node_ids": [
           7908597579
+        ],
+        "turns": [
+          "Road #285 -> Road #286"
         ],
         "type": "intersection"
       },
@@ -38101,10 +38101,10 @@
         "control": "Signed",
         "id": 433,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7908597580
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38157,10 +38157,10 @@
         "control": "Signed",
         "id": 434,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7908597577
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38197,8 +38197,8 @@
         "control": "Uncontrolled",
         "id": 435,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38239,11 +38239,11 @@
         "control": "Signed",
         "id": 436,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #124 -> Road #125"
-        ],
         "osm_node_ids": [
           8312439326
+        ],
+        "turns": [
+          "Road #124 -> Road #125"
         ],
         "type": "intersection"
       },
@@ -38281,8 +38281,8 @@
         "control": "Uncontrolled",
         "id": 437,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38319,8 +38319,8 @@
         "control": "Uncontrolled",
         "id": 438,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38357,8 +38357,8 @@
         "control": "Uncontrolled",
         "id": 439,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38399,10 +38399,10 @@
         "control": "Signed",
         "id": 440,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8481640859
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38439,8 +38439,8 @@
         "control": "Uncontrolled",
         "id": 441,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38485,10 +38485,10 @@
         "control": "Signed",
         "id": 442,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5518536456
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38525,8 +38525,8 @@
         "control": "Uncontrolled",
         "id": 443,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38567,10 +38567,10 @@
         "control": "Signed",
         "id": 444,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8481640865
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38611,10 +38611,10 @@
         "control": "Signed",
         "id": 445,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8481640876
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38667,10 +38667,10 @@
         "control": "Signed",
         "id": 446,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8481640879
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38707,8 +38707,8 @@
         "control": "Uncontrolled",
         "id": 447,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38745,8 +38745,8 @@
         "control": "Uncontrolled",
         "id": 448,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -38819,11 +38819,11 @@
         "control": "Signed",
         "id": 449,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3672604266,
           6264559092
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39084,10 +39084,10 @@
         "control": "Signed",
         "id": 451,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8733041520
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39140,10 +39140,10 @@
         "control": "Signalled",
         "id": 452,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8733041519
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39196,11 +39196,11 @@
         "control": "Signalled",
         "id": 453,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #286 -> Road #287"
-        ],
         "osm_node_ids": [
           8733041518
+        ],
+        "turns": [
+          "Road #286 -> Road #287"
         ],
         "type": "intersection"
       },
@@ -39258,11 +39258,11 @@
         "control": "Signed",
         "id": 454,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3672602003,
           3672604265
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39299,10 +39299,10 @@
         "control": "Signed",
         "id": 455,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8740550413
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39343,10 +39343,10 @@
         "control": "Signed",
         "id": 456,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8740550411
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39387,10 +39387,10 @@
         "control": "Signed",
         "id": 457,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8740550412
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39435,12 +39435,12 @@
         "control": "Signed",
         "id": 458,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #405 -> Road #404",
-          "Road #404 -> Road #405"
-        ],
         "osm_node_ids": [
           8990249593
+        ],
+        "turns": [
+          "Road #405 -> Road #404",
+          "Road #404 -> Road #405"
         ],
         "type": "intersection"
       },
@@ -39482,12 +39482,12 @@
         "control": "Signed",
         "id": 459,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #436 -> Road #434",
-          "Road #434 -> Road #436"
-        ],
         "osm_node_ids": [
           8990249596
+        ],
+        "turns": [
+          "Road #436 -> Road #434",
+          "Road #434 -> Road #436"
         ],
         "type": "intersection"
       },
@@ -39533,10 +39533,10 @@
         "control": "Signed",
         "id": 460,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8990249594
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39585,12 +39585,12 @@
         "control": "Signed",
         "id": 461,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #437 -> Road #436",
-          "Road #436 -> Road #437"
-        ],
         "osm_node_ids": [
           7105816299
+        ],
+        "turns": [
+          "Road #437 -> Road #436",
+          "Road #436 -> Road #437"
         ],
         "type": "intersection"
       },
@@ -39636,10 +39636,10 @@
         "control": "Signed",
         "id": 462,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9258530363
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39676,8 +39676,8 @@
         "control": "Uncontrolled",
         "id": 463,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39718,11 +39718,11 @@
         "control": "Signed",
         "id": 464,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #14 -> Road #15"
-        ],
         "osm_node_ids": [
           9258530380
+        ],
+        "turns": [
+          "Road #14 -> Road #15"
         ],
         "type": "intersection"
       },
@@ -39768,10 +39768,10 @@
         "control": "Signed",
         "id": 465,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9258530385
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39812,10 +39812,10 @@
         "control": "Signed",
         "id": 466,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9258530387
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39856,16 +39856,16 @@
         "control": "Signed",
         "id": 467,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6596018201
+        ],
+        "turns": [
           "Road #397 -> Road #602",
           "Road #397 -> Road #396",
           "Road #602 -> Road #397",
           "Road #602 -> Road #396",
           "Road #396 -> Road #397",
           "Road #396 -> Road #602"
-        ],
-        "osm_node_ids": [
-          6596018201
         ],
         "type": "intersection"
       },
@@ -39903,10 +39903,10 @@
         "control": "Signed",
         "id": 468,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1675168030
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39951,10 +39951,10 @@
         "control": "Signed",
         "id": 469,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9316506598
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -39995,11 +39995,11 @@
         "control": "Signed",
         "id": 471,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #290 -> Road #291"
-        ],
         "osm_node_ids": [
           6309407706
+        ],
+        "turns": [
+          "Road #290 -> Road #291"
         ],
         "type": "intersection"
       },
@@ -40041,12 +40041,12 @@
         "control": "Signed",
         "id": 475,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #41 -> Road #40",
-          "Road #40 -> Road #41"
-        ],
         "osm_node_ids": [
           342579601
+        ],
+        "turns": [
+          "Road #41 -> Road #40",
+          "Road #40 -> Road #41"
         ],
         "type": "intersection"
       },
@@ -40084,8 +40084,8 @@
         "control": "Uncontrolled",
         "id": 476,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40126,13 +40126,13 @@
         "control": "Signed",
         "id": 477,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9319419287
+        ],
+        "turns": [
           "Road #618 -> Road #54",
           "Road #53 -> Road #54",
           "Road #53 -> Road #618"
-        ],
-        "osm_node_ids": [
-          9319419287
         ],
         "type": "intersection"
       },
@@ -40170,10 +40170,10 @@
         "control": "Signed",
         "id": 478,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           9319419289
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40246,13 +40246,13 @@
         "control": "Signed",
         "id": 479,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #241 -> Road #242"
-        ],
         "osm_node_ids": [
           9319419293,
           9319419267,
           9319419265
+        ],
+        "turns": [
+          "Road #241 -> Road #242"
         ],
         "type": "intersection"
       },
@@ -40302,11 +40302,11 @@
         "control": "Signed",
         "id": 483,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #622 -> Road #623"
-        ],
         "osm_node_ids": [
           3672602002
+        ],
+        "turns": [
+          "Road #622 -> Road #623"
         ],
         "type": "intersection"
       },
@@ -40344,10 +40344,10 @@
         "control": "Signed",
         "id": 485,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           9740274263
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40388,16 +40388,16 @@
         "control": "Signed",
         "id": 486,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9740274258
+        ],
+        "turns": [
           "Road #625 -> Road #626",
           "Road #625 -> Road #627",
           "Road #626 -> Road #625",
           "Road #626 -> Road #627",
           "Road #627 -> Road #625",
           "Road #627 -> Road #626"
-        ],
-        "osm_node_ids": [
-          9740274258
         ],
         "type": "intersection"
       },
@@ -40435,10 +40435,10 @@
         "control": "Signed",
         "id": 488,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           9740274265
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40475,8 +40475,8 @@
         "control": "Uncontrolled",
         "id": 490,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40525,11 +40525,11 @@
         "control": "Signed",
         "id": 491,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #42 -> Road #43"
-        ],
         "osm_node_ids": [
           342579512
+        ],
+        "turns": [
+          "Road #42 -> Road #43"
         ],
         "type": "intersection"
       },
@@ -40567,8 +40567,8 @@
         "control": "Uncontrolled",
         "id": 492,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40605,8 +40605,8 @@
         "control": "Uncontrolled",
         "id": 493,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40667,11 +40667,11 @@
         "control": "Signed",
         "id": 494,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           342579554,
           6500031458
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -40712,10 +40712,10 @@
         "control": "Signed",
         "id": 495,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6500031459
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/montlake_roundabout/geometry.json
+++ b/tests/src/montlake_roundabout/geometry.json
@@ -1029,8 +1029,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1079,13 +1079,13 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          9167886982
+        ],
+        "turns": [
           "Road #1 -> Road #23",
           "Road #22 -> Road #1",
           "Road #22 -> Road #23"
-        ],
-        "osm_node_ids": [
-          9167886982
         ],
         "type": "intersection"
       },
@@ -1123,8 +1123,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1169,13 +1169,13 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          9167886983
+        ],
+        "turns": [
           "Road #23 -> Road #24",
           "Road #23 -> Road #2",
           "Road #2 -> Road #24"
-        ],
-        "osm_node_ids": [
-          9167886983
         ],
         "type": "intersection"
       },
@@ -1213,8 +1213,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1271,7 +1271,11 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9167886984,
+          9167886986
+        ],
+        "turns": [
           "Road #19 -> Road #21",
           "Road #19 -> Road #3",
           "Road #3 -> Road #21",
@@ -1279,10 +1283,6 @@
           "Road #24 -> Road #21",
           "Road #24 -> Road #19",
           "Road #24 -> Road #3"
-        ],
-        "osm_node_ids": [
-          9167886984,
-          9167886986
         ],
         "type": "intersection"
       },
@@ -1324,13 +1324,13 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          9167886985
+        ],
+        "turns": [
           "Road #4 -> Road #22",
           "Road #21 -> Road #4",
           "Road #21 -> Road #22"
-        ],
-        "osm_node_ids": [
-          9167886985
         ],
         "type": "intersection"
       },
@@ -1368,8 +1368,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1410,10 +1410,10 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           429678954
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1454,10 +1454,10 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8821419612
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1530,13 +1530,13 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #5 -> Road #4",
-          "Road #4 -> Road #5"
-        ],
         "osm_node_ids": [
           8557965343,
           8557965342
+        ],
+        "turns": [
+          "Road #5 -> Road #4",
+          "Road #4 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -1574,8 +1574,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1612,8 +1612,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1650,8 +1650,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1688,8 +1688,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1726,8 +1726,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1764,8 +1764,8 @@
         "control": "Uncontrolled",
         "id": 19,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1814,12 +1814,12 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #0 -> Road #1",
-          "Road #1 -> Road #0"
-        ],
         "osm_node_ids": [
           8953629439
+        ],
+        "turns": [
+          "Road #0 -> Road #1",
+          "Road #1 -> Road #0"
         ],
         "type": "intersection"
       },
@@ -1865,10 +1865,10 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8953625429
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1905,8 +1905,8 @@
         "control": "Uncontrolled",
         "id": 23,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/northgate_dual_carriageway/geometry.json
+++ b/tests/src/northgate_dual_carriageway/geometry.json
@@ -13899,14 +13899,14 @@
         "control": "Signalled",
         "id": 1,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1968559794
+        ],
+        "turns": [
           "Road #78 -> Road #84",
           "Road #83 -> Road #84",
           "Road #83 -> Road #78",
           "Road #1 -> Road #78"
-        ],
-        "osm_node_ids": [
-          1968559794
         ],
         "type": "intersection"
       },
@@ -13952,13 +13952,13 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          53092589
+        ],
+        "turns": [
           "Road #2 -> Road #94",
           "Road #93 -> Road #94",
           "Road #93 -> Road #2"
-        ],
-        "osm_node_ids": [
-          53092589
         ],
         "type": "intersection"
       },
@@ -13996,8 +13996,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -14034,12 +14034,12 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #4 -> Road #138",
-          "Road #138 -> Road #4"
-        ],
         "osm_node_ids": [
           4787774425
+        ],
+        "turns": [
+          "Road #4 -> Road #138",
+          "Road #138 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -14077,8 +14077,8 @@
         "control": "Uncontrolled",
         "id": 5,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -14123,14 +14123,14 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554843688
+        ],
+        "turns": [
           "Road #130 -> Road #7",
           "Road #47 -> Road #130",
           "Road #47 -> Road #7",
           "Road #7 -> Road #130"
-        ],
-        "osm_node_ids": [
-          4554843688
         ],
         "type": "intersection"
       },
@@ -14168,14 +14168,14 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254654
+        ],
+        "turns": [
           "Road #25 -> Road #8",
           "Road #25 -> Road #24",
           "Road #24 -> Road #25",
           "Road #24 -> Road #8"
-        ],
-        "osm_node_ids": [
-          476254654
         ],
         "type": "intersection"
       },
@@ -14213,14 +14213,14 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254657
+        ],
+        "turns": [
           "Road #69 -> Road #70",
           "Road #70 -> Road #69",
           "Road #8 -> Road #69",
           "Road #8 -> Road #70"
-        ],
-        "osm_node_ids": [
-          476254657
         ],
         "type": "intersection"
       },
@@ -14262,14 +14262,14 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254665
+        ],
+        "turns": [
           "Road #70 -> Road #71",
           "Road #70 -> Road #9",
           "Road #71 -> Road #70",
           "Road #71 -> Road #9"
-        ],
-        "osm_node_ids": [
-          476254665
         ],
         "type": "intersection"
       },
@@ -14307,14 +14307,14 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254668
+        ],
+        "turns": [
           "Road #24 -> Road #23",
           "Road #9 -> Road #24",
           "Road #9 -> Road #23",
           "Road #23 -> Road #24"
-        ],
-        "osm_node_ids": [
-          476254668
         ],
         "type": "intersection"
       },
@@ -14352,14 +14352,14 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254672
+        ],
+        "turns": [
           "Road #23 -> Road #10",
           "Road #23 -> Road #22",
           "Road #22 -> Road #23",
           "Road #22 -> Road #10"
-        ],
-        "osm_node_ids": [
-          476254672
         ],
         "type": "intersection"
       },
@@ -14401,14 +14401,14 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254675
+        ],
+        "turns": [
           "Road #71 -> Road #72",
           "Road #72 -> Road #71",
           "Road #10 -> Road #71",
           "Road #10 -> Road #72"
-        ],
-        "osm_node_ids": [
-          476254675
         ],
         "type": "intersection"
       },
@@ -14450,14 +14450,14 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254714
+        ],
+        "turns": [
           "Road #72 -> Road #73",
           "Road #72 -> Road #11",
           "Road #73 -> Road #72",
           "Road #73 -> Road #11"
-        ],
-        "osm_node_ids": [
-          476254714
         ],
         "type": "intersection"
       },
@@ -14495,14 +14495,14 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254715
+        ],
+        "turns": [
           "Road #22 -> Road #21",
           "Road #11 -> Road #22",
           "Road #11 -> Road #21",
           "Road #21 -> Road #22"
-        ],
-        "osm_node_ids": [
-          476254715
         ],
         "type": "intersection"
       },
@@ -14544,12 +14544,12 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #13 -> Road #15",
-          "Road #14 -> Road #15"
-        ],
         "osm_node_ids": [
           476254734
+        ],
+        "turns": [
+          "Road #13 -> Road #15",
+          "Road #14 -> Road #15"
         ],
         "type": "intersection"
       },
@@ -14587,11 +14587,11 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #26 -> Road #14"
-        ],
         "osm_node_ids": [
           476254735
+        ],
+        "turns": [
+          "Road #26 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -14633,14 +14633,14 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554837508
+        ],
+        "turns": [
           "Road #67 -> Road #68",
           "Road #68 -> Road #67",
           "Road #17 -> Road #67",
           "Road #17 -> Road #68"
-        ],
-        "osm_node_ids": [
-          4554837508
         ],
         "type": "intersection"
       },
@@ -14682,12 +14682,12 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #15 -> Road #18",
-          "Road #15 -> Road #16"
-        ],
         "osm_node_ids": [
           476254736
+        ],
+        "turns": [
+          "Road #15 -> Road #18",
+          "Road #15 -> Road #16"
         ],
         "type": "intersection"
       },
@@ -14725,12 +14725,12 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #245 -> Road #246",
-          "Road #19 -> Road #246"
-        ],
         "osm_node_ids": [
           476254738
+        ],
+        "turns": [
+          "Road #245 -> Road #246",
+          "Road #19 -> Road #246"
         ],
         "type": "intersection"
       },
@@ -14768,14 +14768,14 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254740
+        ],
+        "turns": [
           "Road #68 -> Road #69",
           "Road #68 -> Road #20",
           "Road #69 -> Road #68",
           "Road #69 -> Road #20"
-        ],
-        "osm_node_ids": [
-          476254740
         ],
         "type": "intersection"
       },
@@ -14813,14 +14813,14 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476254741
+        ],
+        "turns": [
           "Road #26 -> Road #25",
           "Road #20 -> Road #26",
           "Road #20 -> Road #25",
           "Road #25 -> Road #26"
-        ],
-        "osm_node_ids": [
-          476254741
         ],
         "type": "intersection"
       },
@@ -14858,8 +14858,8 @@
         "control": "Uncontrolled",
         "id": 24,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -14900,14 +14900,14 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554773508
+        ],
+        "turns": [
           "Road #157 -> Road #27",
           "Road #157 -> Road #66",
           "Road #66 -> Road #157",
           "Road #66 -> Road #27"
-        ],
-        "osm_node_ids": [
-          4554773508
         ],
         "type": "intersection"
       },
@@ -14957,15 +14957,15 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          411602465
+        ],
+        "turns": [
           "Road #249 -> Road #132",
           "Road #249 -> Road #250",
           "Road #250 -> Road #132",
           "Road #28 -> Road #132",
           "Road #28 -> Road #250"
-        ],
-        "osm_node_ids": [
-          411602465
         ],
         "type": "intersection"
       },
@@ -15007,12 +15007,12 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #132 -> Road #133",
-          "Road #132 -> Road #29"
-        ],
         "osm_node_ids": [
           476254742
+        ],
+        "turns": [
+          "Road #132 -> Road #133",
+          "Road #132 -> Road #29"
         ],
         "type": "intersection"
       },
@@ -15054,13 +15054,13 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554773505
+        ],
+        "turns": [
           "Road #31 -> Road #157",
           "Road #31 -> Road #244",
           "Road #157 -> Road #244"
-        ],
-        "osm_node_ids": [
-          4554773505
         ],
         "type": "intersection"
       },
@@ -15102,14 +15102,14 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554843682
+        ],
+        "turns": [
           "Road #40 -> Road #32",
           "Road #40 -> Road #41",
           "Road #41 -> Road #40",
           "Road #41 -> Road #32"
-        ],
-        "osm_node_ids": [
-          4554843682
         ],
         "type": "intersection"
       },
@@ -15151,14 +15151,14 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661959
+        ],
+        "turns": [
           "Road #214 -> Road #215",
           "Road #215 -> Road #214",
           "Road #32 -> Road #214",
           "Road #32 -> Road #215"
-        ],
-        "osm_node_ids": [
-          476661959
         ],
         "type": "intersection"
       },
@@ -15200,14 +15200,14 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661964
+        ],
+        "turns": [
           "Road #216 -> Road #217",
           "Road #216 -> Road #33",
           "Road #217 -> Road #216",
           "Road #217 -> Road #33"
-        ],
-        "osm_node_ids": [
-          476661964
         ],
         "type": "intersection"
       },
@@ -15253,14 +15253,14 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661965
+        ],
+        "turns": [
           "Road #41 -> Road #42",
           "Road #33 -> Road #41",
           "Road #33 -> Road #42",
           "Road #42 -> Road #41"
-        ],
-        "osm_node_ids": [
-          476661965
         ],
         "type": "intersection"
       },
@@ -15298,14 +15298,14 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661966
+        ],
+        "turns": [
           "Road #42 -> Road #34",
           "Road #42 -> Road #43",
           "Road #43 -> Road #42",
           "Road #43 -> Road #34"
-        ],
-        "osm_node_ids": [
-          476661966
         ],
         "type": "intersection"
       },
@@ -15347,14 +15347,14 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661967
+        ],
+        "turns": [
           "Road #218 -> Road #219",
           "Road #219 -> Road #218",
           "Road #34 -> Road #218",
           "Road #34 -> Road #219"
-        ],
-        "osm_node_ids": [
-          476661967
         ],
         "type": "intersection"
       },
@@ -15392,14 +15392,14 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661971
+        ],
+        "turns": [
           "Road #43 -> Road #44",
           "Road #35 -> Road #43",
           "Road #35 -> Road #44",
           "Road #44 -> Road #43"
-        ],
-        "osm_node_ids": [
-          476661971
         ],
         "type": "intersection"
       },
@@ -15437,14 +15437,14 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661972
+        ],
+        "turns": [
           "Road #44 -> Road #36",
           "Road #44 -> Road #45",
           "Road #45 -> Road #44",
           "Road #45 -> Road #36"
-        ],
-        "osm_node_ids": [
-          476661972
         ],
         "type": "intersection"
       },
@@ -15490,14 +15490,14 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661973
+        ],
+        "turns": [
           "Road #222 -> Road #223",
           "Road #223 -> Road #222",
           "Road #36 -> Road #222",
           "Road #36 -> Road #223"
-        ],
-        "osm_node_ids": [
-          476661973
         ],
         "type": "intersection"
       },
@@ -15543,14 +15543,14 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661976
+        ],
+        "turns": [
           "Road #129 -> Road #37",
           "Road #129 -> Road #47",
           "Road #37 -> Road #129",
           "Road #37 -> Road #47"
-        ],
-        "osm_node_ids": [
-          476661976
         ],
         "type": "intersection"
       },
@@ -15592,16 +15592,16 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9127145511
+        ],
+        "turns": [
           "Road #46 -> Road #228",
           "Road #46 -> Road #229",
           "Road #228 -> Road #46",
           "Road #228 -> Road #229",
           "Road #229 -> Road #46",
           "Road #229 -> Road #228"
-        ],
-        "osm_node_ids": [
-          9127145511
         ],
         "type": "intersection"
       },
@@ -15643,14 +15643,14 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661981
+        ],
+        "turns": [
           "Road #213 -> Road #214",
           "Road #213 -> Road #48",
           "Road #214 -> Road #213",
           "Road #214 -> Road #48"
-        ],
-        "osm_node_ids": [
-          476661981
         ],
         "type": "intersection"
       },
@@ -15692,14 +15692,14 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661979
+        ],
+        "turns": [
           "Road #39 -> Road #40",
           "Road #48 -> Road #39",
           "Road #48 -> Road #40",
           "Road #40 -> Road #39"
-        ],
-        "osm_node_ids": [
-          476661979
         ],
         "type": "intersection"
       },
@@ -15741,14 +15741,14 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554843686
+        ],
+        "turns": [
           "Road #7 -> Road #49",
           "Road #7 -> Road #6",
           "Road #6 -> Road #7",
           "Road #6 -> Road #49"
-        ],
-        "osm_node_ids": [
-          4554843686
         ],
         "type": "intersection"
       },
@@ -15802,7 +15802,10 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1395426463
+        ],
+        "turns": [
           "Road #38 -> Road #158",
           "Road #38 -> Road #39",
           "Road #39 -> Road #38",
@@ -15810,9 +15813,6 @@
           "Road #49 -> Road #38",
           "Road #49 -> Road #158",
           "Road #49 -> Road #39"
-        ],
-        "osm_node_ids": [
-          1395426463
         ],
         "type": "intersection"
       },
@@ -15858,14 +15858,14 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661982
+        ],
+        "turns": [
           "Road #143 -> Road #212",
           "Road #143 -> Road #50",
           "Road #212 -> Road #143",
           "Road #212 -> Road #50"
-        ],
-        "osm_node_ids": [
-          476661982
         ],
         "type": "intersection"
       },
@@ -15911,14 +15911,14 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661977
+        ],
+        "turns": [
           "Road #37 -> Road #38",
           "Road #50 -> Road #37",
           "Road #50 -> Road #38",
           "Road #38 -> Road #37"
-        ],
-        "osm_node_ids": [
-          476661977
         ],
         "type": "intersection"
       },
@@ -15960,14 +15960,14 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476714997
+        ],
+        "turns": [
           "Road #55 -> Road #54",
           "Road #55 -> Road #51",
           "Road #54 -> Road #55",
           "Road #54 -> Road #51"
-        ],
-        "osm_node_ids": [
-          476714997
         ],
         "type": "intersection"
       },
@@ -16017,7 +16017,11 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476715001,
+          476661970
+        ],
+        "turns": [
           "Road #219 -> Road #221",
           "Road #219 -> Road #35",
           "Road #51 -> Road #219",
@@ -16025,10 +16029,6 @@
           "Road #51 -> Road #35",
           "Road #221 -> Road #219",
           "Road #221 -> Road #35"
-        ],
-        "osm_node_ids": [
-          476715001,
-          476661970
         ],
         "type": "intersection"
       },
@@ -16066,14 +16066,14 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476715010
+        ],
+        "turns": [
           "Road #217 -> Road #52",
           "Road #217 -> Road #218",
           "Road #218 -> Road #217",
           "Road #218 -> Road #52"
-        ],
-        "osm_node_ids": [
-          476715010
         ],
         "type": "intersection"
       },
@@ -16115,14 +16115,14 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476715022
+        ],
+        "turns": [
           "Road #56 -> Road #55",
           "Road #55 -> Road #56",
           "Road #52 -> Road #56",
           "Road #52 -> Road #55"
-        ],
-        "osm_node_ids": [
-          476715022
         ],
         "type": "intersection"
       },
@@ -16160,11 +16160,11 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #60 -> Road #54"
-        ],
         "osm_node_ids": [
           476715211
+        ],
+        "turns": [
+          "Road #60 -> Road #54"
         ],
         "type": "intersection"
       },
@@ -16202,16 +16202,16 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4554843678
+        ],
+        "turns": [
           "Road #215 -> Road #58",
           "Road #215 -> Road #216",
           "Road #58 -> Road #215",
           "Road #58 -> Road #216",
           "Road #216 -> Road #215",
           "Road #216 -> Road #58"
-        ],
-        "osm_node_ids": [
-          4554843678
         ],
         "type": "intersection"
       },
@@ -16253,14 +16253,14 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476715244
+        ],
+        "turns": [
           "Road #221 -> Road #60",
           "Road #221 -> Road #222",
           "Road #222 -> Road #221",
           "Road #222 -> Road #60"
-        ],
-        "osm_node_ids": [
-          476715244
         ],
         "type": "intersection"
       },
@@ -16302,14 +16302,14 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          479716858
+        ],
+        "turns": [
           "Road #57 -> Road #61",
           "Road #57 -> Road #58",
           "Road #58 -> Road #61",
           "Road #58 -> Road #57"
-        ],
-        "osm_node_ids": [
-          479716858
         ],
         "type": "intersection"
       },
@@ -16347,11 +16347,11 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #61 -> Road #62"
-        ],
         "osm_node_ids": [
           479716851
+        ],
+        "turns": [
+          "Road #61 -> Road #62"
         ],
         "type": "intersection"
       },
@@ -16389,11 +16389,11 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #62 -> Road #63"
-        ],
         "osm_node_ids": [
           479716854
+        ],
+        "turns": [
+          "Road #62 -> Road #63"
         ],
         "type": "intersection"
       },
@@ -16439,12 +16439,12 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #184 -> Road #185",
-          "Road #64 -> Road #185"
-        ],
         "osm_node_ids": [
           4787774433
+        ],
+        "turns": [
+          "Road #184 -> Road #185",
+          "Road #64 -> Road #185"
         ],
         "type": "intersection"
       },
@@ -16482,11 +16482,11 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #186 -> Road #65"
-        ],
         "osm_node_ids": [
           7625387501
+        ],
+        "turns": [
+          "Road #186 -> Road #65"
         ],
         "type": "intersection"
       },
@@ -16528,12 +16528,12 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #65 -> Road #76",
-          "Road #76 -> Road #104"
-        ],
         "osm_node_ids": [
           476715048
+        ],
+        "turns": [
+          "Road #65 -> Road #76",
+          "Road #76 -> Road #104"
         ],
         "type": "intersection"
       },
@@ -16571,8 +16571,8 @@
         "control": "Uncontrolled",
         "id": 62,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16613,12 +16613,12 @@
         "control": "Signed",
         "id": 63,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #74 -> Road #106",
-          "Road #94 -> Road #74"
-        ],
         "osm_node_ids": [
           1905102152
+        ],
+        "turns": [
+          "Road #74 -> Road #106",
+          "Road #94 -> Road #74"
         ],
         "type": "intersection"
       },
@@ -16656,12 +16656,12 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #95 -> Road #74",
-          "Road #74 -> Road #95"
-        ],
         "osm_node_ids": [
           3409784125
+        ],
+        "turns": [
+          "Road #95 -> Road #74",
+          "Road #74 -> Road #95"
         ],
         "type": "intersection"
       },
@@ -16699,8 +16699,8 @@
         "control": "Uncontrolled",
         "id": 65,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16737,10 +16737,10 @@
         "control": "Signed",
         "id": 66,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4723314713
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16777,8 +16777,8 @@
         "control": "Uncontrolled",
         "id": 67,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16815,8 +16815,8 @@
         "control": "Uncontrolled",
         "id": 68,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16853,12 +16853,12 @@
         "control": "Signed",
         "id": 69,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #188 -> Road #80",
-          "Road #80 -> Road #188"
-        ],
         "osm_node_ids": [
           5420650496
+        ],
+        "turns": [
+          "Road #188 -> Road #80",
+          "Road #80 -> Road #188"
         ],
         "type": "intersection"
       },
@@ -16908,15 +16908,15 @@
         "control": "Signed",
         "id": 70,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4787774436
+        ],
+        "turns": [
           "Road #80 -> Road #161",
           "Road #80 -> Road #96",
           "Road #161 -> Road #80",
           "Road #161 -> Road #96",
           "Road #96 -> Road #161"
-        ],
-        "osm_node_ids": [
-          4787774436
         ],
         "type": "intersection"
       },
@@ -17006,7 +17006,11 @@
         "control": "Signalled",
         "id": 71,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          7625387504,
+          53092587
+        ],
+        "turns": [
           "Road #167 -> Road #81",
           "Road #167 -> Road #102",
           "Road #167 -> Road #187",
@@ -17021,10 +17025,6 @@
           "Road #116 -> Road #102",
           "Road #116 -> Road #187",
           "Road #116 -> Road #183"
-        ],
-        "osm_node_ids": [
-          7625387504,
-          53092587
         ],
         "type": "intersection"
       },
@@ -17066,12 +17066,12 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #98 -> Road #113",
-          "Road #87 -> Road #98"
-        ],
         "osm_node_ids": [
           1968559770
+        ],
+        "turns": [
+          "Road #98 -> Road #113",
+          "Road #87 -> Road #98"
         ],
         "type": "intersection"
       },
@@ -17117,13 +17117,13 @@
         "control": "Signed",
         "id": 73,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          1968559768
+        ],
+        "turns": [
           "Road #88 -> Road #87",
           "Road #86 -> Road #87",
           "Road #86 -> Road #88"
-        ],
-        "osm_node_ids": [
-          1968559768
         ],
         "type": "intersection"
       },
@@ -17161,8 +17161,8 @@
         "control": "Uncontrolled",
         "id": 74,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17203,12 +17203,12 @@
         "control": "Signed",
         "id": 75,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #82 -> Road #83",
-          "Road #82 -> Road #90"
-        ],
         "osm_node_ids": [
           1968559734
+        ],
+        "turns": [
+          "Road #82 -> Road #83",
+          "Road #82 -> Road #90"
         ],
         "type": "intersection"
       },
@@ -17266,14 +17266,14 @@
         "control": "Signed",
         "id": 76,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          411602471
+        ],
+        "turns": [
           "Road #110 -> Road #111",
           "Road #110 -> Road #131",
           "Road #90 -> Road #131",
           "Road #131 -> Road #111"
-        ],
-        "osm_node_ids": [
-          411602471
         ],
         "type": "intersection"
       },
@@ -17311,8 +17311,8 @@
         "control": "Uncontrolled",
         "id": 77,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17357,10 +17357,10 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2706302805
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17397,8 +17397,8 @@
         "control": "Uncontrolled",
         "id": 79,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17439,10 +17439,10 @@
         "control": "Signed",
         "id": 80,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2706302814
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17499,12 +17499,12 @@
         "control": "Signed",
         "id": 81,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #141 -> Road #93"
-        ],
         "osm_node_ids": [
           4787774427,
           7518081808
+        ],
+        "turns": [
+          "Road #141 -> Road #93"
         ],
         "type": "intersection"
       },
@@ -17542,8 +17542,8 @@
         "control": "Uncontrolled",
         "id": 82,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17584,16 +17584,16 @@
         "control": "Signed",
         "id": 83,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3711400491
+        ],
+        "turns": [
           "Road #97 -> Road #145",
           "Road #97 -> Road #146",
           "Road #145 -> Road #97",
           "Road #145 -> Road #146",
           "Road #146 -> Road #97",
           "Road #146 -> Road #145"
-        ],
-        "osm_node_ids": [
-          3711400491
         ],
         "type": "intersection"
       },
@@ -17631,8 +17631,8 @@
         "control": "Uncontrolled",
         "id": 84,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17669,12 +17669,12 @@
         "control": "Signed",
         "id": 85,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #244 -> Road #99",
-          "Road #244 -> Road #245"
-        ],
         "osm_node_ids": [
           4024951462
+        ],
+        "turns": [
+          "Road #244 -> Road #99",
+          "Road #244 -> Road #245"
         ],
         "type": "intersection"
       },
@@ -17716,12 +17716,12 @@
         "control": "Signed",
         "id": 86,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #100 -> Road #17",
-          "Road #16 -> Road #17"
-        ],
         "osm_node_ids": [
           4024951461
+        ],
+        "turns": [
+          "Road #100 -> Road #17",
+          "Road #16 -> Road #17"
         ],
         "type": "intersection"
       },
@@ -17759,11 +17759,11 @@
         "control": "Signed",
         "id": 87,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #407 -> Road #162"
-        ],
         "osm_node_ids": [
           9754620676
+        ],
+        "turns": [
+          "Road #407 -> Road #162"
         ],
         "type": "intersection"
       },
@@ -17801,11 +17801,11 @@
         "control": "Signed",
         "id": 90,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #103 -> Road #139"
-        ],
         "osm_node_ids": [
           4787774426
+        ],
+        "turns": [
+          "Road #103 -> Road #139"
         ],
         "type": "intersection"
       },
@@ -17859,11 +17859,11 @@
         "control": "Signed",
         "id": 92,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #106 -> Road #164"
-        ],
         "osm_node_ids": [
           4787774428
+        ],
+        "turns": [
+          "Road #106 -> Road #164"
         ],
         "type": "intersection"
       },
@@ -17901,11 +17901,11 @@
         "control": "Signed",
         "id": 93,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #374 -> Road #107"
-        ],
         "osm_node_ids": [
           4272355596
+        ],
+        "turns": [
+          "Road #374 -> Road #107"
         ],
         "type": "intersection"
       },
@@ -17947,12 +17947,12 @@
         "control": "Signed",
         "id": 94,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #107 -> Road #375",
-          "Road #107 -> Road #247"
-        ],
         "osm_node_ids": [
           9322923125
+        ],
+        "turns": [
+          "Road #107 -> Road #375",
+          "Road #107 -> Road #247"
         ],
         "type": "intersection"
       },
@@ -17990,11 +17990,11 @@
         "control": "Signed",
         "id": 95,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #112 -> Road #114"
-        ],
         "osm_node_ids": [
           1111800655
+        ],
+        "turns": [
+          "Road #112 -> Road #114"
         ],
         "type": "intersection"
       },
@@ -18032,11 +18032,11 @@
         "control": "Signed",
         "id": 96,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #113 -> Road #374"
-        ],
         "osm_node_ids": [
           53100765
+        ],
+        "turns": [
+          "Road #113 -> Road #374"
         ],
         "type": "intersection"
       },
@@ -18074,10 +18074,10 @@
         "control": "Signed",
         "id": 98,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4632418344
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18130,10 +18130,10 @@
         "control": "Signed",
         "id": 99,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9188152684
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18182,12 +18182,12 @@
         "control": "Signed",
         "id": 100,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #250 -> Road #6",
-          "Road #6 -> Road #250"
-        ],
         "osm_node_ids": [
           4723314702
+        ],
+        "turns": [
+          "Road #250 -> Road #6",
+          "Road #6 -> Road #250"
         ],
         "type": "intersection"
       },
@@ -18233,10 +18233,10 @@
         "control": "Signed",
         "id": 102,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044297
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18281,10 +18281,10 @@
         "control": "Signed",
         "id": 103,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044263
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18333,11 +18333,11 @@
         "control": "Signed",
         "id": 106,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #81 -> Road #82"
-        ],
         "osm_node_ids": [
           4723314715
+        ],
+        "turns": [
+          "Road #81 -> Road #82"
         ],
         "type": "intersection"
       },
@@ -18391,11 +18391,11 @@
         "control": "Signed",
         "id": 107,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #115 -> Road #116"
-        ],
         "osm_node_ids": [
           4723314716
+        ],
+        "turns": [
+          "Road #115 -> Road #116"
         ],
         "type": "intersection"
       },
@@ -18433,10 +18433,10 @@
         "control": "Signed",
         "id": 109,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5420650504
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18473,10 +18473,10 @@
         "control": "Signed",
         "id": 110,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5420650502
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18521,13 +18521,13 @@
         "control": "Signed",
         "id": 111,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          476661975
+        ],
+        "turns": [
           "Road #111 -> Road #112",
           "Road #111 -> Road #128",
           "Road #128 -> Road #112"
-        ],
-        "osm_node_ids": [
-          476661975
         ],
         "type": "intersection"
       },
@@ -18573,12 +18573,12 @@
         "control": "Signalled",
         "id": 112,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #85 -> Road #86",
-          "Road #135 -> Road #86"
-        ],
         "osm_node_ids": [
           9772983384
+        ],
+        "turns": [
+          "Road #85 -> Road #86",
+          "Road #135 -> Road #86"
         ],
         "type": "intersection"
       },
@@ -18624,13 +18624,13 @@
         "control": "Signalled",
         "id": 113,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9198107248
+        ],
+        "turns": [
           "Road #140 -> Road #141",
           "Road #140 -> Road #136",
           "Road #136 -> Road #141"
-        ],
-        "osm_node_ids": [
-          9198107248
         ],
         "type": "intersection"
       },
@@ -18672,13 +18672,13 @@
         "control": "Signed",
         "id": 114,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          411602472
+        ],
+        "turns": [
           "Road #142 -> Road #115",
           "Road #114 -> Road #115",
           "Road #114 -> Road #142"
-        ],
-        "osm_node_ids": [
-          411602472
         ],
         "type": "intersection"
       },
@@ -18716,8 +18716,8 @@
         "control": "Uncontrolled",
         "id": 115,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18762,13 +18762,13 @@
         "control": "Signed",
         "id": 116,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          3711400490
+        ],
+        "turns": [
           "Road #147 -> Road #407",
           "Road #104 -> Road #407",
           "Road #104 -> Road #147"
-        ],
-        "osm_node_ids": [
-          3711400490
         ],
         "type": "intersection"
       },
@@ -18806,10 +18806,10 @@
         "control": "Signed",
         "id": 124,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           6981738609
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18846,8 +18846,8 @@
         "control": "Uncontrolled",
         "id": 125,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18884,8 +18884,8 @@
         "control": "Uncontrolled",
         "id": 126,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18926,13 +18926,13 @@
         "control": "Signed",
         "id": 127,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5420650494
+        ],
+        "turns": [
           "Road #435 -> Road #154",
           "Road #155 -> Road #435",
           "Road #155 -> Road #154"
-        ],
-        "osm_node_ids": [
-          5420650494
         ],
         "type": "intersection"
       },
@@ -18970,10 +18970,10 @@
         "control": "Signed",
         "id": 128,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5420650495
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19010,10 +19010,10 @@
         "control": "Signed",
         "id": 129,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5420650500
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19054,14 +19054,14 @@
         "control": "Signed",
         "id": 132,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476661983
+        ],
+        "turns": [
           "Road #212 -> Road #213",
           "Road #213 -> Road #212",
           "Road #158 -> Road #212",
           "Road #158 -> Road #213"
-        ],
-        "osm_node_ids": [
-          476661983
         ],
         "type": "intersection"
       },
@@ -19103,16 +19103,16 @@
         "control": "Signed",
         "id": 133,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          476715215
+        ],
+        "turns": [
           "Road #159 -> Road #56",
           "Road #159 -> Road #57",
           "Road #56 -> Road #159",
           "Road #56 -> Road #57",
           "Road #57 -> Road #159",
           "Road #57 -> Road #56"
-        ],
-        "osm_node_ids": [
-          476715215
         ],
         "type": "intersection"
       },
@@ -19154,13 +19154,13 @@
         "control": "Signed",
         "id": 134,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          7625387502
+        ],
+        "turns": [
           "Road #185 -> Road #186",
           "Road #185 -> Road #160",
           "Road #160 -> Road #186"
-        ],
-        "osm_node_ids": [
-          7625387502
         ],
         "type": "intersection"
       },
@@ -19198,8 +19198,8 @@
         "control": "Uncontrolled",
         "id": 135,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19256,7 +19256,10 @@
         "control": "Signalled",
         "id": 136,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9198107249
+        ],
+        "turns": [
           "Road #164 -> Road #136",
           "Road #164 -> Road #165",
           "Road #164 -> Road #137",
@@ -19264,9 +19267,6 @@
           "Road #136 -> Road #137",
           "Road #137 -> Road #136",
           "Road #137 -> Road #165"
-        ],
-        "osm_node_ids": [
-          9198107249
         ],
         "type": "intersection"
       },
@@ -19304,10 +19304,10 @@
         "control": "Signed",
         "id": 137,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           6981738608
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19348,10 +19348,10 @@
         "control": "Signed",
         "id": 139,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9734066143
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19612,10 +19612,10 @@
         "control": "Signed",
         "id": 140,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6139800717
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19652,8 +19652,8 @@
         "control": "Uncontrolled",
         "id": 142,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19706,11 +19706,11 @@
         "control": "Signed",
         "id": 146,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #165 -> Road #166"
-        ],
         "osm_node_ids": [
           6938807525
+        ],
+        "turns": [
+          "Road #165 -> Road #166"
         ],
         "type": "intersection"
       },
@@ -19768,12 +19768,12 @@
         "control": "Signed",
         "id": 147,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #139 -> Road #140"
-        ],
         "osm_node_ids": [
           6938807532,
           8975595263
+        ],
+        "turns": [
+          "Road #139 -> Road #140"
         ],
         "type": "intersection"
       },
@@ -19811,8 +19811,8 @@
         "control": "Uncontrolled",
         "id": 149,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19853,10 +19853,10 @@
         "control": "Signed",
         "id": 153,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384317434
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19901,12 +19901,12 @@
         "control": "Signed",
         "id": 156,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #187 -> Road #188",
-          "Road #188 -> Road #187"
-        ],
         "osm_node_ids": [
           4723314722
+        ],
+        "turns": [
+          "Road #187 -> Road #188",
+          "Road #188 -> Road #187"
         ],
         "type": "intersection"
       },
@@ -19960,7 +19960,10 @@
         "control": "Signed",
         "id": 157,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4022851873
+        ],
+        "turns": [
           "Road #225 -> Road #76",
           "Road #225 -> Road #189",
           "Road #225 -> Road #75",
@@ -19973,9 +19976,6 @@
           "Road #75 -> Road #225",
           "Road #75 -> Road #76",
           "Road #75 -> Road #189"
-        ],
-        "osm_node_ids": [
-          4022851873
         ],
         "type": "intersection"
       },
@@ -20013,8 +20013,8 @@
         "control": "Uncontrolled",
         "id": 158,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20051,8 +20051,8 @@
         "control": "Uncontrolled",
         "id": 159,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20093,10 +20093,10 @@
         "control": "Signed",
         "id": 160,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595231
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20145,11 +20145,11 @@
         "control": "Signed",
         "id": 162,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #102 -> Road #103"
-        ],
         "osm_node_ids": [
           4723314725
+        ],
+        "turns": [
+          "Road #102 -> Road #103"
         ],
         "type": "intersection"
       },
@@ -20203,11 +20203,11 @@
         "control": "Signed",
         "id": 163,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #166 -> Road #167"
-        ],
         "osm_node_ids": [
           6938807530
+        ],
+        "turns": [
+          "Road #166 -> Road #167"
         ],
         "type": "intersection"
       },
@@ -20253,10 +20253,10 @@
         "control": "Signed",
         "id": 165,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595243
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20305,10 +20305,10 @@
         "control": "Signed",
         "id": 166,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044275
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20353,10 +20353,10 @@
         "control": "Signed",
         "id": 167,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595245
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20397,10 +20397,10 @@
         "control": "Signed",
         "id": 168,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595247
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20445,10 +20445,10 @@
         "control": "Signed",
         "id": 169,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4723314720
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20493,10 +20493,10 @@
         "control": "Signed",
         "id": 170,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595250
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20549,11 +20549,11 @@
         "control": "Signed",
         "id": 173,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #183 -> Road #184"
-        ],
         "osm_node_ids": [
           7625387499
+        ],
+        "turns": [
+          "Road #183 -> Road #184"
         ],
         "type": "intersection"
       },
@@ -20607,11 +20607,11 @@
         "control": "Signed",
         "id": 174,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #162 -> Road #163"
-        ],
         "osm_node_ids": [
           4787774434
+        ],
+        "turns": [
+          "Road #162 -> Road #163"
         ],
         "type": "intersection"
       },
@@ -20657,10 +20657,10 @@
         "control": "Signed",
         "id": 175,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595251
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20713,12 +20713,12 @@
         "control": "Signed",
         "id": 177,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #138 -> Road #137",
-          "Road #137 -> Road #138"
-        ],
         "osm_node_ids": [
           8301425181
+        ],
+        "turns": [
+          "Road #138 -> Road #137",
+          "Road #137 -> Road #138"
         ],
         "type": "intersection"
       },
@@ -20772,10 +20772,10 @@
         "control": "Signed",
         "id": 179,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7518081809
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20816,10 +20816,10 @@
         "control": "Signed",
         "id": 180,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2706302783
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20860,16 +20860,16 @@
         "control": "Signed",
         "id": 181,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9123420400
+        ],
+        "turns": [
           "Road #227 -> Road #211",
           "Road #227 -> Road #228",
           "Road #211 -> Road #227",
           "Road #211 -> Road #228",
           "Road #228 -> Road #227",
           "Road #228 -> Road #211"
-        ],
-        "osm_node_ids": [
-          9123420400
         ],
         "type": "intersection"
       },
@@ -20907,8 +20907,8 @@
         "control": "Uncontrolled",
         "id": 182,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20949,16 +20949,16 @@
         "control": "Signed",
         "id": 183,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9812120018
+        ],
+        "turns": [
           "Road #224 -> Road #226",
           "Road #224 -> Road #227",
           "Road #226 -> Road #224",
           "Road #226 -> Road #227",
           "Road #227 -> Road #224",
           "Road #227 -> Road #226"
-        ],
-        "osm_node_ids": [
-          9812120018
         ],
         "type": "intersection"
       },
@@ -20996,10 +20996,10 @@
         "control": "Signed",
         "id": 187,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9188152681
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21260,10 +21260,10 @@
         "control": "Signed",
         "id": 188,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9188152667
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21300,8 +21300,8 @@
         "control": "Uncontrolled",
         "id": 189,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21338,10 +21338,10 @@
         "control": "Signed",
         "id": 191,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9188152670
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21382,10 +21382,10 @@
         "control": "Signed",
         "id": 193,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9812120063
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21422,8 +21422,8 @@
         "control": "Uncontrolled",
         "id": 194,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21460,8 +21460,8 @@
         "control": "Uncontrolled",
         "id": 195,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21514,14 +21514,14 @@
         "control": "Signed",
         "id": 197,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9322923130
+        ],
+        "turns": [
           "Road #248 -> Road #249",
           "Road #248 -> Road #30",
           "Road #29 -> Road #249",
           "Road #29 -> Road #30"
-        ],
-        "osm_node_ids": [
-          9322923130
         ],
         "type": "intersection"
       },
@@ -21559,8 +21559,8 @@
         "control": "Uncontrolled",
         "id": 198,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21605,10 +21605,10 @@
         "control": "Signed",
         "id": 200,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044266
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21649,10 +21649,10 @@
         "control": "Signed",
         "id": 201,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044272
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21705,12 +21705,12 @@
         "control": "Signalled",
         "id": 203,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #79 -> Road #78",
-          "Road #78 -> Road #79"
-        ],
         "osm_node_ids": [
           9384044265
+        ],
+        "turns": [
+          "Road #79 -> Road #78",
+          "Road #78 -> Road #79"
         ],
         "type": "intersection"
       },
@@ -21748,8 +21748,8 @@
         "control": "Uncontrolled",
         "id": 205,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21794,10 +21794,10 @@
         "control": "Signed",
         "id": 206,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4723314709
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21850,11 +21850,11 @@
         "control": "Signed",
         "id": 208,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #84 -> Road #85"
-        ],
         "osm_node_ids": [
           9384044271
+        ],
+        "turns": [
+          "Road #84 -> Road #85"
         ],
         "type": "intersection"
       },
@@ -21928,15 +21928,15 @@
         "control": "Signed",
         "id": 209,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9384044270,
+          9384044269
+        ],
+        "turns": [
           "Road #0 -> Road #1",
           "Road #0 -> Road #110",
           "Road #109 -> Road #1",
           "Road #109 -> Road #110"
-        ],
-        "osm_node_ids": [
-          9384044270,
-          9384044269
         ],
         "type": "intersection"
       },
@@ -21978,10 +21978,10 @@
         "control": "Signed",
         "id": 212,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7518081824
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22018,8 +22018,8 @@
         "control": "Uncontrolled",
         "id": 213,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22072,12 +22072,12 @@
         "control": "Signed",
         "id": 214,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #89 -> Road #88",
-          "Road #88 -> Road #89"
-        ],
         "osm_node_ids": [
           9384044273
+        ],
+        "turns": [
+          "Road #89 -> Road #88",
+          "Road #88 -> Road #89"
         ],
         "type": "intersection"
       },
@@ -22123,10 +22123,10 @@
         "control": "Signed",
         "id": 216,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595253
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22187,13 +22187,13 @@
         "control": "Signed",
         "id": 218,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #142 -> Road #143",
-          "Road #143 -> Road #142"
-        ],
         "osm_node_ids": [
           9384044277,
           9384044290
+        ],
+        "turns": [
+          "Road #142 -> Road #143",
+          "Road #143 -> Road #142"
         ],
         "type": "intersection"
       },
@@ -22263,7 +22263,11 @@
         "control": "Signed",
         "id": 222,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9384044291,
+          9384044293
+        ],
+        "turns": [
           "Road #131 -> Road #128",
           "Road #131 -> Road #129",
           "Road #131 -> Road #130",
@@ -22276,10 +22280,6 @@
           "Road #130 -> Road #131",
           "Road #130 -> Road #128",
           "Road #130 -> Road #129"
-        ],
-        "osm_node_ids": [
-          9384044291,
-          9384044293
         ],
         "type": "intersection"
       },
@@ -22321,10 +22321,10 @@
         "control": "Signed",
         "id": 229,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044287
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22405,17 +22405,17 @@
         "control": "Signalled",
         "id": 230,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9384044296,
+          53211559
+        ],
+        "turns": [
           "Road #375 -> Road #135",
           "Road #375 -> Road #0",
           "Road #375 -> Road #109",
           "Road #133 -> Road #135",
           "Road #133 -> Road #0",
           "Road #133 -> Road #109"
-        ],
-        "osm_node_ids": [
-          9384044296,
-          53211559
         ],
         "type": "intersection"
       },
@@ -22677,10 +22677,10 @@
         "control": "Signed",
         "id": 231,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9772983389
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22941,10 +22941,10 @@
         "control": "Signed",
         "id": 232,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044299
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23205,10 +23205,10 @@
         "control": "Signed",
         "id": 233,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044300
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23249,10 +23249,10 @@
         "control": "Signed",
         "id": 234,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044298
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23289,10 +23289,10 @@
         "control": "Signed",
         "id": 235,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4723314706
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23341,11 +23341,11 @@
         "control": "Signed",
         "id": 238,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #97 -> Road #96"
-        ],
         "osm_node_ids": [
           7518078674
+        ],
+        "turns": [
+          "Road #97 -> Road #96"
         ],
         "type": "intersection"
       },
@@ -23383,8 +23383,8 @@
         "control": "Uncontrolled",
         "id": 242,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23421,8 +23421,8 @@
         "control": "Uncontrolled",
         "id": 243,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23459,8 +23459,8 @@
         "control": "Uncontrolled",
         "id": 244,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23497,8 +23497,8 @@
         "control": "Uncontrolled",
         "id": 245,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23543,10 +23543,10 @@
         "control": "Signed",
         "id": 246,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384317432
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23591,10 +23591,10 @@
         "control": "Signed",
         "id": 247,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8975595264
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23651,13 +23651,13 @@
         "control": "Signed",
         "id": 249,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #2 -> Road #3",
-          "Road #3 -> Road #2"
-        ],
         "osm_node_ids": [
           9384570977,
           9384570978
+        ],
+        "turns": [
+          "Road #2 -> Road #3",
+          "Road #3 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -23695,8 +23695,8 @@
         "control": "Uncontrolled",
         "id": 256,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23733,8 +23733,8 @@
         "control": "Uncontrolled",
         "id": 258,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23771,8 +23771,8 @@
         "control": "Uncontrolled",
         "id": 260,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23809,10 +23809,10 @@
         "control": "Signed",
         "id": 262,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9687585570
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24073,10 +24073,10 @@
         "control": "Signed",
         "id": 263,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9687585571
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24129,12 +24129,12 @@
         "control": "Signed",
         "id": 265,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #145 -> Road #144",
-          "Road #144 -> Road #145"
-        ],
         "osm_node_ids": [
           9687585566
+        ],
+        "turns": [
+          "Road #145 -> Road #144",
+          "Road #144 -> Road #145"
         ],
         "type": "intersection"
       },
@@ -24172,10 +24172,10 @@
         "control": "Signed",
         "id": 269,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9687585569
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24436,10 +24436,10 @@
         "control": "Signed",
         "id": 271,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9687585572
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24492,12 +24492,12 @@
         "control": "Signed",
         "id": 277,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #146 -> Road #147",
-          "Road #147 -> Road #146"
-        ],
         "osm_node_ids": [
           9687585578
+        ],
+        "turns": [
+          "Road #146 -> Road #147",
+          "Road #147 -> Road #146"
         ],
         "type": "intersection"
       },
@@ -24539,10 +24539,10 @@
         "control": "Signed",
         "id": 278,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9687585564
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24579,8 +24579,8 @@
         "control": "Uncontrolled",
         "id": 279,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24617,8 +24617,8 @@
         "control": "Uncontrolled",
         "id": 281,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24659,10 +24659,10 @@
         "control": "Signed",
         "id": 282,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9687585577
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24715,12 +24715,12 @@
         "control": "Signed",
         "id": 283,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #189 -> Road #190",
-          "Road #190 -> Road #189"
-        ],
         "osm_node_ids": [
           9687621320
+        ],
+        "turns": [
+          "Road #189 -> Road #190",
+          "Road #190 -> Road #189"
         ],
         "type": "intersection"
       },
@@ -24770,11 +24770,11 @@
         "control": "Signed",
         "id": 286,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #63 -> Road #64"
-        ],
         "osm_node_ids": [
           9188129782
+        ],
+        "turns": [
+          "Road #63 -> Road #64"
         ],
         "type": "intersection"
       },
@@ -24828,12 +24828,12 @@
         "control": "Signed",
         "id": 289,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #160 -> Road #159",
-          "Road #159 -> Road #160"
-        ],
         "osm_node_ids": [
           9188129783
+        ],
+        "turns": [
+          "Road #160 -> Road #159",
+          "Road #159 -> Road #160"
         ],
         "type": "intersection"
       },
@@ -24891,12 +24891,12 @@
         "control": "Signed",
         "id": 291,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #225 -> Road #226",
-          "Road #226 -> Road #225"
-        ],
         "osm_node_ids": [
           9188129781
+        ],
+        "turns": [
+          "Road #225 -> Road #226",
+          "Road #226 -> Road #225"
         ],
         "type": "intersection"
       },
@@ -24934,10 +24934,10 @@
         "control": "Signed",
         "id": 292,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9693399662
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24990,11 +24990,11 @@
         "control": "Signed",
         "id": 293,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #27 -> Road #28"
-        ],
         "osm_node_ids": [
           9693399663
+        ],
+        "turns": [
+          "Road #27 -> Road #28"
         ],
         "type": "intersection"
       },
@@ -25036,10 +25036,10 @@
         "control": "Signed",
         "id": 294,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9693399664
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25080,10 +25080,10 @@
         "control": "Signed",
         "id": 295,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9693399658
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25120,10 +25120,10 @@
         "control": "Signed",
         "id": 296,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9693399659
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25160,10 +25160,10 @@
         "control": "Signed",
         "id": 297,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9693399665
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25212,11 +25212,11 @@
         "control": "Signed",
         "id": 298,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #30 -> Road #31"
-        ],
         "osm_node_ids": [
           9693399660
+        ],
+        "turns": [
+          "Road #30 -> Road #31"
         ],
         "type": "intersection"
       },
@@ -25254,10 +25254,10 @@
         "control": "Signed",
         "id": 299,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9693399661
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25302,10 +25302,10 @@
         "control": "Signed",
         "id": 300,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9188152718
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25346,10 +25346,10 @@
         "control": "Signed",
         "id": 303,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9812120028
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25394,12 +25394,12 @@
         "control": "Signed",
         "id": 305,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #223 -> Road #224",
-          "Road #224 -> Road #223"
-        ],
         "osm_node_ids": [
           9712100076
+        ],
+        "turns": [
+          "Road #223 -> Road #224",
+          "Road #224 -> Road #223"
         ],
         "type": "intersection"
       },
@@ -25441,12 +25441,12 @@
         "control": "Signed",
         "id": 306,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #45 -> Road #46",
-          "Road #46 -> Road #45"
-        ],
         "osm_node_ids": [
           9712100079
+        ],
+        "turns": [
+          "Road #45 -> Road #46",
+          "Road #46 -> Road #45"
         ],
         "type": "intersection"
       },
@@ -25488,10 +25488,10 @@
         "control": "Signed",
         "id": 310,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9712100080
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25528,10 +25528,10 @@
         "control": "Signed",
         "id": 311,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9712100087
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25572,10 +25572,10 @@
         "control": "Signed",
         "id": 312,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9712100086
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25612,10 +25612,10 @@
         "control": "Signed",
         "id": 313,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9712100083
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25652,8 +25652,8 @@
         "control": "Uncontrolled",
         "id": 314,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25690,10 +25690,10 @@
         "control": "Signed",
         "id": 315,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788177
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25730,10 +25730,10 @@
         "control": "Signed",
         "id": 316,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788170
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25778,12 +25778,12 @@
         "control": "Signed",
         "id": 317,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #66 -> Road #67",
-          "Road #67 -> Road #66"
-        ],
         "osm_node_ids": [
           9718788171
+        ],
+        "turns": [
+          "Road #66 -> Road #67",
+          "Road #67 -> Road #66"
         ],
         "type": "intersection"
       },
@@ -25821,10 +25821,10 @@
         "control": "Signed",
         "id": 318,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788164
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25869,11 +25869,11 @@
         "control": "Signed",
         "id": 319,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #246 -> Road #13"
-        ],
         "osm_node_ids": [
           9718788174
+        ],
+        "turns": [
+          "Road #246 -> Road #13"
         ],
         "type": "intersection"
       },
@@ -26135,10 +26135,10 @@
         "control": "Signed",
         "id": 320,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788165
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26175,10 +26175,10 @@
         "control": "Signed",
         "id": 321,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788166
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26219,11 +26219,11 @@
         "control": "Signed",
         "id": 322,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #18 -> Road #19"
-        ],
         "osm_node_ids": [
           9718788173
+        ],
+        "turns": [
+          "Road #18 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -26485,10 +26485,10 @@
         "control": "Signed",
         "id": 323,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788167
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26525,10 +26525,10 @@
         "control": "Signed",
         "id": 324,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788168
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26573,11 +26573,11 @@
         "control": "Signed",
         "id": 325,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #99 -> Road #100"
-        ],
         "osm_node_ids": [
           9718788172
+        ],
+        "turns": [
+          "Road #99 -> Road #100"
         ],
         "type": "intersection"
       },
@@ -26615,10 +26615,10 @@
         "control": "Signed",
         "id": 326,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788169
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26659,10 +26659,10 @@
         "control": "Signed",
         "id": 327,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788163
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26703,10 +26703,10 @@
         "control": "Signed",
         "id": 328,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788179
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26743,10 +26743,10 @@
         "control": "Signed",
         "id": 329,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9718788178
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26787,10 +26787,10 @@
         "control": "Signed",
         "id": 330,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9712451021
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27051,10 +27051,10 @@
         "control": "Signed",
         "id": 331,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9384044289
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27111,11 +27111,11 @@
         "control": "Signed",
         "id": 332,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #247 -> Road #248"
-        ],
         "osm_node_ids": [
           9322923129
+        ],
+        "turns": [
+          "Road #247 -> Road #248"
         ],
         "type": "intersection"
       },
@@ -27153,10 +27153,10 @@
         "control": "Signed",
         "id": 333,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9772983386
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27197,10 +27197,10 @@
         "control": "Signed",
         "id": 334,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9772983388
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27241,10 +27241,10 @@
         "control": "Signed",
         "id": 335,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9772983385
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27285,10 +27285,10 @@
         "control": "Signed",
         "id": 336,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9800403237
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27325,8 +27325,8 @@
         "control": "Uncontrolled",
         "id": 338,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27367,10 +27367,10 @@
         "control": "Signed",
         "id": 340,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096625
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27407,10 +27407,10 @@
         "control": "Signed",
         "id": 341,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096629
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27447,10 +27447,10 @@
         "control": "Signed",
         "id": 342,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096631
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27491,10 +27491,10 @@
         "control": "Signed",
         "id": 343,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096626
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27535,12 +27535,12 @@
         "control": "Signed",
         "id": 344,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #153 -> Road #152",
-          "Road #152 -> Road #153"
-        ],
         "osm_node_ids": [
           9801096630
+        ],
+        "turns": [
+          "Road #153 -> Road #152",
+          "Road #152 -> Road #153"
         ],
         "type": "intersection"
       },
@@ -27802,10 +27802,10 @@
         "control": "Signed",
         "id": 345,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096636
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27842,10 +27842,10 @@
         "control": "Signed",
         "id": 346,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096637
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27882,10 +27882,10 @@
         "control": "Signed",
         "id": 347,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096633
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27922,10 +27922,10 @@
         "control": "Signed",
         "id": 350,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096634
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27966,10 +27966,10 @@
         "control": "Signed",
         "id": 351,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096640
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28006,10 +28006,10 @@
         "control": "Signed",
         "id": 352,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096645
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28050,10 +28050,10 @@
         "control": "Signed",
         "id": 353,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9801096644
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28098,10 +28098,10 @@
         "control": "Signed",
         "id": 354,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9812120027
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28138,8 +28138,8 @@
         "control": "Uncontrolled",
         "id": 356,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28176,8 +28176,8 @@
         "control": "Uncontrolled",
         "id": 357,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28222,12 +28222,12 @@
         "control": "Signed",
         "id": 358,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #436 -> Road #435",
-          "Road #435 -> Road #436"
-        ],
         "osm_node_ids": [
           9801096639
+        ],
+        "turns": [
+          "Road #436 -> Road #435",
+          "Road #435 -> Road #436"
         ],
         "type": "intersection"
       },
@@ -28265,8 +28265,8 @@
         "control": "Uncontrolled",
         "id": 359,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28315,12 +28315,12 @@
         "control": "Signed",
         "id": 361,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #229 -> Road #439",
-          "Road #439 -> Road #229"
-        ],
         "osm_node_ids": [
           9188152674
+        ],
+        "turns": [
+          "Road #229 -> Road #439",
+          "Road #439 -> Road #229"
         ],
         "type": "intersection"
       },
@@ -28358,8 +28358,8 @@
         "control": "Uncontrolled",
         "id": 362,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28396,8 +28396,8 @@
         "control": "Uncontrolled",
         "id": 363,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28434,8 +28434,8 @@
         "control": "Uncontrolled",
         "id": 364,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/oneway_loop/geometry.json
+++ b/tests/src/oneway_loop/geometry.json
@@ -1655,8 +1655,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1693,10 +1693,10 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1249482198
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1733,10 +1733,10 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           25496662
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1777,13 +1777,13 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          25496664
+        ],
+        "turns": [
           "Road #28 -> Road #2",
           "Road #28 -> Road #3",
           "Road #2 -> Road #3"
-        ],
-        "osm_node_ids": [
-          25496664
         ],
         "type": "intersection"
       },
@@ -1825,11 +1825,11 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #27"
-        ],
         "osm_node_ids": [
           25496667
+        ],
+        "turns": [
+          "Road #7 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -1871,10 +1871,10 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1080429836
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1927,11 +1927,11 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #5 -> Road #6"
-        ],
         "osm_node_ids": [
           25496666
+        ],
+        "turns": [
+          "Road #5 -> Road #6"
         ],
         "type": "intersection"
       },
@@ -1969,8 +1969,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2015,10 +2015,10 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1080429785
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2063,10 +2063,10 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9568915239
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2107,11 +2107,11 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #6 -> Road #7"
-        ],
         "osm_node_ids": [
           1080429864
+        ],
+        "turns": [
+          "Road #6 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -2153,11 +2153,11 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #5"
-        ],
         "osm_node_ids": [
           1080429761
+        ],
+        "turns": [
+          "Road #4 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -2203,10 +2203,10 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1701265007
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2255,11 +2255,11 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #3 -> Road #4"
-        ],
         "osm_node_ids": [
           1701265003
+        ],
+        "turns": [
+          "Road #3 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -2297,10 +2297,10 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           1701265019
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2337,10 +2337,10 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1701264964
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2377,8 +2377,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2415,8 +2415,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2453,10 +2453,10 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3080103386
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2493,8 +2493,8 @@
         "control": "Uncontrolled",
         "id": 20,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2531,10 +2531,10 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7845046175
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2571,10 +2571,10 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7845046177
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2619,16 +2619,16 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25496663
+        ],
+        "turns": [
           "Road #1 -> Road #30",
           "Road #1 -> Road #2",
           "Road #30 -> Road #1",
           "Road #30 -> Road #2",
           "Road #2 -> Road #1",
           "Road #2 -> Road #30"
-        ],
-        "osm_node_ids": [
-          25496663
         ],
         "type": "intersection"
       },
@@ -2674,10 +2674,10 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9586144486
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2718,10 +2718,10 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9586144488
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2766,10 +2766,10 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9568915240
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2814,11 +2814,11 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #27 -> Road #28"
-        ],
         "osm_node_ids": [
           9568915256
+        ],
+        "turns": [
+          "Road #27 -> Road #28"
         ],
         "type": "intersection"
       },
@@ -2860,10 +2860,10 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9568915258
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2900,10 +2900,10 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9568915259
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2948,10 +2948,10 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9568915241
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2996,10 +2996,10 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9586144492
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/perth_peanut_roundabout/geometry.json
+++ b/tests/src/perth_peanut_roundabout/geometry.json
@@ -1064,12 +1064,12 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #13 -> Road #14",
-          "Road #0 -> Road #14"
-        ],
         "osm_node_ids": [
           61067223
+        ],
+        "turns": [
+          "Road #13 -> Road #14",
+          "Road #0 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -1107,8 +1107,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1149,13 +1149,13 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          585206954
+        ],
+        "turns": [
           "Road #2 -> Road #21",
           "Road #25 -> Road #2",
           "Road #25 -> Road #21"
-        ],
-        "osm_node_ids": [
-          585206954
         ],
         "type": "intersection"
       },
@@ -1193,8 +1193,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1235,13 +1235,13 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          5548292618
+        ],
+        "turns": [
           "Road #4 -> Road #20",
           "Road #24 -> Road #4",
           "Road #24 -> Road #20"
-        ],
-        "osm_node_ids": [
-          5548292618
         ],
         "type": "intersection"
       },
@@ -1283,16 +1283,16 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          569953961
+        ],
+        "turns": [
           "Road #3 -> Road #5",
           "Road #3 -> Road #4",
           "Road #5 -> Road #3",
           "Road #5 -> Road #4",
           "Road #4 -> Road #3",
           "Road #4 -> Road #5"
-        ],
-        "osm_node_ids": [
-          569953961
         ],
         "type": "intersection"
       },
@@ -1330,8 +1330,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1372,13 +1372,13 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          6257803115
+        ],
+        "turns": [
           "Road #23 -> Road #22",
           "Road #23 -> Road #6",
           "Road #6 -> Road #22"
-        ],
-        "osm_node_ids": [
-          6257803115
         ],
         "type": "intersection"
       },
@@ -1416,8 +1416,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1466,16 +1466,16 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          367716964
+        ],
+        "turns": [
           "Road #1 -> Road #2",
           "Road #1 -> Road #16",
           "Road #2 -> Road #1",
           "Road #2 -> Road #16",
           "Road #16 -> Road #1",
           "Road #16 -> Road #2"
-        ],
-        "osm_node_ids": [
-          367716964
         ],
         "type": "intersection"
       },
@@ -1517,13 +1517,13 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          5082188321
+        ],
+        "turns": [
           "Road #19 -> Road #0",
           "Road #19 -> Road #17",
           "Road #17 -> Road #0"
-        ],
-        "osm_node_ids": [
-          5082188321
         ],
         "type": "intersection"
       },
@@ -1561,8 +1561,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1599,8 +1599,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1641,12 +1641,12 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #9 -> Road #10",
-          "Road #20 -> Road #10"
-        ],
         "osm_node_ids": [
           585206957
+        ],
+        "turns": [
+          "Road #9 -> Road #10",
+          "Road #20 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -1692,12 +1692,12 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #21 -> Road #8",
-          "Road #7 -> Road #8"
-        ],
         "osm_node_ids": [
           585206956
+        ],
+        "turns": [
+          "Road #21 -> Road #8",
+          "Road #7 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -1755,15 +1755,15 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6257803111,
+          585206952
+        ],
+        "turns": [
           "Road #11 -> Road #13",
           "Road #11 -> Road #19",
           "Road #22 -> Road #13",
           "Road #22 -> Road #19"
-        ],
-        "osm_node_ids": [
-          6257803111,
-          585206952
         ],
         "type": "intersection"
       },
@@ -1813,12 +1813,12 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #10 -> Road #23",
-          "Road #10 -> Road #11"
-        ],
         "osm_node_ids": [
           585206951
+        ],
+        "turns": [
+          "Road #10 -> Road #23",
+          "Road #10 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -1868,12 +1868,12 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #8 -> Road #24",
-          "Road #8 -> Road #9"
-        ],
         "osm_node_ids": [
           6257803113
+        ],
+        "turns": [
+          "Road #8 -> Road #24",
+          "Road #8 -> Road #9"
         ],
         "type": "intersection"
       },
@@ -1915,12 +1915,12 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #14 -> Road #25",
-          "Road #14 -> Road #7"
-        ],
         "osm_node_ids": [
           585206960
+        ],
+        "turns": [
+          "Road #14 -> Road #25",
+          "Road #14 -> Road #7"
         ],
         "type": "intersection"
       },

--- a/tests/src/perth_stretched_lights/geometry.json
+++ b/tests/src/perth_stretched_lights/geometry.json
@@ -1590,13 +1590,13 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          367715264
+        ],
+        "turns": [
           "Road #2 -> Road #3",
           "Road #2 -> Road #0",
           "Road #0 -> Road #3"
-        ],
-        "osm_node_ids": [
-          367715264
         ],
         "type": "intersection"
       },
@@ -1634,8 +1634,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1680,14 +1680,14 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6257659835
+        ],
+        "turns": [
           "Road #9 -> Road #10",
           "Road #9 -> Road #1",
           "Road #10 -> Road #9",
           "Road #10 -> Road #1"
-        ],
-        "osm_node_ids": [
-          6257659835
         ],
         "type": "intersection"
       },
@@ -1729,14 +1729,14 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6257659836
+        ],
+        "turns": [
           "Road #8 -> Road #9",
           "Road #9 -> Road #8",
           "Road #4 -> Road #8",
           "Road #4 -> Road #9"
-        ],
-        "osm_node_ids": [
-          6257659836
         ],
         "type": "intersection"
       },
@@ -1774,8 +1774,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1820,15 +1820,15 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          33397360
+        ],
+        "turns": [
           "Road #6 -> Road #12",
           "Road #6 -> Road #7",
           "Road #12 -> Road #7",
           "Road #7 -> Road #6",
           "Road #7 -> Road #12"
-        ],
-        "osm_node_ids": [
-          33397360
         ],
         "type": "intersection"
       },
@@ -1866,8 +1866,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1904,8 +1904,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1942,8 +1942,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1980,8 +1980,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2018,8 +2018,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2056,8 +2056,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2094,8 +2094,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2132,8 +2132,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2170,8 +2170,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2208,8 +2208,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2254,10 +2254,10 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206009
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2322,15 +2322,15 @@
         "control": "Signalled",
         "id": 17,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          7761206011,
+          7761206012
+        ],
+        "turns": [
           "Road #1 -> Road #4",
           "Road #1 -> Road #2",
           "Road #3 -> Road #4",
           "Road #3 -> Road #2"
-        ],
-        "osm_node_ids": [
-          7761206011,
-          7761206012
         ],
         "type": "intersection"
       },
@@ -2380,10 +2380,10 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206010
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2428,10 +2428,10 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206013
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2476,12 +2476,12 @@
         "control": "Signalled",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #10 -> Road #11",
-          "Road #11 -> Road #10"
-        ],
         "osm_node_ids": [
           7761206015
+        ],
+        "turns": [
+          "Road #10 -> Road #11",
+          "Road #11 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -2527,10 +2527,10 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206014
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2571,10 +2571,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206016
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2627,12 +2627,12 @@
         "control": "Signalled",
         "id": 24,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #5 -> Road #6",
-          "Road #6 -> Road #5"
-        ],
         "osm_node_ids": [
           7761206018
+        ],
+        "turns": [
+          "Road #5 -> Road #6",
+          "Road #6 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -2674,10 +2674,10 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206017
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2722,10 +2722,10 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206020
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2778,12 +2778,12 @@
         "control": "Signalled",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #13 -> Road #12",
-          "Road #12 -> Road #13"
-        ],
         "osm_node_ids": [
           7761206021
+        ],
+        "turns": [
+          "Road #13 -> Road #12",
+          "Road #12 -> Road #13"
         ],
         "type": "intersection"
       },
@@ -2829,10 +2829,10 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761197344
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2873,10 +2873,10 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206022
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2929,12 +2929,12 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #8",
-          "Road #8 -> Road #7"
-        ],
         "osm_node_ids": [
           7761206024
+        ],
+        "turns": [
+          "Road #7 -> Road #8",
+          "Road #8 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -2980,10 +2980,10 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7761206023
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/quad_intersection/geometry.json
+++ b/tests/src/quad_intersection/geometry.json
@@ -2425,8 +2425,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2463,8 +2463,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2501,11 +2501,11 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #1 -> Road #44"
-        ],
         "osm_node_ids": [
           29464212
+        ],
+        "turns": [
+          "Road #1 -> Road #44"
         ],
         "type": "intersection"
       },
@@ -2543,10 +2543,10 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4240314159
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2587,16 +2587,16 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4303556051
+        ],
+        "turns": [
           "Road #6 -> Road #7",
           "Road #6 -> Road #3",
           "Road #7 -> Road #6",
           "Road #7 -> Road #3",
           "Road #3 -> Road #6",
           "Road #3 -> Road #7"
-        ],
-        "osm_node_ids": [
-          4303556051
         ],
         "type": "intersection"
       },
@@ -2634,8 +2634,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2676,13 +2676,13 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          53128053
+        ],
+        "turns": [
           "Road #5 -> Road #15",
           "Road #14 -> Road #15",
           "Road #14 -> Road #5"
-        ],
-        "osm_node_ids": [
-          53128053
         ],
         "type": "intersection"
       },
@@ -2720,10 +2720,10 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           53137203
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2760,8 +2760,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2798,11 +2798,11 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #8 -> Road #54"
-        ],
         "osm_node_ids": [
           29447666
+        ],
+        "turns": [
+          "Road #8 -> Road #54"
         ],
         "type": "intersection"
       },
@@ -2840,8 +2840,8 @@
         "control": "Uncontrolled",
         "id": 13,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2882,12 +2882,12 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #12 -> Road #22",
-          "Road #56 -> Road #12"
-        ],
         "osm_node_ids": [
           3391701887
+        ],
+        "turns": [
+          "Road #12 -> Road #22",
+          "Road #56 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -2925,8 +2925,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3007,7 +3007,13 @@
         "control": "Signalled",
         "id": 16,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3391701883,
+          29449863,
+          29464223,
+          3391701882
+        ],
+        "turns": [
           "Road #68 -> Road #2",
           "Road #68 -> Road #55",
           "Road #68 -> Road #18",
@@ -3023,12 +3029,6 @@
           "Road #35 -> Road #2",
           "Road #35 -> Road #55",
           "Road #35 -> Road #32"
-        ],
-        "osm_node_ids": [
-          3391701883,
-          29449863,
-          29464223,
-          3391701882
         ],
         "type": "intersection"
       },
@@ -3066,8 +3066,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3104,8 +3104,8 @@
         "control": "Uncontrolled",
         "id": 21,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3142,8 +3142,8 @@
         "control": "Uncontrolled",
         "id": 22,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3180,11 +3180,11 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #24 -> Road #21"
-        ],
         "osm_node_ids": [
           4136765600
+        ],
+        "turns": [
+          "Road #24 -> Road #21"
         ],
         "type": "intersection"
       },
@@ -3222,8 +3222,8 @@
         "control": "Uncontrolled",
         "id": 24,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3260,11 +3260,11 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #52 -> Road #24"
-        ],
         "osm_node_ids": [
           4240312862
+        ],
+        "turns": [
+          "Road #52 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -3302,11 +3302,11 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #31 -> Road #29"
-        ],
         "osm_node_ids": [
           4240312872
+        ],
+        "turns": [
+          "Road #31 -> Road #29"
         ],
         "type": "intersection"
       },
@@ -3344,11 +3344,11 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #29 -> Road #68"
-        ],
         "osm_node_ids": [
           9546245855
+        ],
+        "turns": [
+          "Road #29 -> Road #68"
         ],
         "type": "intersection"
       },
@@ -3386,8 +3386,8 @@
         "control": "Uncontrolled",
         "id": 30,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3424,11 +3424,11 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #30 -> Road #31"
-        ],
         "osm_node_ids": [
           4240331992
+        ],
+        "turns": [
+          "Road #30 -> Road #31"
         ],
         "type": "intersection"
       },
@@ -3466,8 +3466,8 @@
         "control": "Uncontrolled",
         "id": 32,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3532,13 +3532,13 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #6 -> Road #5"
-        ],
         "osm_node_ids": [
           5760898610,
           2775431964,
           5760898609
+        ],
+        "turns": [
+          "Road #6 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -3576,8 +3576,8 @@
         "control": "Uncontrolled",
         "id": 35,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3626,12 +3626,12 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #3 -> Road #4",
-          "Road #4 -> Road #3"
-        ],
         "osm_node_ids": [
           5760903300
+        ],
+        "turns": [
+          "Road #3 -> Road #4",
+          "Road #4 -> Road #3"
         ],
         "type": "intersection"
       },
@@ -3669,10 +3669,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5760903060
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3709,8 +3709,8 @@
         "control": "Uncontrolled",
         "id": 40,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3747,8 +3747,8 @@
         "control": "Uncontrolled",
         "id": 41,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3785,8 +3785,8 @@
         "control": "Uncontrolled",
         "id": 42,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3823,8 +3823,8 @@
         "control": "Uncontrolled",
         "id": 43,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3861,10 +3861,10 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9074539748
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3901,10 +3901,10 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9074539761
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3949,11 +3949,11 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #32 -> Road #33"
-        ],
         "osm_node_ids": [
           9231042183
+        ],
+        "turns": [
+          "Road #32 -> Road #33"
         ],
         "type": "intersection"
       },
@@ -3999,11 +3999,11 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #34 -> Road #35"
-        ],
         "osm_node_ids": [
           9231042179
+        ],
+        "turns": [
+          "Road #34 -> Road #35"
         ],
         "type": "intersection"
       },
@@ -4045,10 +4045,10 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9074539762
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4085,8 +4085,8 @@
         "control": "Uncontrolled",
         "id": 51,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4123,11 +4123,11 @@
         "control": "Signed",
         "id": 52,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #51 -> Road #52"
-        ],
         "osm_node_ids": [
           9074894120
+        ],
+        "turns": [
+          "Road #51 -> Road #52"
         ],
         "type": "intersection"
       },
@@ -4165,11 +4165,11 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #54 -> Road #53"
-        ],
         "osm_node_ids": [
           9074894122
+        ],
+        "turns": [
+          "Road #54 -> Road #53"
         ],
         "type": "intersection"
       },
@@ -4207,8 +4207,8 @@
         "control": "Uncontrolled",
         "id": 54,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4245,8 +4245,8 @@
         "control": "Uncontrolled",
         "id": 55,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4283,10 +4283,10 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9231042180
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4335,11 +4335,11 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #15 -> Road #16"
-        ],
         "osm_node_ids": [
           5760906315
+        ],
+        "turns": [
+          "Road #15 -> Road #16"
         ],
         "type": "intersection"
       },
@@ -4389,11 +4389,11 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #18 -> Road #19"
-        ],
         "osm_node_ids": [
           3702070714
+        ],
+        "turns": [
+          "Road #18 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -4439,10 +4439,10 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2775432009
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4703,10 +4703,10 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9074539744
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4755,11 +4755,11 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #22 -> Road #23"
-        ],
         "osm_node_ids": [
           9231042186
+        ],
+        "turns": [
+          "Road #22 -> Road #23"
         ],
         "type": "intersection"
       },
@@ -4813,11 +4813,11 @@
         "control": "Signed",
         "id": 62,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #55 -> Road #56"
-        ],
         "osm_node_ids": [
           9231042185
+        ],
+        "turns": [
+          "Road #55 -> Road #56"
         ],
         "type": "intersection"
       },
@@ -4859,10 +4859,10 @@
         "control": "Signed",
         "id": 63,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9231042184
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4899,10 +4899,10 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9074539756
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4939,10 +4939,10 @@
         "control": "Signed",
         "id": 65,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9074539759
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/roosevelt_cycletrack/geometry.json
+++ b/tests/src/roosevelt_cycletrack/geometry.json
@@ -15575,8 +15575,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -15617,13 +15617,13 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          53102770
+        ],
+        "turns": [
           "Road #3 -> Road #70",
           "Road #69 -> Road #3",
           "Road #69 -> Road #70"
-        ],
-        "osm_node_ids": [
-          53102770
         ],
         "type": "intersection"
       },
@@ -15661,8 +15661,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -15707,13 +15707,13 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          53190558
+        ],
+        "turns": [
           "Road #6 -> Road #67",
           "Road #66 -> Road #6",
           "Road #66 -> Road #67"
-        ],
-        "osm_node_ids": [
-          53190558
         ],
         "type": "intersection"
       },
@@ -15751,8 +15751,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -15809,14 +15809,14 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #9 -> Road #65",
-          "Road #63 -> Road #9",
-          "Road #63 -> Road #65"
-        ],
         "osm_node_ids": [
           53231062,
           4695138681
+        ],
+        "turns": [
+          "Road #9 -> Road #65",
+          "Road #63 -> Road #9",
+          "Road #63 -> Road #65"
         ],
         "type": "intersection"
       },
@@ -15858,13 +15858,13 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53231061
+        ],
+        "turns": [
           "Road #72 -> Road #10",
           "Road #72 -> Road #73",
           "Road #10 -> Road #73"
-        ],
-        "osm_node_ids": [
-          53231061
         ],
         "type": "intersection"
       },
@@ -15902,8 +15902,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -15940,8 +15940,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -15978,8 +15978,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16024,13 +16024,13 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          59713137
+        ],
+        "turns": [
           "Road #61 -> Road #19",
           "Road #61 -> Road #62",
           "Road #19 -> Road #62"
-        ],
-        "osm_node_ids": [
-          59713137
         ],
         "type": "intersection"
       },
@@ -16068,8 +16068,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16106,8 +16106,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16152,16 +16152,16 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          59713145
+        ],
+        "turns": [
           "Road #415 -> Road #39",
           "Road #415 -> Road #23",
           "Road #39 -> Road #415",
           "Road #39 -> Road #23",
           "Road #23 -> Road #415",
           "Road #23 -> Road #39"
-        ],
-        "osm_node_ids": [
-          59713145
         ],
         "type": "intersection"
       },
@@ -16199,8 +16199,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16241,13 +16241,13 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          53108154
+        ],
+        "turns": [
           "Road #27 -> Road #80",
           "Road #79 -> Road #27",
           "Road #79 -> Road #80"
-        ],
-        "osm_node_ids": [
-          53108154
         ],
         "type": "intersection"
       },
@@ -16285,8 +16285,8 @@
         "control": "Uncontrolled",
         "id": 16,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16331,13 +16331,13 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          59713117
+        ],
+        "turns": [
           "Road #73 -> Road #74",
           "Road #73 -> Road #30",
           "Road #30 -> Road #74"
-        ],
-        "osm_node_ids": [
-          59713117
         ],
         "type": "intersection"
       },
@@ -16379,10 +16379,10 @@
         "control": "Signed",
         "id": 18,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286399
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16643,10 +16643,10 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908851926
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16683,8 +16683,8 @@
         "control": "Uncontrolled",
         "id": 20,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16729,16 +16729,16 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3308575503
+        ],
+        "turns": [
           "Road #479 -> Road #480",
           "Road #479 -> Road #36",
           "Road #480 -> Road #479",
           "Road #480 -> Road #36",
           "Road #36 -> Road #479",
           "Road #36 -> Road #480"
-        ],
-        "osm_node_ids": [
-          3308575503
         ],
         "type": "intersection"
       },
@@ -16776,10 +16776,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           3308575498
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16816,10 +16816,10 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           59713144
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16856,8 +16856,8 @@
         "control": "Uncontrolled",
         "id": 26,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16906,7 +16906,10 @@
         "control": "Signalled",
         "id": 27,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53162656
+        ],
+        "turns": [
           "Road #44 -> Road #413",
           "Road #44 -> Road #93",
           "Road #92 -> Road #44",
@@ -16914,9 +16917,6 @@
           "Road #92 -> Road #93",
           "Road #413 -> Road #44",
           "Road #413 -> Road #93"
-        ],
-        "osm_node_ids": [
-          53162656
         ],
         "type": "intersection"
       },
@@ -16954,8 +16954,8 @@
         "control": "Uncontrolled",
         "id": 31,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -16992,10 +16992,10 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           3902538253
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17036,16 +17036,16 @@
         "control": "Signed",
         "id": 35,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3902538249
+        ],
+        "turns": [
           "Road #0 -> Road #50",
           "Road #0 -> Road #1",
           "Road #50 -> Road #0",
           "Road #50 -> Road #1",
           "Road #1 -> Road #0",
           "Road #1 -> Road #50"
-        ],
-        "osm_node_ids": [
-          3902538249
         ],
         "type": "intersection"
       },
@@ -17083,10 +17083,10 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           3976726723
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17347,10 +17347,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3976726724
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17611,10 +17611,10 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908851924
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17655,13 +17655,13 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4026632161
+        ],
+        "turns": [
           "Road #85 -> Road #55",
           "Road #85 -> Road #86",
           "Road #55 -> Road #86"
-        ],
-        "osm_node_ids": [
-          4026632161
         ],
         "type": "intersection"
       },
@@ -17703,13 +17703,13 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4026632167
+        ],
+        "turns": [
           "Road #90 -> Road #57",
           "Road #90 -> Road #91",
           "Road #57 -> Road #91"
-        ],
-        "osm_node_ids": [
-          4026632167
         ],
         "type": "intersection"
       },
@@ -17747,10 +17747,10 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4026632168
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17787,12 +17787,12 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #83 -> Road #59",
-          "Road #83 -> Road #84"
-        ],
         "osm_node_ids": [
           4026632173
+        ],
+        "turns": [
+          "Road #83 -> Road #59",
+          "Road #83 -> Road #84"
         ],
         "type": "intersection"
       },
@@ -17830,10 +17830,10 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4026632174
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17870,10 +17870,10 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           4214025137
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -17926,7 +17926,10 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53231060
+        ],
+        "turns": [
           "Road #16 -> Road #17",
           "Road #16 -> Road #76",
           "Road #75 -> Road #16",
@@ -17934,9 +17937,6 @@
           "Road #75 -> Road #76",
           "Road #17 -> Road #16",
           "Road #17 -> Road #76"
-        ],
-        "osm_node_ids": [
-          53231060
         ],
         "type": "intersection"
       },
@@ -17974,11 +17974,11 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #86 -> Road #90"
-        ],
         "osm_node_ids": [
           3003528164
+        ],
+        "turns": [
+          "Road #86 -> Road #90"
         ],
         "type": "intersection"
       },
@@ -18016,11 +18016,11 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #101 -> Road #87"
-        ],
         "osm_node_ids": [
           4272380198
+        ],
+        "turns": [
+          "Road #101 -> Road #87"
         ],
         "type": "intersection"
       },
@@ -18066,12 +18066,12 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #87 -> Road #88",
-          "Road #87 -> Road #156"
-        ],
         "osm_node_ids": [
           59711142
+        ],
+        "turns": [
+          "Road #87 -> Road #88",
+          "Road #87 -> Road #156"
         ],
         "type": "intersection"
       },
@@ -18125,10 +18125,10 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379050
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18165,8 +18165,8 @@
         "control": "Uncontrolled",
         "id": 55,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18211,10 +18211,10 @@
         "control": "Signed",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379068
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18263,12 +18263,12 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #14 -> Road #15",
-          "Road #15 -> Road #14"
-        ],
         "osm_node_ids": [
           4694379049
+        ],
+        "turns": [
+          "Road #14 -> Road #15",
+          "Road #15 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -18314,11 +18314,11 @@
         "control": "Signed",
         "id": 62,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379075,
           4694379076
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18355,8 +18355,8 @@
         "control": "Uncontrolled",
         "id": 63,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18409,12 +18409,12 @@
         "control": "Signed",
         "id": 65,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #12 -> Road #13",
-          "Road #13 -> Road #12"
-        ],
         "osm_node_ids": [
           4694379065
+        ],
+        "turns": [
+          "Road #12 -> Road #13",
+          "Road #13 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -18452,8 +18452,8 @@
         "control": "Uncontrolled",
         "id": 67,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18498,10 +18498,10 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379309
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18538,8 +18538,8 @@
         "control": "Uncontrolled",
         "id": 71,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18588,11 +18588,11 @@
         "control": "Signed",
         "id": 73,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #102 -> Road #103"
-        ],
         "osm_node_ids": [
           4583297954
+        ],
+        "turns": [
+          "Road #102 -> Road #103"
         ],
         "type": "intersection"
       },
@@ -18638,11 +18638,11 @@
         "control": "Signed",
         "id": 76,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #65 -> Road #66"
-        ],
         "osm_node_ids": [
           4695138679
+        ],
+        "turns": [
+          "Road #65 -> Road #66"
         ],
         "type": "intersection"
       },
@@ -18696,11 +18696,11 @@
         "control": "Signed",
         "id": 82,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #62 -> Road #63"
-        ],
         "osm_node_ids": [
           4695138680
+        ],
+        "turns": [
+          "Road #62 -> Road #63"
         ],
         "type": "intersection"
       },
@@ -18742,10 +18742,10 @@
         "control": "Signed",
         "id": 83,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695138790
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18782,10 +18782,10 @@
         "control": "Signed",
         "id": 85,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341352
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18838,10 +18838,10 @@
         "control": "Signed",
         "id": 87,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695138796
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18878,8 +18878,8 @@
         "control": "Uncontrolled",
         "id": 89,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -18928,12 +18928,12 @@
         "control": "Signed",
         "id": 90,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #19 -> Road #20",
-          "Road #20 -> Road #19"
-        ],
         "osm_node_ids": [
           4695138666
+        ],
+        "turns": [
+          "Road #19 -> Road #20",
+          "Road #20 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -18979,10 +18979,10 @@
         "control": "Signed",
         "id": 91,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379070
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19023,10 +19023,10 @@
         "control": "Signed",
         "id": 92,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379058
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19071,10 +19071,10 @@
         "control": "Signed",
         "id": 94,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379311
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19131,14 +19131,14 @@
         "control": "Signed",
         "id": 95,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4694379084
+        ],
+        "turns": [
           "Road #423 -> Road #459",
           "Road #158 -> Road #423",
           "Road #158 -> Road #459",
           "Road #459 -> Road #423"
-        ],
-        "osm_node_ids": [
-          4694379084
         ],
         "type": "intersection"
       },
@@ -19184,10 +19184,10 @@
         "control": "Signed",
         "id": 96,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724323
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19232,10 +19232,10 @@
         "control": "Signed",
         "id": 98,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724324
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19276,10 +19276,10 @@
         "control": "Signed",
         "id": 99,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724340
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19316,10 +19316,10 @@
         "control": "Signed",
         "id": 100,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724338
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19376,12 +19376,12 @@
         "control": "Signed",
         "id": 101,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #23 -> Road #22",
-          "Road #22 -> Road #23"
-        ],
         "osm_node_ids": [
           4829724321
+        ],
+        "turns": [
+          "Road #23 -> Road #22",
+          "Road #22 -> Road #23"
         ],
         "type": "intersection"
       },
@@ -19419,8 +19419,8 @@
         "control": "Uncontrolled",
         "id": 103,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19469,11 +19469,11 @@
         "control": "Signalled",
         "id": 105,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #157 -> Road #158"
-        ],
         "osm_node_ids": [
           4829741814
+        ],
+        "turns": [
+          "Road #157 -> Road #158"
         ],
         "type": "intersection"
       },
@@ -19519,10 +19519,10 @@
         "control": "Signed",
         "id": 107,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745922
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19567,10 +19567,10 @@
         "control": "Signed",
         "id": 109,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745923
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19623,12 +19623,12 @@
         "control": "Signed",
         "id": 113,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #98 -> Road #99"
-        ],
         "osm_node_ids": [
           4829741817,
           4829745931
+        ],
+        "turns": [
+          "Road #98 -> Road #99"
         ],
         "type": "intersection"
       },
@@ -19666,10 +19666,10 @@
         "control": "Signed",
         "id": 114,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745932
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19706,10 +19706,10 @@
         "control": "Signed",
         "id": 116,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745939
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19750,10 +19750,10 @@
         "control": "Signed",
         "id": 117,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745937
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19794,10 +19794,10 @@
         "control": "Signed",
         "id": 121,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750347
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19842,10 +19842,10 @@
         "control": "Signed",
         "id": 122,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750348
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19894,10 +19894,10 @@
         "control": "Signed",
         "id": 124,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750354
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19942,10 +19942,10 @@
         "control": "Signed",
         "id": 125,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750351
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -19990,10 +19990,10 @@
         "control": "Signed",
         "id": 126,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750349
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20042,11 +20042,11 @@
         "control": "Signed",
         "id": 128,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750362,
           4694379300
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20091,10 +20091,10 @@
         "control": "Signed",
         "id": 129,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750361
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20139,10 +20139,10 @@
         "control": "Signed",
         "id": 131,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750355
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20179,8 +20179,8 @@
         "control": "Uncontrolled",
         "id": 132,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20217,8 +20217,8 @@
         "control": "Uncontrolled",
         "id": 133,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20267,12 +20267,12 @@
         "control": "Signed",
         "id": 135,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #36 -> Road #37",
-          "Road #37 -> Road #36"
-        ],
         "osm_node_ids": [
           4829750340
+        ],
+        "turns": [
+          "Road #36 -> Road #37",
+          "Road #37 -> Road #36"
         ],
         "type": "intersection"
       },
@@ -20310,8 +20310,8 @@
         "control": "Uncontrolled",
         "id": 136,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20348,8 +20348,8 @@
         "control": "Uncontrolled",
         "id": 138,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20394,10 +20394,10 @@
         "control": "Signed",
         "id": 139,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220197
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20442,10 +20442,10 @@
         "control": "Signed",
         "id": 140,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220178
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20486,10 +20486,10 @@
         "control": "Signed",
         "id": 142,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220200
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20538,10 +20538,10 @@
         "control": "Signed",
         "id": 143,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220185
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20594,10 +20594,10 @@
         "control": "Signed",
         "id": 146,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220194
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20646,10 +20646,10 @@
         "control": "Signed",
         "id": 149,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220189
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20694,10 +20694,10 @@
         "control": "Signed",
         "id": 150,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831220191
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20734,8 +20734,8 @@
         "control": "Uncontrolled",
         "id": 152,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20788,12 +20788,12 @@
         "control": "Signed",
         "id": 156,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #42 -> Road #43",
-          "Road #43 -> Road #42"
-        ],
         "osm_node_ids": [
           4831220187
+        ],
+        "turns": [
+          "Road #42 -> Road #43",
+          "Road #43 -> Road #42"
         ],
         "type": "intersection"
       },
@@ -20851,12 +20851,12 @@
         "control": "Signed",
         "id": 159,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #41 -> Road #42",
-          "Road #42 -> Road #41"
-        ],
         "osm_node_ids": [
           4831220183
+        ],
+        "turns": [
+          "Road #41 -> Road #42",
+          "Road #42 -> Road #41"
         ],
         "type": "intersection"
       },
@@ -20894,8 +20894,8 @@
         "control": "Uncontrolled",
         "id": 160,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -20944,10 +20944,10 @@
         "control": "Signed",
         "id": 161,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831240605
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21008,11 +21008,11 @@
         "control": "Signed",
         "id": 164,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831240617,
           4829745934
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21065,11 +21065,11 @@
         "control": "Signed",
         "id": 165,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #96 -> Road #97"
-        ],
         "osm_node_ids": [
           4831240614
+        ],
+        "turns": [
+          "Road #96 -> Road #97"
         ],
         "type": "intersection"
       },
@@ -21107,10 +21107,10 @@
         "control": "Signed",
         "id": 166,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831240619
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21163,11 +21163,11 @@
         "control": "Signed",
         "id": 167,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #93 -> Road #94"
-        ],
         "osm_node_ids": [
           4831240603
+        ],
+        "turns": [
+          "Road #93 -> Road #94"
         ],
         "type": "intersection"
       },
@@ -21205,10 +21205,10 @@
         "control": "Signed",
         "id": 168,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831243621
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21261,10 +21261,10 @@
         "control": "Signed",
         "id": 170,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831378213
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21301,8 +21301,8 @@
         "control": "Uncontrolled",
         "id": 172,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21339,8 +21339,8 @@
         "control": "Uncontrolled",
         "id": 173,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21377,10 +21377,10 @@
         "control": "Signed",
         "id": 174,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154271091
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21429,11 +21429,11 @@
         "control": "Signed",
         "id": 177,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #91 -> Road #92"
-        ],
         "osm_node_ids": [
           5154271086
+        ],
+        "turns": [
+          "Road #91 -> Road #92"
         ],
         "type": "intersection"
       },
@@ -21487,11 +21487,11 @@
         "control": "Signed",
         "id": 181,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #82 -> Road #83"
-        ],
         "osm_node_ids": [
           5154271081
+        ],
+        "turns": [
+          "Road #82 -> Road #83"
         ],
         "type": "intersection"
       },
@@ -21545,10 +21545,10 @@
         "control": "Signed",
         "id": 183,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154271096
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21585,11 +21585,11 @@
         "control": "Signed",
         "id": 184,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #59 -> Road #60"
-        ],
         "osm_node_ids": [
           5154271075
+        ],
+        "turns": [
+          "Road #59 -> Road #60"
         ],
         "type": "intersection"
       },
@@ -21631,10 +21631,10 @@
         "control": "Signed",
         "id": 185,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5154271085
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21679,12 +21679,12 @@
         "control": "Signed",
         "id": 186,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #57 -> Road #58",
-          "Road #58 -> Road #57"
-        ],
         "osm_node_ids": [
           5154271074
+        ],
+        "turns": [
+          "Road #57 -> Road #58",
+          "Road #58 -> Road #57"
         ],
         "type": "intersection"
       },
@@ -21738,10 +21738,10 @@
         "control": "Signed",
         "id": 187,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154271090
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21778,10 +21778,10 @@
         "control": "Signed",
         "id": 188,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154271092
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21838,12 +21838,12 @@
         "control": "Signed",
         "id": 190,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #25 -> Road #26",
-          "Road #26 -> Road #25"
-        ],
         "osm_node_ids": [
           5154286392
+        ],
+        "turns": [
+          "Road #25 -> Road #26",
+          "Road #26 -> Road #25"
         ],
         "type": "intersection"
       },
@@ -21885,10 +21885,10 @@
         "control": "Signed",
         "id": 192,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286394
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21929,10 +21929,10 @@
         "control": "Signed",
         "id": 193,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286397
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -21973,10 +21973,10 @@
         "control": "Signed",
         "id": 195,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286398
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22017,10 +22017,10 @@
         "control": "Signed",
         "id": 196,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286404
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22061,10 +22061,10 @@
         "control": "Signed",
         "id": 197,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286410
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22113,10 +22113,10 @@
         "control": "Signed",
         "id": 198,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286418
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22153,8 +22153,8 @@
         "control": "Uncontrolled",
         "id": 199,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22203,12 +22203,12 @@
         "control": "Signed",
         "id": 200,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #34 -> Road #33",
-          "Road #33 -> Road #34"
-        ],
         "osm_node_ids": [
           5154286413
+        ],
+        "turns": [
+          "Road #34 -> Road #33",
+          "Road #33 -> Road #34"
         ],
         "type": "intersection"
       },
@@ -22254,10 +22254,10 @@
         "control": "Signed",
         "id": 201,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286822
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22294,8 +22294,8 @@
         "control": "Uncontrolled",
         "id": 202,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22348,10 +22348,10 @@
         "control": "Signed",
         "id": 205,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286823
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22404,11 +22404,11 @@
         "control": "Signed",
         "id": 207,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #80 -> Road #81"
-        ],
         "osm_node_ids": [
           1709161422
+        ],
+        "turns": [
+          "Road #80 -> Road #81"
         ],
         "type": "intersection"
       },
@@ -22466,12 +22466,12 @@
         "control": "Signed",
         "id": 208,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #24 -> Road #25",
-          "Road #25 -> Road #24"
-        ],
         "osm_node_ids": [
           5154286401
+        ],
+        "turns": [
+          "Road #24 -> Road #25",
+          "Road #25 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -22525,10 +22525,10 @@
         "control": "Signed",
         "id": 209,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286419
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22577,11 +22577,11 @@
         "control": "Signed",
         "id": 211,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #77 -> Road #79"
-        ],
         "osm_node_ids": [
           5154286386
+        ],
+        "turns": [
+          "Road #77 -> Road #79"
         ],
         "type": "intersection"
       },
@@ -22631,11 +22631,11 @@
         "control": "Signed",
         "id": 213,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #74 -> Road #75"
-        ],
         "osm_node_ids": [
           5154341329
+        ],
+        "turns": [
+          "Road #74 -> Road #75"
         ],
         "type": "intersection"
       },
@@ -22689,11 +22689,11 @@
         "control": "Signed",
         "id": 216,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #71 -> Road #72"
-        ],
         "osm_node_ids": [
           5154341344
+        ],
+        "turns": [
+          "Road #71 -> Road #72"
         ],
         "type": "intersection"
       },
@@ -22751,12 +22751,12 @@
         "control": "Signed",
         "id": 217,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #11 -> Road #10",
-          "Road #10 -> Road #11"
-        ],
         "osm_node_ids": [
           5154341343
+        ],
+        "turns": [
+          "Road #11 -> Road #10",
+          "Road #10 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -22794,10 +22794,10 @@
         "control": "Signed",
         "id": 219,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341362
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22834,10 +22834,10 @@
         "control": "Signed",
         "id": 220,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341350
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22878,10 +22878,10 @@
         "control": "Signed",
         "id": 221,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341370
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22934,10 +22934,10 @@
         "control": "Signed",
         "id": 222,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341372
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -22978,10 +22978,10 @@
         "control": "Signed",
         "id": 224,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154402035
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23034,12 +23034,12 @@
         "control": "Signed",
         "id": 226,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #28 -> Road #29",
-          "Road #29 -> Road #28"
-        ],
         "osm_node_ids": [
           5154402034
+        ],
+        "turns": [
+          "Road #28 -> Road #29",
+          "Road #29 -> Road #28"
         ],
         "type": "intersection"
       },
@@ -23077,8 +23077,8 @@
         "control": "Uncontrolled",
         "id": 228,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23131,10 +23131,10 @@
         "control": "Signed",
         "id": 229,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154402048
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23175,10 +23175,10 @@
         "control": "Signed",
         "id": 230,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154402047
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23215,8 +23215,8 @@
         "control": "Uncontrolled",
         "id": 231,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23257,10 +23257,10 @@
         "control": "Signed",
         "id": 232,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154405780
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23305,10 +23305,10 @@
         "control": "Signed",
         "id": 233,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154405785
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23345,8 +23345,8 @@
         "control": "Uncontrolled",
         "id": 234,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23399,12 +23399,12 @@
         "control": "Signed",
         "id": 237,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #1 -> Road #2",
-          "Road #2 -> Road #1"
-        ],
         "osm_node_ids": [
           5154405774
+        ],
+        "turns": [
+          "Road #1 -> Road #2",
+          "Road #2 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -23458,11 +23458,11 @@
         "control": "Signed",
         "id": 240,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #70 -> Road #71"
-        ],
         "osm_node_ids": [
           5154405776
+        ],
+        "turns": [
+          "Road #70 -> Road #71"
         ],
         "type": "intersection"
       },
@@ -23516,10 +23516,10 @@
         "control": "Signed",
         "id": 242,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154405783
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23556,8 +23556,8 @@
         "control": "Uncontrolled",
         "id": 243,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23598,10 +23598,10 @@
         "control": "Signed",
         "id": 244,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695138686
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23642,10 +23642,10 @@
         "control": "Signed",
         "id": 245,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411340
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23686,10 +23686,10 @@
         "control": "Signed",
         "id": 247,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411344
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23730,10 +23730,10 @@
         "control": "Signed",
         "id": 248,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411345
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23770,8 +23770,8 @@
         "control": "Uncontrolled",
         "id": 251,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23824,11 +23824,11 @@
         "control": "Signed",
         "id": 252,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #67 -> Road #68"
-        ],
         "osm_node_ids": [
           5154411325
+        ],
+        "turns": [
+          "Road #67 -> Road #68"
         ],
         "type": "intersection"
       },
@@ -23878,10 +23878,10 @@
         "control": "Signed",
         "id": 253,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411349
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23918,8 +23918,8 @@
         "control": "Uncontrolled",
         "id": 255,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -23972,12 +23972,12 @@
         "control": "Signed",
         "id": 256,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #49 -> Road #50",
-          "Road #50 -> Road #49"
-        ],
         "osm_node_ids": [
           5154411331
+        ],
+        "turns": [
+          "Road #49 -> Road #50",
+          "Road #50 -> Road #49"
         ],
         "type": "intersection"
       },
@@ -24031,10 +24031,10 @@
         "control": "Signed",
         "id": 257,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411348
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24079,11 +24079,11 @@
         "control": "Signed",
         "id": 259,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #68 -> Road #69"
-        ],
         "osm_node_ids": [
           5154411343
+        ],
+        "turns": [
+          "Road #68 -> Road #69"
         ],
         "type": "intersection"
       },
@@ -24141,12 +24141,12 @@
         "control": "Signed",
         "id": 261,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #4 -> Road #5",
-          "Road #5 -> Road #4"
-        ],
         "osm_node_ids": [
           5154411328
+        ],
+        "turns": [
+          "Road #4 -> Road #5",
+          "Road #5 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -24188,10 +24188,10 @@
         "control": "Signed",
         "id": 262,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695138688
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24228,8 +24228,8 @@
         "control": "Uncontrolled",
         "id": 263,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24306,14 +24306,14 @@
         "control": "Signed",
         "id": 265,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #7 -> Road #8",
-          "Road #8 -> Road #7"
-        ],
         "osm_node_ids": [
           5154413371,
           5154413369,
           4695138789
+        ],
+        "turns": [
+          "Road #7 -> Road #8",
+          "Road #8 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -24351,8 +24351,8 @@
         "control": "Uncontrolled",
         "id": 266,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24401,10 +24401,10 @@
         "control": "Signed",
         "id": 267,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154413373
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24445,10 +24445,10 @@
         "control": "Signed",
         "id": 268,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415801
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24493,10 +24493,10 @@
         "control": "Signed",
         "id": 269,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415800
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24541,10 +24541,10 @@
         "control": "Signed",
         "id": 270,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415776
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24597,12 +24597,12 @@
         "control": "Signed",
         "id": 271,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #17 -> Road #18",
-          "Road #18 -> Road #17"
-        ],
         "osm_node_ids": [
           5154415770
+        ],
+        "turns": [
+          "Road #17 -> Road #18",
+          "Road #18 -> Road #17"
         ],
         "type": "intersection"
       },
@@ -24656,11 +24656,11 @@
         "control": "Signed",
         "id": 273,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #76 -> Road #77"
-        ],
         "osm_node_ids": [
           5154415767
+        ],
+        "turns": [
+          "Road #76 -> Road #77"
         ],
         "type": "intersection"
       },
@@ -24698,10 +24698,10 @@
         "control": "Signed",
         "id": 275,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415789
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24738,10 +24738,10 @@
         "control": "Signed",
         "id": 276,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415782
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24794,10 +24794,10 @@
         "control": "Signed",
         "id": 277,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415797
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24838,16 +24838,16 @@
         "control": "Signed",
         "id": 278,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5443485488
+        ],
+        "turns": [
           "Road #13 -> Road #14",
           "Road #13 -> Road #397",
           "Road #14 -> Road #13",
           "Road #14 -> Road #397",
           "Road #397 -> Road #13",
           "Road #397 -> Road #14"
-        ],
-        "osm_node_ids": [
-          5443485488
         ],
         "type": "intersection"
       },
@@ -24889,10 +24889,10 @@
         "control": "Signed",
         "id": 279,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5443485487
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -24933,13 +24933,13 @@
         "control": "Signed",
         "id": 281,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          6040524426
+        ],
+        "turns": [
           "Road #399 -> Road #85",
           "Road #84 -> Road #399",
           "Road #84 -> Road #85"
-        ],
-        "osm_node_ids": [
-          6040524426
         ],
         "type": "intersection"
       },
@@ -24981,10 +24981,10 @@
         "control": "Signed",
         "id": 282,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5443485496
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25025,16 +25025,16 @@
         "control": "Signed",
         "id": 283,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5443485514
+        ],
+        "turns": [
           "Road #408 -> Road #401",
           "Road #408 -> Road #409",
           "Road #401 -> Road #408",
           "Road #401 -> Road #409",
           "Road #409 -> Road #408",
           "Road #409 -> Road #401"
-        ],
-        "osm_node_ids": [
-          5443485514
         ],
         "type": "intersection"
       },
@@ -25088,12 +25088,12 @@
         "control": "Signed",
         "id": 284,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #402 -> Road #401",
-          "Road #401 -> Road #402"
-        ],
         "osm_node_ids": [
           5443485513
+        ],
+        "turns": [
+          "Road #402 -> Road #401",
+          "Road #401 -> Road #402"
         ],
         "type": "intersection"
       },
@@ -25143,12 +25143,12 @@
         "control": "Signed",
         "id": 285,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #403 -> Road #402",
-          "Road #402 -> Road #403"
-        ],
         "osm_node_ids": [
           5443485511
+        ],
+        "turns": [
+          "Road #403 -> Road #402",
+          "Road #402 -> Road #403"
         ],
         "type": "intersection"
       },
@@ -25190,13 +25190,13 @@
         "control": "Signed",
         "id": 286,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5443485510
+        ],
+        "turns": [
           "Road #95 -> Road #403",
           "Road #95 -> Road #96",
           "Road #403 -> Road #96"
-        ],
-        "osm_node_ids": [
-          5443485510
         ],
         "type": "intersection"
       },
@@ -25238,13 +25238,13 @@
         "control": "Signed",
         "id": 287,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5443485520
+        ],
+        "turns": [
           "Road #100 -> Road #404",
           "Road #100 -> Road #101",
           "Road #404 -> Road #101"
-        ],
-        "osm_node_ids": [
-          5443485520
         ],
         "type": "intersection"
       },
@@ -25290,12 +25290,12 @@
         "control": "Signed",
         "id": 288,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #404 -> Road #405",
-          "Road #405 -> Road #404"
-        ],
         "osm_node_ids": [
           5443485519
+        ],
+        "turns": [
+          "Road #404 -> Road #405",
+          "Road #405 -> Road #404"
         ],
         "type": "intersection"
       },
@@ -25341,12 +25341,12 @@
         "control": "Signed",
         "id": 289,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #406 -> Road #405",
-          "Road #405 -> Road #406"
-        ],
         "osm_node_ids": [
           5443485516
+        ],
+        "turns": [
+          "Road #406 -> Road #405",
+          "Road #405 -> Road #406"
         ],
         "type": "intersection"
       },
@@ -25388,13 +25388,13 @@
         "control": "Signed",
         "id": 290,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5443485515
+        ],
+        "turns": [
           "Road #99 -> Road #406",
           "Road #99 -> Road #100",
           "Road #406 -> Road #100"
-        ],
-        "osm_node_ids": [
-          5443485515
         ],
         "type": "intersection"
       },
@@ -25448,7 +25448,10 @@
         "control": "Signalled",
         "id": 291,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53222750
+        ],
+        "turns": [
           "Road #482 -> Road #407",
           "Road #482 -> Road #98",
           "Road #97 -> Road #482",
@@ -25456,9 +25459,6 @@
           "Road #97 -> Road #98",
           "Road #407 -> Road #482",
           "Road #407 -> Road #98"
-        ],
-        "osm_node_ids": [
-          53222750
         ],
         "type": "intersection"
       },
@@ -25512,12 +25512,12 @@
         "control": "Signed",
         "id": 292,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #407 -> Road #408",
-          "Road #408 -> Road #407"
-        ],
         "osm_node_ids": [
           4829745921
+        ],
+        "turns": [
+          "Road #407 -> Road #408",
+          "Road #408 -> Road #407"
         ],
         "type": "intersection"
       },
@@ -25555,10 +25555,10 @@
         "control": "Signalled",
         "id": 293,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           53222751
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25599,13 +25599,13 @@
         "control": "Signed",
         "id": 294,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          53097833
+        ],
+        "turns": [
           "Road #81 -> Road #410",
           "Road #81 -> Road #82",
           "Road #410 -> Road #82"
-        ],
-        "osm_node_ids": [
-          53097833
         ],
         "type": "intersection"
       },
@@ -25655,12 +25655,12 @@
         "control": "Signed",
         "id": 295,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #410 -> Road #411",
-          "Road #411 -> Road #410"
-        ],
         "osm_node_ids": [
           5154271082
+        ],
+        "turns": [
+          "Road #410 -> Road #411",
+          "Road #411 -> Road #410"
         ],
         "type": "intersection"
       },
@@ -25698,8 +25698,8 @@
         "control": "Uncontrolled",
         "id": 296,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25736,10 +25736,10 @@
         "control": "Signalled",
         "id": 297,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           53162658
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25792,12 +25792,12 @@
         "control": "Signed",
         "id": 298,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #413 -> Road #412",
-          "Road #412 -> Road #413"
-        ],
         "osm_node_ids": [
           4831240604
+        ],
+        "turns": [
+          "Road #413 -> Road #412",
+          "Road #412 -> Road #413"
         ],
         "type": "intersection"
       },
@@ -25835,10 +25835,10 @@
         "control": "Signed",
         "id": 300,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3976726725
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25875,10 +25875,10 @@
         "control": "Signed",
         "id": 301,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3003528165
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25923,10 +25923,10 @@
         "control": "Signed",
         "id": 302,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908851932
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -25971,10 +25971,10 @@
         "control": "Signed",
         "id": 303,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908851929
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26019,10 +26019,10 @@
         "control": "Signed",
         "id": 304,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908863568
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26063,10 +26063,10 @@
         "control": "Signed",
         "id": 305,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908863567
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26107,10 +26107,10 @@
         "control": "Signed",
         "id": 306,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908863566
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26155,10 +26155,10 @@
         "control": "Signed",
         "id": 307,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5908863569
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26195,12 +26195,12 @@
         "control": "Signed",
         "id": 308,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #425 -> Road #423",
-          "Road #423 -> Road #425"
-        ],
         "osm_node_ids": [
           4531063551
+        ],
+        "turns": [
+          "Road #425 -> Road #423",
+          "Road #423 -> Road #425"
         ],
         "type": "intersection"
       },
@@ -26238,8 +26238,8 @@
         "control": "Uncontrolled",
         "id": 309,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26276,10 +26276,10 @@
         "control": "Signed",
         "id": 310,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6697419470
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26332,10 +26332,10 @@
         "control": "Signed",
         "id": 311,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695138663
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26404,13 +26404,13 @@
         "control": "Signed",
         "id": 312,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #8 -> Road #9",
-          "Road #9 -> Road #8"
-        ],
         "osm_node_ids": [
           4384739623,
           4695138662
+        ],
+        "turns": [
+          "Road #8 -> Road #9",
+          "Road #9 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -26460,10 +26460,10 @@
         "control": "Signed",
         "id": 314,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4695138661
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26512,12 +26512,12 @@
         "control": "Signed",
         "id": 315,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #6 -> Road #5",
-          "Road #5 -> Road #6"
-        ],
         "osm_node_ids": [
           4384739624
+        ],
+        "turns": [
+          "Road #6 -> Road #5",
+          "Road #5 -> Road #6"
         ],
         "type": "intersection"
       },
@@ -26559,10 +26559,10 @@
         "control": "Signed",
         "id": 316,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411326
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26603,10 +26603,10 @@
         "control": "Signed",
         "id": 317,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154411342
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26659,12 +26659,12 @@
         "control": "Signed",
         "id": 318,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #2 -> Road #3",
-          "Road #3 -> Road #2"
-        ],
         "osm_node_ids": [
           4384739627
+        ],
+        "turns": [
+          "Road #2 -> Road #3",
+          "Road #3 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -26718,10 +26718,10 @@
         "control": "Signed",
         "id": 319,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154405775
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26762,10 +26762,10 @@
         "control": "Signed",
         "id": 320,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341330
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26814,12 +26814,12 @@
         "control": "Signed",
         "id": 321,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #29 -> Road #30",
-          "Road #30 -> Road #29"
-        ],
         "osm_node_ids": [
           4384739630
+        ],
+        "turns": [
+          "Road #29 -> Road #30",
+          "Road #30 -> Road #29"
         ],
         "type": "intersection"
       },
@@ -26869,10 +26869,10 @@
         "control": "Signed",
         "id": 322,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154341332
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -26929,12 +26929,12 @@
         "control": "Signed",
         "id": 323,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #15 -> Road #16",
-          "Road #16 -> Road #15"
-        ],
         "osm_node_ids": [
           4384739631
+        ],
+        "turns": [
+          "Road #15 -> Road #16",
+          "Road #16 -> Road #15"
         ],
         "type": "intersection"
       },
@@ -26988,10 +26988,10 @@
         "control": "Signed",
         "id": 324,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154415769
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27040,10 +27040,10 @@
         "control": "Signed",
         "id": 325,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286387
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27096,12 +27096,12 @@
         "control": "Signed",
         "id": 326,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #27 -> Road #26",
-          "Road #26 -> Road #27"
-        ],
         "osm_node_ids": [
           4384739632
+        ],
+        "turns": [
+          "Road #27 -> Road #26",
+          "Road #26 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -27155,10 +27155,10 @@
         "control": "Signed",
         "id": 327,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154286388
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27211,10 +27211,10 @@
         "control": "Signed",
         "id": 328,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154271073
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27267,12 +27267,12 @@
         "control": "Signed",
         "id": 329,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #400 -> Road #399",
-          "Road #399 -> Road #400"
-        ],
         "osm_node_ids": [
           5443485497
+        ],
+        "turns": [
+          "Road #400 -> Road #399",
+          "Road #399 -> Road #400"
         ],
         "type": "intersection"
       },
@@ -27326,10 +27326,10 @@
         "control": "Signed",
         "id": 330,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5154271072
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27378,12 +27378,12 @@
         "control": "Signed",
         "id": 331,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #43 -> Road #44",
-          "Road #44 -> Road #43"
-        ],
         "osm_node_ids": [
           4384739635
+        ],
+        "turns": [
+          "Road #43 -> Road #44",
+          "Road #44 -> Road #43"
         ],
         "type": "intersection"
       },
@@ -27437,10 +27437,10 @@
         "control": "Signed",
         "id": 332,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4831240602
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27493,10 +27493,10 @@
         "control": "Signed",
         "id": 333,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5766880419
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27549,10 +27549,10 @@
         "control": "Signed",
         "id": 334,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5766880418
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27597,11 +27597,11 @@
         "control": "Signed",
         "id": 335,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #156 -> Road #157"
-        ],
         "osm_node_ids": [
           5674754355
+        ],
+        "turns": [
+          "Road #156 -> Road #157"
         ],
         "type": "intersection"
       },
@@ -27655,10 +27655,10 @@
         "control": "Signed",
         "id": 337,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452209413
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27695,8 +27695,8 @@
         "control": "Uncontrolled",
         "id": 338,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -27957,7 +27957,14 @@
         "control": "Signalled",
         "id": 342,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5674754357,
+          4829741818,
+          53079358,
+          5674754356,
+          4829724322
+        ],
+        "turns": [
           "Road #88 -> Road #415",
           "Road #88 -> Road #102",
           "Road #88 -> Road #459",
@@ -27965,13 +27972,6 @@
           "Road #415 -> Road #459",
           "Road #459 -> Road #415",
           "Road #459 -> Road #102"
-        ],
-        "osm_node_ids": [
-          5674754357,
-          4829741818,
-          53079358,
-          5674754356,
-          4829724322
         ],
         "type": "intersection"
       },
@@ -28013,13 +28013,13 @@
         "control": "Signed",
         "id": 343,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          7152797295
+        ],
+        "turns": [
           "Road #94 -> Road #462",
           "Road #94 -> Road #95",
           "Road #462 -> Road #95"
-        ],
-        "osm_node_ids": [
-          7152797295
         ],
         "type": "intersection"
       },
@@ -28069,12 +28069,12 @@
         "control": "Signed",
         "id": 344,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #463 -> Road #462",
-          "Road #462 -> Road #463"
-        ],
         "osm_node_ids": [
           7152797296
+        ],
+        "turns": [
+          "Road #463 -> Road #462",
+          "Road #462 -> Road #463"
         ],
         "type": "intersection"
       },
@@ -28112,10 +28112,10 @@
         "control": "Signed",
         "id": 345,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7152797297
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28156,16 +28156,16 @@
         "control": "Signed",
         "id": 346,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8318893544
+        ],
+        "turns": [
           "Road #425 -> Road #464",
           "Road #425 -> Road #424",
           "Road #464 -> Road #425",
           "Road #464 -> Road #424",
           "Road #424 -> Road #425",
           "Road #424 -> Road #464"
-        ],
-        "osm_node_ids": [
-          8318893544
         ],
         "type": "intersection"
       },
@@ -28215,12 +28215,12 @@
         "control": "Signed",
         "id": 347,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #464 -> Road #465",
-          "Road #465 -> Road #464"
-        ],
         "osm_node_ids": [
           8428577669
+        ],
+        "turns": [
+          "Road #464 -> Road #465",
+          "Road #465 -> Road #464"
         ],
         "type": "intersection"
       },
@@ -28270,7 +28270,10 @@
         "control": "Signed",
         "id": 348,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8318893546
+        ],
+        "turns": [
           "Road #465 -> Road #476",
           "Road #465 -> Road #468",
           "Road #465 -> Road #467",
@@ -28283,9 +28286,6 @@
           "Road #467 -> Road #465",
           "Road #467 -> Road #476",
           "Road #467 -> Road #468"
-        ],
-        "osm_node_ids": [
-          8318893546
         ],
         "type": "intersection"
       },
@@ -28335,7 +28335,10 @@
         "control": "Signed",
         "id": 353,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8318893551
+        ],
+        "turns": [
           "Road #468 -> Road #476",
           "Road #468 -> Road #473",
           "Road #468 -> Road #467",
@@ -28348,9 +28351,6 @@
           "Road #467 -> Road #468",
           "Road #467 -> Road #476",
           "Road #467 -> Road #473"
-        ],
-        "osm_node_ids": [
-          8318893551
         ],
         "type": "intersection"
       },
@@ -28404,12 +28404,12 @@
         "control": "Signed",
         "id": 356,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #473 -> Road #474",
-          "Road #474 -> Road #473"
-        ],
         "osm_node_ids": [
           8428577668
+        ],
+        "turns": [
+          "Road #473 -> Road #474",
+          "Road #474 -> Road #473"
         ],
         "type": "intersection"
       },
@@ -28463,12 +28463,12 @@
         "control": "Signed",
         "id": 357,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #474 -> Road #475",
-          "Road #475 -> Road #474"
-        ],
         "osm_node_ids": [
           8428577667
+        ],
+        "turns": [
+          "Road #474 -> Road #475",
+          "Road #475 -> Road #474"
         ],
         "type": "intersection"
       },
@@ -28514,13 +28514,13 @@
         "control": "Signed",
         "id": 358,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          4583297951
+        ],
+        "turns": [
           "Road #475 -> Road #47",
           "Road #103 -> Road #475",
           "Road #103 -> Road #47"
-        ],
-        "osm_node_ids": [
-          4583297951
         ],
         "type": "intersection"
       },
@@ -28566,13 +28566,13 @@
         "control": "Signed",
         "id": 359,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          9153364282
+        ],
+        "turns": [
           "Road #478 -> Road #495",
           "Road #494 -> Road #495",
           "Road #494 -> Road #478"
-        ],
-        "osm_node_ids": [
-          9153364282
         ],
         "type": "intersection"
       },
@@ -28626,12 +28626,12 @@
         "control": "Signed",
         "id": 360,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #478 -> Road #479",
-          "Road #479 -> Road #478"
-        ],
         "osm_node_ids": [
           4829750339
+        ],
+        "turns": [
+          "Road #478 -> Road #479",
+          "Road #479 -> Road #478"
         ],
         "type": "intersection"
       },
@@ -28685,12 +28685,12 @@
         "control": "Signed",
         "id": 361,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #480 -> Road #481",
-          "Road #481 -> Road #480"
-        ],
         "osm_node_ids": [
           4829750338
+        ],
+        "turns": [
+          "Road #480 -> Road #481",
+          "Road #481 -> Road #480"
         ],
         "type": "intersection"
       },
@@ -28748,12 +28748,12 @@
         "control": "Signed",
         "id": 362,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #481 -> Road #482",
-          "Road #482 -> Road #481"
-        ],
         "osm_node_ids": [
           5452243878
+        ],
+        "turns": [
+          "Road #481 -> Road #482",
+          "Road #482 -> Road #481"
         ],
         "type": "intersection"
       },
@@ -28791,8 +28791,8 @@
         "control": "Uncontrolled",
         "id": 363,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28845,13 +28845,13 @@
         "control": "Signed",
         "id": 364,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #484 -> Road #483",
-          "Road #483 -> Road #484"
-        ],
         "osm_node_ids": [
           4829706952,
           4829706958
+        ],
+        "turns": [
+          "Road #484 -> Road #483",
+          "Road #483 -> Road #484"
         ],
         "type": "intersection"
       },
@@ -28889,8 +28889,8 @@
         "control": "Uncontrolled",
         "id": 365,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -28935,16 +28935,16 @@
         "control": "Signed",
         "id": 366,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9729815848
+        ],
+        "turns": [
           "Road #39 -> Road #40",
           "Road #39 -> Road #485",
           "Road #40 -> Road #39",
           "Road #40 -> Road #485",
           "Road #485 -> Road #39",
           "Road #485 -> Road #40"
-        ],
-        "osm_node_ids": [
-          9729815848
         ],
         "type": "intersection"
       },
@@ -28998,12 +28998,12 @@
         "control": "Signed",
         "id": 367,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #485 -> Road #486",
-          "Road #486 -> Road #485"
-        ],
         "osm_node_ids": [
           9729815863
+        ],
+        "turns": [
+          "Road #485 -> Road #486",
+          "Road #486 -> Road #485"
         ],
         "type": "intersection"
       },
@@ -29041,10 +29041,10 @@
         "control": "Signed",
         "id": 368,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           9729815850
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29081,8 +29081,8 @@
         "control": "Uncontrolled",
         "id": 369,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29135,13 +29135,13 @@
         "control": "Signed",
         "id": 370,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #488 -> Road #487",
-          "Road #487 -> Road #488"
-        ],
         "osm_node_ids": [
           4831220180,
           4831220179
+        ],
+        "turns": [
+          "Road #488 -> Road #487",
+          "Road #487 -> Road #488"
         ],
         "type": "intersection"
       },
@@ -29191,12 +29191,12 @@
         "control": "Signed",
         "id": 371,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #489 -> Road #488",
-          "Road #488 -> Road #489"
-        ],
         "osm_node_ids": [
           4831220181
+        ],
+        "turns": [
+          "Road #489 -> Road #488",
+          "Road #488 -> Road #489"
         ],
         "type": "intersection"
       },
@@ -29234,8 +29234,8 @@
         "control": "Uncontrolled",
         "id": 372,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29272,8 +29272,8 @@
         "control": "Uncontrolled",
         "id": 373,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29326,13 +29326,13 @@
         "control": "Signed",
         "id": 374,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #491 -> Road #490",
-          "Road #490 -> Road #491"
-        ],
         "osm_node_ids": [
           4694379066,
           5154402037
+        ],
+        "turns": [
+          "Road #491 -> Road #490",
+          "Road #490 -> Road #491"
         ],
         "type": "intersection"
       },
@@ -29370,8 +29370,8 @@
         "control": "Uncontrolled",
         "id": 375,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29408,8 +29408,8 @@
         "control": "Uncontrolled",
         "id": 377,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29446,8 +29446,8 @@
         "control": "Uncontrolled",
         "id": 378,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29484,8 +29484,8 @@
         "control": "Uncontrolled",
         "id": 380,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -29522,8 +29522,8 @@
         "control": "Uncontrolled",
         "id": 381,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/seattle_slip_lane/geometry.json
+++ b/tests/src/seattle_slip_lane/geometry.json
@@ -3192,8 +3192,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3234,16 +3234,16 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          59713144
+        ],
+        "turns": [
           "Road #7 -> Road #1",
           "Road #7 -> Road #15",
           "Road #1 -> Road #7",
           "Road #1 -> Road #15",
           "Road #15 -> Road #7",
           "Road #15 -> Road #1"
-        ],
-        "osm_node_ids": [
-          59713144
         ],
         "type": "intersection"
       },
@@ -3281,8 +3281,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3327,16 +3327,16 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          59713145
+        ],
+        "turns": [
           "Road #65 -> Road #6",
           "Road #65 -> Road #4",
           "Road #6 -> Road #65",
           "Road #6 -> Road #4",
           "Road #4 -> Road #65",
           "Road #4 -> Road #6"
-        ],
-        "osm_node_ids": [
-          59713145
         ],
         "type": "intersection"
       },
@@ -3374,8 +3374,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3412,11 +3412,11 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #14 -> Road #11"
-        ],
         "osm_node_ids": [
           4272380198
+        ],
+        "turns": [
+          "Road #14 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -3462,12 +3462,12 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #11 -> Road #12",
-          "Road #11 -> Road #31"
-        ],
         "osm_node_ids": [
           59711142
+        ],
+        "turns": [
+          "Road #11 -> Road #12",
+          "Road #11 -> Road #31"
         ],
         "type": "intersection"
       },
@@ -3505,8 +3505,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3543,10 +3543,10 @@
         "control": "Signalled",
         "id": 13,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           53079359
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3583,8 +3583,8 @@
         "control": "Uncontrolled",
         "id": 15,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3629,10 +3629,10 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379309
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3669,10 +3669,10 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379308
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3721,11 +3721,11 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #17 -> Road #18"
-        ],
         "osm_node_ids": [
           4583297954
+        ],
+        "turns": [
+          "Road #17 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -3771,10 +3771,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4694379311
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3831,14 +3831,14 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          4694379084
+        ],
+        "turns": [
           "Road #66 -> Road #81",
           "Road #33 -> Road #66",
           "Road #33 -> Road #81",
           "Road #81 -> Road #66"
-        ],
-        "osm_node_ids": [
-          4694379084
         ],
         "type": "intersection"
       },
@@ -3884,10 +3884,10 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724323
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3932,10 +3932,10 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724324
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3976,10 +3976,10 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724340
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4016,10 +4016,10 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829724338
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4076,12 +4076,12 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #4 -> Road #3",
-          "Road #3 -> Road #4"
-        ],
         "osm_node_ids": [
           4829724321
+        ],
+        "turns": [
+          "Road #4 -> Road #3",
+          "Road #3 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -4119,8 +4119,8 @@
         "control": "Uncontrolled",
         "id": 32,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4169,11 +4169,11 @@
         "control": "Signalled",
         "id": 34,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #32 -> Road #33"
-        ],
         "osm_node_ids": [
           4829741814
+        ],
+        "turns": [
+          "Road #32 -> Road #33"
         ],
         "type": "intersection"
       },
@@ -4227,12 +4227,12 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #0 -> Road #1",
-          "Road #1 -> Road #0"
-        ],
         "osm_node_ids": [
           4829741816
+        ],
+        "turns": [
+          "Road #0 -> Road #1",
+          "Road #1 -> Road #0"
         ],
         "type": "intersection"
       },
@@ -4270,10 +4270,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745939
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4310,8 +4310,8 @@
         "control": "Uncontrolled",
         "id": 38,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4352,10 +4352,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829745937
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4392,8 +4392,8 @@
         "control": "Uncontrolled",
         "id": 41,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4438,10 +4438,10 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750349
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4490,11 +4490,11 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750362,
           4694379300
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4539,10 +4539,10 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750361
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4579,10 +4579,10 @@
         "control": "Signed",
         "id": 47,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4829750357
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4619,8 +4619,8 @@
         "control": "Uncontrolled",
         "id": 48,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4657,12 +4657,12 @@
         "control": "Signed",
         "id": 51,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #68 -> Road #66",
-          "Road #66 -> Road #68"
-        ],
         "osm_node_ids": [
           4531063551
+        ],
+        "turns": [
+          "Road #68 -> Road #66",
+          "Road #66 -> Road #68"
         ],
         "type": "intersection"
       },
@@ -4700,8 +4700,8 @@
         "control": "Uncontrolled",
         "id": 52,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4738,8 +4738,8 @@
         "control": "Uncontrolled",
         "id": 53,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4784,11 +4784,11 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #31 -> Road #32"
-        ],
         "osm_node_ids": [
           5674754355
+        ],
+        "turns": [
+          "Road #31 -> Road #32"
         ],
         "type": "intersection"
       },
@@ -4842,10 +4842,10 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5452209413
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4882,8 +4882,8 @@
         "control": "Uncontrolled",
         "id": 57,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4920,10 +4920,10 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           6886226579
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5184,7 +5184,14 @@
         "control": "Signalled",
         "id": 62,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5674754357,
+          4829741818,
+          53079358,
+          5674754356,
+          4829724322
+        ],
+        "turns": [
           "Road #12 -> Road #65",
           "Road #12 -> Road #17",
           "Road #12 -> Road #81",
@@ -5192,13 +5199,6 @@
           "Road #65 -> Road #81",
           "Road #81 -> Road #65",
           "Road #81 -> Road #17"
-        ],
-        "osm_node_ids": [
-          5674754357,
-          4829741818,
-          53079358,
-          5674754356,
-          4829724322
         ],
         "type": "intersection"
       },
@@ -5240,16 +5240,16 @@
         "control": "Signed",
         "id": 67,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8318893544
+        ],
+        "turns": [
           "Road #67 -> Road #68",
           "Road #67 -> Road #86",
           "Road #68 -> Road #67",
           "Road #68 -> Road #86",
           "Road #86 -> Road #67",
           "Road #86 -> Road #68"
-        ],
-        "osm_node_ids": [
-          8318893544
         ],
         "type": "intersection"
       },
@@ -5299,12 +5299,12 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #86 -> Road #87",
-          "Road #87 -> Road #86"
-        ],
         "osm_node_ids": [
           8428577669
+        ],
+        "turns": [
+          "Road #86 -> Road #87",
+          "Road #87 -> Road #86"
         ],
         "type": "intersection"
       },
@@ -5354,7 +5354,10 @@
         "control": "Signed",
         "id": 69,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8318893546
+        ],
+        "turns": [
           "Road #87 -> Road #98",
           "Road #87 -> Road #90",
           "Road #87 -> Road #89",
@@ -5367,9 +5370,6 @@
           "Road #89 -> Road #87",
           "Road #89 -> Road #98",
           "Road #89 -> Road #90"
-        ],
-        "osm_node_ids": [
-          8318893546
         ],
         "type": "intersection"
       },
@@ -5419,7 +5419,10 @@
         "control": "Signed",
         "id": 74,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          8318893551
+        ],
+        "turns": [
           "Road #90 -> Road #98",
           "Road #90 -> Road #95",
           "Road #90 -> Road #89",
@@ -5432,9 +5435,6 @@
           "Road #89 -> Road #90",
           "Road #89 -> Road #98",
           "Road #89 -> Road #95"
-        ],
-        "osm_node_ids": [
-          8318893551
         ],
         "type": "intersection"
       },
@@ -5488,12 +5488,12 @@
         "control": "Signed",
         "id": 77,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #95 -> Road #96",
-          "Road #96 -> Road #95"
-        ],
         "osm_node_ids": [
           8428577668
+        ],
+        "turns": [
+          "Road #95 -> Road #96",
+          "Road #96 -> Road #95"
         ],
         "type": "intersection"
       },
@@ -5547,12 +5547,12 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #96 -> Road #97",
-          "Road #97 -> Road #96"
-        ],
         "osm_node_ids": [
           8428577667
+        ],
+        "turns": [
+          "Road #96 -> Road #97",
+          "Road #97 -> Road #96"
         ],
         "type": "intersection"
       },
@@ -5598,13 +5598,13 @@
         "control": "Signed",
         "id": 79,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          4583297951
+        ],
+        "turns": [
           "Road #97 -> Road #10",
           "Road #18 -> Road #97",
           "Road #18 -> Road #10"
-        ],
-        "osm_node_ids": [
-          4583297951
         ],
         "type": "intersection"
       },
@@ -5650,16 +5650,16 @@
         "control": "Signed",
         "id": 80,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9729815848
+        ],
+        "turns": [
           "Road #6 -> Road #7",
           "Road #6 -> Road #100",
           "Road #7 -> Road #6",
           "Road #7 -> Road #100",
           "Road #100 -> Road #6",
           "Road #100 -> Road #7"
-        ],
-        "osm_node_ids": [
-          9729815848
         ],
         "type": "intersection"
       },
@@ -5713,12 +5713,12 @@
         "control": "Signed",
         "id": 81,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #100 -> Road #101",
-          "Road #101 -> Road #100"
-        ],
         "osm_node_ids": [
           9729815863
+        ],
+        "turns": [
+          "Road #100 -> Road #101",
+          "Road #101 -> Road #100"
         ],
         "type": "intersection"
       },
@@ -5764,16 +5764,16 @@
         "control": "Signed",
         "id": 83,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9729815851
+        ],
+        "turns": [
           "Road #15 -> Road #16",
           "Road #15 -> Road #105",
           "Road #16 -> Road #15",
           "Road #16 -> Road #105",
           "Road #105 -> Road #15",
           "Road #105 -> Road #16"
-        ],
-        "osm_node_ids": [
-          9729815851
         ],
         "type": "intersection"
       },
@@ -5827,12 +5827,12 @@
         "control": "Signed",
         "id": 84,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #105 -> Road #106",
-          "Road #106 -> Road #105"
-        ],
         "osm_node_ids": [
           9729815864
+        ],
+        "turns": [
+          "Road #105 -> Road #106",
+          "Road #106 -> Road #105"
         ],
         "type": "intersection"
       },
@@ -5882,7 +5882,10 @@
         "control": "Signed",
         "id": 85,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9729815852
+        ],
+        "turns": [
           "Road #102 -> Road #106",
           "Road #102 -> Road #76",
           "Road #102 -> Road #107",
@@ -5895,9 +5898,6 @@
           "Road #107 -> Road #102",
           "Road #107 -> Road #106",
           "Road #107 -> Road #76"
-        ],
-        "osm_node_ids": [
-          9729815852
         ],
         "type": "intersection"
       },
@@ -5943,16 +5943,16 @@
         "control": "Signed",
         "id": 91,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9729815854
+        ],
+        "turns": [
           "Road #101 -> Road #102",
           "Road #101 -> Road #110",
           "Road #102 -> Road #101",
           "Road #102 -> Road #110",
           "Road #110 -> Road #101",
           "Road #110 -> Road #102"
-        ],
-        "osm_node_ids": [
-          9729815854
         ],
         "type": "intersection"
       },
@@ -5994,16 +5994,16 @@
         "control": "Signed",
         "id": 92,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6886226578
+        ],
+        "turns": [
           "Road #110 -> Road #77",
           "Road #110 -> Road #78",
           "Road #77 -> Road #110",
           "Road #77 -> Road #78",
           "Road #78 -> Road #110",
           "Road #78 -> Road #77"
-        ],
-        "osm_node_ids": [
-          6886226578
         ],
         "type": "intersection"
       },
@@ -6045,16 +6045,16 @@
         "control": "Signed",
         "id": 96,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          9729815853
+        ],
+        "turns": [
           "Road #77 -> Road #107",
           "Road #77 -> Road #76",
           "Road #107 -> Road #77",
           "Road #107 -> Road #76",
           "Road #76 -> Road #77",
           "Road #76 -> Road #107"
-        ],
-        "osm_node_ids": [
-          9729815853
         ],
         "type": "intersection"
       },

--- a/tests/src/seattle_triangle/geometry.json
+++ b/tests/src/seattle_triangle/geometry.json
@@ -2852,8 +2852,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2902,7 +2902,10 @@
         "control": "Signalled",
         "id": 1,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1884382824
+        ],
+        "turns": [
           "Road #3 -> Road #1",
           "Road #3 -> Road #70",
           "Road #2 -> Road #3",
@@ -2911,9 +2914,6 @@
           "Road #1 -> Road #3",
           "Road #1 -> Road #2",
           "Road #1 -> Road #70"
-        ],
-        "osm_node_ids": [
-          1884382824
         ],
         "type": "intersection"
       },
@@ -2963,7 +2963,10 @@
         "control": "Signalled",
         "id": 2,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          775936191
+        ],
+        "turns": [
           "Road #15 -> Road #8",
           "Road #15 -> Road #2",
           "Road #12 -> Road #8",
@@ -2971,9 +2974,6 @@
           "Road #12 -> Road #2",
           "Road #2 -> Road #8",
           "Road #2 -> Road #15"
-        ],
-        "osm_node_ids": [
-          775936191
         ],
         "type": "intersection"
       },
@@ -3027,7 +3027,10 @@
         "control": "Signalled",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1884382823
+        ],
+        "turns": [
           "Road #72 -> Road #5",
           "Road #72 -> Road #4",
           "Road #5 -> Road #72",
@@ -3037,9 +3040,6 @@
           "Road #9 -> Road #4",
           "Road #4 -> Road #72",
           "Road #4 -> Road #5"
-        ],
-        "osm_node_ids": [
-          1884382823
         ],
         "type": "intersection"
       },
@@ -3077,8 +3077,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3123,12 +3123,12 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #10 -> Road #73",
-          "Road #73 -> Road #10"
-        ],
         "osm_node_ids": [
           8780140700
+        ],
+        "turns": [
+          "Road #10 -> Road #73",
+          "Road #73 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -3166,8 +3166,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3204,8 +3204,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3242,8 +3242,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3280,8 +3280,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3318,8 +3318,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3356,8 +3356,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3398,10 +3398,10 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021900
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3438,8 +3438,8 @@
         "control": "Uncontrolled",
         "id": 14,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3484,10 +3484,10 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021896
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3524,8 +3524,8 @@
         "control": "Uncontrolled",
         "id": 16,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3562,8 +3562,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3600,8 +3600,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3638,8 +3638,8 @@
         "control": "Uncontrolled",
         "id": 19,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3692,10 +3692,10 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021891
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3732,10 +3732,10 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021889
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3780,10 +3780,10 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021890
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3820,10 +3820,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021892
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3876,12 +3876,12 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #7 -> Road #6",
-          "Road #6 -> Road #7"
-        ],
         "osm_node_ids": [
           5772021885
+        ],
+        "turns": [
+          "Road #7 -> Road #6",
+          "Road #6 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -3919,10 +3919,10 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021893
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4183,10 +4183,10 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021895
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4239,12 +4239,12 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #13 -> Road #14",
-          "Road #14 -> Road #13"
-        ],
         "osm_node_ids": [
           5772021884
+        ],
+        "turns": [
+          "Road #13 -> Road #14",
+          "Road #14 -> Road #13"
         ],
         "type": "intersection"
       },
@@ -4506,10 +4506,10 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021897
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4550,10 +4550,10 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021898
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4814,10 +4814,10 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021899
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4870,11 +4870,11 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #11 -> Road #12"
-        ],
         "osm_node_ids": [
           5772021883
+        ],
+        "turns": [
+          "Road #11 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -4912,10 +4912,10 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021901
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4956,10 +4956,10 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021878
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5000,10 +5000,10 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021902
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5044,10 +5044,10 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021903
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5088,10 +5088,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021905
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5128,10 +5128,10 @@
         "control": "Signed",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021906
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5180,12 +5180,12 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #1 -> Road #0",
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           5772021888
+        ],
+        "turns": [
+          "Road #1 -> Road #0",
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -5227,10 +5227,10 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5768923253
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5267,10 +5267,10 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772394401
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5307,10 +5307,10 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772394403
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5363,11 +5363,11 @@
         "control": "Signed",
         "id": 45,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #8 -> Road #9"
-        ],
         "osm_node_ids": [
           7083431694
+        ],
+        "turns": [
+          "Road #8 -> Road #9"
         ],
         "type": "intersection"
       },
@@ -5421,13 +5421,13 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #4 -> Road #3",
-          "Road #3 -> Road #4"
-        ],
         "osm_node_ids": [
           7083431692,
           7083431690
+        ],
+        "turns": [
+          "Road #4 -> Road #3",
+          "Road #3 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -5473,10 +5473,10 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7083431696
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5521,10 +5521,10 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5772021874
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5569,10 +5569,10 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7083431697
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5609,8 +5609,8 @@
         "control": "Uncontrolled",
         "id": 51,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5663,10 +5663,10 @@
         "control": "Signed",
         "id": 52,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8780140710
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5719,12 +5719,12 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #14 -> Road #15",
-          "Road #15 -> Road #14"
-        ],
         "osm_node_ids": [
           8780140709
+        ],
+        "turns": [
+          "Road #14 -> Road #15",
+          "Road #15 -> Road #14"
         ],
         "type": "intersection"
       },
@@ -5782,10 +5782,10 @@
         "control": "Signed",
         "id": 54,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8780140707
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5838,12 +5838,12 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #6 -> Road #5",
-          "Road #5 -> Road #6"
-        ],
         "osm_node_ids": [
           8780140703
+        ],
+        "turns": [
+          "Road #6 -> Road #5",
+          "Road #5 -> Road #6"
         ],
         "type": "intersection"
       },
@@ -5897,10 +5897,10 @@
         "control": "Signed",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8780140701
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5949,12 +5949,12 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #70 -> Road #71"
-        ],
         "osm_node_ids": [
           5772021887,
           5772021904
+        ],
+        "turns": [
+          "Road #70 -> Road #71"
         ],
         "type": "intersection"
       },
@@ -5992,8 +5992,8 @@
         "control": "Uncontrolled",
         "id": 58,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6042,12 +6042,12 @@
         "control": "Signed",
         "id": 59,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #73 -> Road #72",
-          "Road #72 -> Road #73"
-        ],
         "osm_node_ids": [
           5772021886
+        ],
+        "turns": [
+          "Road #73 -> Road #72",
+          "Road #72 -> Road #73"
         ],
         "type": "intersection"
       },
@@ -6085,8 +6085,8 @@
         "control": "Uncontrolled",
         "id": 60,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6123,8 +6123,8 @@
         "control": "Uncontrolled",
         "id": 61,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/service_road_loop/geometry.json
+++ b/tests/src/service_road_loop/geometry.json
@@ -957,8 +957,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -995,8 +995,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1033,8 +1033,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1075,12 +1075,12 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #5",
-          "Road #5 -> Road #4"
-        ],
         "osm_node_ids": [
           3710247245
+        ],
+        "turns": [
+          "Road #4 -> Road #5",
+          "Road #5 -> Road #4"
         ],
         "type": "intersection"
       },
@@ -1122,12 +1122,12 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #2 -> Road #3",
-          "Road #3 -> Road #2"
-        ],
         "osm_node_ids": [
           30984582
+        ],
+        "turns": [
+          "Road #2 -> Road #3",
+          "Road #3 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -1165,8 +1165,8 @@
         "control": "Uncontrolled",
         "id": 5,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1203,8 +1203,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1245,16 +1245,16 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5908769456
+        ],
+        "turns": [
           "Road #3 -> Road #10",
           "Road #3 -> Road #4",
           "Road #10 -> Road #3",
           "Road #10 -> Road #4",
           "Road #4 -> Road #3",
           "Road #4 -> Road #10"
-        ],
-        "osm_node_ids": [
-          5908769456
         ],
         "type": "intersection"
       },
@@ -1300,14 +1300,14 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6036958646
+        ],
+        "turns": [
           "Road #0 -> Road #11",
           "Road #0 -> Road #1",
           "Road #1 -> Road #0",
           "Road #1 -> Road #11"
-        ],
-        "osm_node_ids": [
-          6036958646
         ],
         "type": "intersection"
       },
@@ -1353,14 +1353,14 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6036958563
+        ],
+        "turns": [
           "Road #1 -> Road #2",
           "Road #12 -> Road #1",
           "Road #12 -> Road #2",
           "Road #2 -> Road #1"
-        ],
-        "osm_node_ids": [
-          6036958563
         ],
         "type": "intersection"
       },
@@ -1402,14 +1402,14 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6036958615
+        ],
+        "turns": [
           "Road #20 -> Road #21",
           "Road #20 -> Road #13",
           "Road #21 -> Road #13",
           "Road #13 -> Road #21"
-        ],
-        "osm_node_ids": [
-          6036958615
         ],
         "type": "intersection"
       },
@@ -1451,14 +1451,14 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6036958634
+        ],
+        "turns": [
           "Road #13 -> Road #14",
           "Road #13 -> Road #22",
           "Road #22 -> Road #14",
           "Road #22 -> Road #13"
-        ],
-        "osm_node_ids": [
-          6036958634
         ],
         "type": "intersection"
       },
@@ -1508,11 +1508,11 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #14 -> Road #12"
-        ],
         "osm_node_ids": [
           6036958569
+        ],
+        "turns": [
+          "Road #14 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -1558,12 +1558,12 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #11 -> Road #16",
-          "Road #11 -> Road #18"
-        ],
         "osm_node_ids": [
           6036958633
+        ],
+        "turns": [
+          "Road #11 -> Road #16",
+          "Road #11 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -1605,12 +1605,12 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #18 -> Road #19",
-          "Road #16 -> Road #19"
-        ],
         "osm_node_ids": [
           6036958616
+        ],
+        "turns": [
+          "Road #18 -> Road #19",
+          "Road #16 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -1660,11 +1660,11 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #19 -> Road #20"
-        ],
         "osm_node_ids": [
           6036958639
+        ],
+        "turns": [
+          "Road #19 -> Road #20"
         ],
         "type": "intersection"
       },
@@ -1702,8 +1702,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -1740,8 +1740,8 @@
         "control": "Uncontrolled",
         "id": 19,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/st_georges_cycletrack/geometry.json
+++ b/tests/src/st_georges_cycletrack/geometry.json
@@ -7225,13 +7225,13 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #179 -> Road #43",
-          "Road #179 -> Road #82"
-        ],
         "osm_node_ids": [
           3799274013,
           25472584
+        ],
+        "turns": [
+          "Road #179 -> Road #43",
+          "Road #179 -> Road #82"
         ],
         "type": "intersection"
       },
@@ -7269,8 +7269,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7323,13 +7323,13 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          25472725
+        ],
+        "turns": [
           "Road #184 -> Road #190",
           "Road #184 -> Road #2",
           "Road #2 -> Road #190"
-        ],
-        "osm_node_ids": [
-          25472725
         ],
         "type": "intersection"
       },
@@ -7367,8 +7367,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7425,13 +7425,13 @@
         "control": "Signalled",
         "id": 5,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          287248398
+        ],
+        "turns": [
           "Road #188 -> Road #185",
           "Road #188 -> Road #4",
           "Road #4 -> Road #185"
-        ],
-        "osm_node_ids": [
-          287248398
         ],
         "type": "intersection"
       },
@@ -7469,8 +7469,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7527,13 +7527,13 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          25472956
+        ],
+        "turns": [
           "Road #40 -> Road #41",
           "Road #40 -> Road #6",
           "Road #6 -> Road #41"
-        ],
-        "osm_node_ids": [
-          25472956
         ],
         "type": "intersection"
       },
@@ -7575,13 +7575,13 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          25472957
+        ],
+        "turns": [
           "Road #7 -> Road #187",
           "Road #41 -> Road #187",
           "Road #41 -> Road #7"
-        ],
-        "osm_node_ids": [
-          25472957
         ],
         "type": "intersection"
       },
@@ -7639,12 +7639,12 @@
         "control": "Signed",
         "id": 9,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #102 -> Road #7",
-          "Road #7 -> Road #102"
-        ],
         "osm_node_ids": [
           2464418698
+        ],
+        "turns": [
+          "Road #102 -> Road #7",
+          "Road #7 -> Road #102"
         ],
         "type": "intersection"
       },
@@ -7682,8 +7682,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7720,8 +7720,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7766,10 +7766,10 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4169653680
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7810,10 +7810,10 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           61334104
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7858,13 +7858,13 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          96619952
+        ],
+        "turns": [
           "Road #15 -> Road #184",
           "Road #185 -> Road #184",
           "Road #185 -> Road #15"
-        ],
-        "osm_node_ids": [
-          96619952
         ],
         "type": "intersection"
       },
@@ -7902,10 +7902,10 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           730857210
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7942,8 +7942,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8008,13 +8008,13 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #43 -> Road #44",
-          "Road #43 -> Road #21"
-        ],
         "osm_node_ids": [
           264341506,
           3799274011
+        ],
+        "turns": [
+          "Road #43 -> Road #44",
+          "Road #43 -> Road #21"
         ],
         "type": "intersection"
       },
@@ -8052,8 +8052,8 @@
         "control": "Uncontrolled",
         "id": 21,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8098,11 +8098,11 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #82 -> Road #83"
-        ],
         "osm_node_ids": [
           264790813
+        ],
+        "turns": [
+          "Road #82 -> Road #83"
         ],
         "type": "intersection"
       },
@@ -8144,10 +8144,10 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3374579450
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8188,13 +8188,13 @@
         "control": "Signed",
         "id": 24,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          265241531
+        ],
+        "turns": [
           "Road #23 -> Road #60",
           "Road #190 -> Road #60",
           "Road #190 -> Road #23"
-        ],
-        "osm_node_ids": [
-          265241531
         ],
         "type": "intersection"
       },
@@ -8232,10 +8232,10 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           265241535
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8284,14 +8284,14 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2180693488
+        ],
+        "turns": [
           "Road #67 -> Road #70",
           "Road #67 -> Road #25",
           "Road #151 -> Road #70",
           "Road #151 -> Road #25"
-        ],
-        "osm_node_ids": [
-          2180693488
         ],
         "type": "intersection"
       },
@@ -8333,11 +8333,11 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #25 -> Road #163"
-        ],
         "osm_node_ids": [
           2180693485
+        ],
+        "turns": [
+          "Road #25 -> Road #163"
         ],
         "type": "intersection"
       },
@@ -8375,8 +8375,8 @@
         "control": "Uncontrolled",
         "id": 28,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8429,11 +8429,11 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #27 -> Road #151"
-        ],
         "osm_node_ids": [
           3890206831
+        ],
+        "turns": [
+          "Road #27 -> Road #151"
         ],
         "type": "intersection"
       },
@@ -8475,16 +8475,16 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          1186174556
+        ],
+        "turns": [
           "Road #4 -> Road #30",
           "Road #4 -> Road #3",
           "Road #30 -> Road #4",
           "Road #30 -> Road #3",
           "Road #3 -> Road #4",
           "Road #3 -> Road #30"
-        ],
-        "osm_node_ids": [
-          1186174556
         ],
         "type": "intersection"
       },
@@ -8522,8 +8522,8 @@
         "control": "Uncontrolled",
         "id": 35,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8560,10 +8560,10 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350081
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8608,10 +8608,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350194
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8652,12 +8652,12 @@
         "control": "Signalled",
         "id": 38,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #126 -> Road #127",
-          "Road #127 -> Road #36"
-        ],
         "osm_node_ids": [
           2059768444
+        ],
+        "turns": [
+          "Road #126 -> Road #127",
+          "Road #127 -> Road #36"
         ],
         "type": "intersection"
       },
@@ -8699,11 +8699,11 @@
         "control": "Signalled",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #36 -> Road #38"
-        ],
         "osm_node_ids": [
           6022813718
+        ],
+        "turns": [
+          "Road #36 -> Road #38"
         ],
         "type": "intersection"
       },
@@ -8785,7 +8785,10 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          364274
+        ],
+        "turns": [
           "Road #58 -> Road #37",
           "Road #58 -> Road #109",
           "Road #131 -> Road #37",
@@ -8794,9 +8797,6 @@
           "Road #128 -> Road #37",
           "Road #128 -> Road #58",
           "Road #128 -> Road #109"
-        ],
-        "osm_node_ids": [
-          364274
         ],
         "type": "intersection"
       },
@@ -8850,11 +8850,11 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #37 -> Road #129"
-        ],
         "osm_node_ids": [
           3328901241
+        ],
+        "turns": [
+          "Road #37 -> Road #129"
         ],
         "type": "intersection"
       },
@@ -8908,11 +8908,11 @@
         "control": "Signalled",
         "id": 42,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #38 -> Road #128"
-        ],
         "osm_node_ids": [
           2932500935
+        ],
+        "turns": [
+          "Road #38 -> Road #128"
         ],
         "type": "intersection"
       },
@@ -8950,11 +8950,11 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #46 -> Road #39"
-        ],
         "osm_node_ids": [
           2059768440
+        ],
+        "turns": [
+          "Road #46 -> Road #39"
         ],
         "type": "intersection"
       },
@@ -9000,11 +9000,11 @@
         "control": "Signalled",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #39 -> Road #130"
-        ],
         "osm_node_ids": [
           6022813720
+        ],
+        "turns": [
+          "Road #39 -> Road #130"
         ],
         "type": "intersection"
       },
@@ -9042,11 +9042,11 @@
         "control": "Signed",
         "id": 46,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #163 -> Road #42"
-        ],
         "osm_node_ids": [
           29158929
+        ],
+        "turns": [
+          "Road #163 -> Road #42"
         ],
         "type": "intersection"
       },
@@ -9084,10 +9084,10 @@
         "control": "Signalled",
         "id": 47,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           3881302130
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9136,11 +9136,11 @@
         "control": "Signalled",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #45 -> Road #46"
-        ],
         "osm_node_ids": [
           61334099
+        ],
+        "turns": [
+          "Road #45 -> Road #46"
         ],
         "type": "intersection"
       },
@@ -9178,10 +9178,10 @@
         "control": "Signed",
         "id": 49,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           2467649381
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9226,12 +9226,12 @@
         "control": "Signed",
         "id": 50,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #62 -> Road #181",
-          "Road #48 -> Road #181"
-        ],
         "osm_node_ids": [
           2467649384
+        ],
+        "turns": [
+          "Road #62 -> Road #181",
+          "Road #48 -> Road #181"
         ],
         "type": "intersection"
       },
@@ -9269,8 +9269,8 @@
         "control": "Uncontrolled",
         "id": 51,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9311,12 +9311,12 @@
         "control": "Signed",
         "id": 52,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #127 -> Road #50",
-          "Road #50 -> Road #127"
-        ],
         "osm_node_ids": [
           6022813716
+        ],
+        "turns": [
+          "Road #127 -> Road #50",
+          "Road #50 -> Road #127"
         ],
         "type": "intersection"
       },
@@ -9358,12 +9358,12 @@
         "control": "Signed",
         "id": 53,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #121 -> Road #51",
-          "Road #51 -> Road #121"
-        ],
         "osm_node_ids": [
           2932500919
+        ],
+        "turns": [
+          "Road #121 -> Road #51",
+          "Road #51 -> Road #121"
         ],
         "type": "intersection"
       },
@@ -9409,10 +9409,10 @@
         "control": "Signed",
         "id": 55,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2932500926
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9469,14 +9469,14 @@
         "control": "Signalled",
         "id": 56,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #51 -> Road #58",
-          "Road #58 -> Road #51"
-        ],
         "osm_node_ids": [
           6022813731,
           2932500927,
           6022813729
+        ],
+        "turns": [
+          "Road #51 -> Road #58",
+          "Road #58 -> Road #51"
         ],
         "type": "intersection"
       },
@@ -9534,13 +9534,13 @@
         "control": "Signalled",
         "id": 58,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #130 -> Road #131"
-        ],
         "osm_node_ids": [
           6022813715,
           8936997804,
           8936997805
+        ],
+        "turns": [
+          "Road #130 -> Road #131"
         ],
         "type": "intersection"
       },
@@ -9598,12 +9598,12 @@
         "control": "Signed",
         "id": 60,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #109 -> Road #126"
-        ],
         "osm_node_ids": [
           6022813725,
           6022823875
+        ],
+        "turns": [
+          "Road #109 -> Road #126"
         ],
         "type": "intersection"
       },
@@ -9641,8 +9641,8 @@
         "control": "Uncontrolled",
         "id": 61,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9687,16 +9687,16 @@
         "control": "Signed",
         "id": 62,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3314367623
+        ],
+        "turns": [
           "Road #57 -> Road #50",
           "Road #57 -> Road #49",
           "Road #50 -> Road #57",
           "Road #50 -> Road #49",
           "Road #49 -> Road #57",
           "Road #49 -> Road #50"
-        ],
-        "osm_node_ids": [
-          3314367623
         ],
         "type": "intersection"
       },
@@ -9734,10 +9734,10 @@
         "control": "Signed",
         "id": 63,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2932500936
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9774,10 +9774,10 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6022813723
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9822,10 +9822,10 @@
         "control": "Signed",
         "id": 66,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4156272581
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9866,10 +9866,10 @@
         "control": "Signed",
         "id": 67,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3799274019
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9906,10 +9906,10 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5425497684
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -9946,12 +9946,12 @@
         "control": "Signed",
         "id": 69,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #66 -> Road #121",
-          "Road #121 -> Road #66"
-        ],
         "osm_node_ids": [
           6022819613
+        ],
+        "turns": [
+          "Road #66 -> Road #121",
+          "Road #121 -> Road #66"
         ],
         "type": "intersection"
       },
@@ -9997,12 +9997,12 @@
         "control": "Signed",
         "id": 70,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #69 -> Road #68",
-          "Road #69 -> Road #67"
-        ],
         "osm_node_ids": [
           3874597627
+        ],
+        "turns": [
+          "Road #69 -> Road #68",
+          "Road #69 -> Road #67"
         ],
         "type": "intersection"
       },
@@ -10040,10 +10040,10 @@
         "control": "Signalled",
         "id": 71,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           8952790002
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10080,10 +10080,10 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           3874597641
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10144,13 +10144,13 @@
         "control": "Signalled",
         "id": 73,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #70 -> Road #150"
-        ],
         "osm_node_ids": [
           3890206825,
           4169653676,
           4169653677
+        ],
+        "turns": [
+          "Road #70 -> Road #150"
         ],
         "type": "intersection"
       },
@@ -10196,11 +10196,11 @@
         "control": "Signalled",
         "id": 74,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3890206820,
           6502835827
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10249,10 +10249,10 @@
         "control": "Signed",
         "id": 75,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350153
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10289,10 +10289,10 @@
         "control": "Signed",
         "id": 76,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350182
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10329,8 +10329,8 @@
         "control": "Uncontrolled",
         "id": 77,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10383,12 +10383,12 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #16 -> Road #15",
-          "Road #15 -> Road #16"
-        ],
         "osm_node_ids": [
           3799274007
+        ],
+        "turns": [
+          "Road #16 -> Road #15",
+          "Road #15 -> Road #16"
         ],
         "type": "intersection"
       },
@@ -10446,12 +10446,12 @@
         "control": "Signed",
         "id": 79,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #24 -> Road #23",
-          "Road #23 -> Road #24"
-        ],
         "osm_node_ids": [
           3799274008
+        ],
+        "turns": [
+          "Road #24 -> Road #23",
+          "Road #23 -> Road #24"
         ],
         "type": "intersection"
       },
@@ -10513,13 +10513,13 @@
         "control": "Signalled",
         "id": 80,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #8 -> Road #62",
-          "Road #61 -> Road #62"
-        ],
         "osm_node_ids": [
           3799274009,
           4156273389
+        ],
+        "turns": [
+          "Road #8 -> Road #62",
+          "Road #61 -> Road #62"
         ],
         "type": "intersection"
       },
@@ -10581,13 +10581,13 @@
         "control": "Signed",
         "id": 81,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #18 -> Road #179",
-          "Road #181 -> Road #179"
-        ],
         "osm_node_ids": [
           4156272585,
           96619956
+        ],
+        "turns": [
+          "Road #18 -> Road #179",
+          "Road #181 -> Road #179"
         ],
         "type": "intersection"
       },
@@ -10637,10 +10637,10 @@
         "control": "Signed",
         "id": 83,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4156273393
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10685,10 +10685,10 @@
         "control": "Signed",
         "id": 84,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3799274015
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10729,10 +10729,10 @@
         "control": "Signed",
         "id": 85,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3799274014
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10769,10 +10769,10 @@
         "control": "Signed",
         "id": 86,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           264341502
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10809,10 +10809,10 @@
         "control": "Signalled",
         "id": 87,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4175070882
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -10849,10 +10849,10 @@
         "control": "Signalled",
         "id": 88,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7004860404
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11113,10 +11113,10 @@
         "control": "Signed",
         "id": 89,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6329043357
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11153,10 +11153,10 @@
         "control": "Signed",
         "id": 90,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6896299617
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11197,10 +11197,10 @@
         "control": "Signed",
         "id": 91,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           3890206822
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11237,8 +11237,8 @@
         "control": "Uncontrolled",
         "id": 93,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11291,10 +11291,10 @@
         "control": "Signed",
         "id": 94,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6329043358
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11331,10 +11331,10 @@
         "control": "Signed",
         "id": 95,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6022813726
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11595,10 +11595,10 @@
         "control": "Signed",
         "id": 97,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6022823874
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11859,10 +11859,10 @@
         "control": "Signed",
         "id": 98,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8947442148
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11899,8 +11899,8 @@
         "control": "Uncontrolled",
         "id": 99,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11941,10 +11941,10 @@
         "control": "Signed",
         "id": 101,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6231431196
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -11981,10 +11981,10 @@
         "control": "Signed",
         "id": 102,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6231431191
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12021,10 +12021,10 @@
         "control": "Signed",
         "id": 103,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6231431193
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12069,10 +12069,10 @@
         "control": "Signed",
         "id": 104,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6022813734
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12109,10 +12109,10 @@
         "control": "Signed",
         "id": 105,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           7004860387
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12165,11 +12165,11 @@
         "control": "Signalled",
         "id": 106,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #26 -> Road #27"
-        ],
         "osm_node_ids": [
           4175070886
+        ],
+        "turns": [
+          "Road #26 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -12215,13 +12215,13 @@
         "control": "Signed",
         "id": 107,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6491174860
+        ],
+        "turns": [
           "Road #138 -> Road #48",
           "Road #47 -> Road #48",
           "Road #47 -> Road #138"
-        ],
-        "osm_node_ids": [
-          6491174860
         ],
         "type": "intersection"
       },
@@ -12259,10 +12259,10 @@
         "control": "Signed",
         "id": 108,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           6491174866
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12315,12 +12315,12 @@
         "control": "Signed",
         "id": 111,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #150 -> Road #40"
-        ],
         "osm_node_ids": [
           6502835826,
           2105133362
+        ],
+        "turns": [
+          "Road #150 -> Road #40"
         ],
         "type": "intersection"
       },
@@ -12358,10 +12358,10 @@
         "control": "Signed",
         "id": 112,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6502835822
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12398,10 +12398,10 @@
         "control": "Signed",
         "id": 113,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6502835823
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12450,10 +12450,10 @@
         "control": "Signed",
         "id": 114,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6502835821
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12490,10 +12490,10 @@
         "control": "Signed",
         "id": 115,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2511061205
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12530,10 +12530,10 @@
         "control": "Signed",
         "id": 117,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6970648941
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12586,10 +12586,10 @@
         "control": "Signed",
         "id": 118,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4156273391
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12626,10 +12626,10 @@
         "control": "Signed",
         "id": 119,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8936997799
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12670,10 +12670,10 @@
         "control": "Signed",
         "id": 120,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6970648943
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12710,10 +12710,10 @@
         "control": "Signed",
         "id": 122,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8936997798
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12754,16 +12754,16 @@
         "control": "Signed",
         "id": 129,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          7728093176
+        ],
+        "turns": [
           "Road #6 -> Road #164",
           "Road #6 -> Road #5",
           "Road #164 -> Road #6",
           "Road #164 -> Road #5",
           "Road #5 -> Road #6",
           "Road #5 -> Road #164"
-        ],
-        "osm_node_ids": [
-          7728093176
         ],
         "type": "intersection"
       },
@@ -12801,10 +12801,10 @@
         "control": "Signed",
         "id": 130,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7728093180
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12861,12 +12861,12 @@
         "control": "Signed",
         "id": 131,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #44 -> Road #45"
-        ],
         "osm_node_ids": [
           8936977833,
           8936977834
+        ],
+        "turns": [
+          "Road #44 -> Road #45"
         ],
         "type": "intersection"
       },
@@ -12904,8 +12904,8 @@
         "control": "Uncontrolled",
         "id": 133,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -12946,10 +12946,10 @@
         "control": "Signed",
         "id": 134,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8942303836
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13210,10 +13210,10 @@
         "control": "Signed",
         "id": 135,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8947417390
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13258,11 +13258,11 @@
         "control": "Signed",
         "id": 136,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #60 -> Road #61"
-        ],
         "osm_node_ids": [
           8947417388
+        ],
+        "turns": [
+          "Road #60 -> Road #61"
         ],
         "type": "intersection"
       },
@@ -13304,10 +13304,10 @@
         "control": "Signalled",
         "id": 137,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8947417387
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13568,10 +13568,10 @@
         "control": "Signed",
         "id": 138,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8947417389
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13612,11 +13612,11 @@
         "control": "Signed",
         "id": 139,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6022813727,
           8947442152
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13653,10 +13653,10 @@
         "control": "Signed",
         "id": 140,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4421018012
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13693,10 +13693,10 @@
         "control": "Signed",
         "id": 141,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136430525
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13737,10 +13737,10 @@
         "control": "Signed",
         "id": 142,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9136430541
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13789,12 +13789,12 @@
         "control": "Signed",
         "id": 143,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #17 -> Road #16",
-          "Road #16 -> Road #17"
-        ],
         "osm_node_ids": [
           9136430547
+        ],
+        "turns": [
+          "Road #17 -> Road #16",
+          "Road #16 -> Road #17"
         ],
         "type": "intersection"
       },
@@ -13840,10 +13840,10 @@
         "control": "Signed",
         "id": 144,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350066
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13884,10 +13884,10 @@
         "control": "Signed",
         "id": 145,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350134
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13932,10 +13932,10 @@
         "control": "Signed",
         "id": 146,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350092
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -13976,10 +13976,10 @@
         "control": "Signed",
         "id": 147,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350128
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -14020,10 +14020,10 @@
         "control": "Signed",
         "id": 148,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350122
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -14068,10 +14068,10 @@
         "control": "Signed",
         "id": 149,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1819350083
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -14124,12 +14124,12 @@
         "control": "Signalled",
         "id": 153,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #187 -> Road #188"
-        ],
         "osm_node_ids": [
           4156273392,
           6970648945
+        ],
+        "turns": [
+          "Road #187 -> Road #188"
         ],
         "type": "intersection"
       },

--- a/tests/src/taipei/geometry.json
+++ b/tests/src/taipei/geometry.json
@@ -4535,8 +4535,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4573,8 +4573,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4619,12 +4619,12 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #3 -> Road #26",
-          "Road #25 -> Road #26"
-        ],
         "osm_node_ids": [
           656415898
+        ],
+        "turns": [
+          "Road #3 -> Road #26",
+          "Road #25 -> Road #26"
         ],
         "type": "intersection"
       },
@@ -4682,15 +4682,15 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          656415914,
+          8807946160
+        ],
+        "turns": [
           "Road #7 -> Road #5",
           "Road #7 -> Road #8",
           "Road #8 -> Road #7",
           "Road #8 -> Road #5"
-        ],
-        "osm_node_ids": [
-          656415914,
-          8807946160
         ],
         "type": "intersection"
       },
@@ -4728,8 +4728,8 @@
         "control": "Uncontrolled",
         "id": 5,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4778,13 +4778,13 @@
         "control": "Signalled",
         "id": 6,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          656415974
+        ],
+        "turns": [
           "Road #29 -> Road #30",
           "Road #29 -> Road #6",
           "Road #6 -> Road #30"
-        ],
-        "osm_node_ids": [
-          656415974
         ],
         "type": "intersection"
       },
@@ -4822,8 +4822,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4872,12 +4872,12 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #86 -> Road #87",
-          "Road #86 -> Road #9"
-        ],
         "osm_node_ids": [
           662161241
+        ],
+        "turns": [
+          "Road #86 -> Road #87",
+          "Road #86 -> Road #9"
         ],
         "type": "intersection"
       },
@@ -4915,8 +4915,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4961,12 +4961,12 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #82 -> Road #83",
-          "Road #82 -> Road #11"
-        ],
         "osm_node_ids": [
           662161891
+        ],
+        "turns": [
+          "Road #82 -> Road #83",
+          "Road #82 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -5004,8 +5004,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5042,8 +5042,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5084,12 +5084,12 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #17 -> Road #84",
-          "Road #83 -> Road #84"
-        ],
         "osm_node_ids": [
           662161955
+        ],
+        "turns": [
+          "Road #17 -> Road #84",
+          "Road #83 -> Road #84"
         ],
         "type": "intersection"
       },
@@ -5127,12 +5127,12 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #73 -> Road #74",
-          "Road #73 -> Road #18"
-        ],
         "osm_node_ids": [
           662161980
+        ],
+        "turns": [
+          "Road #73 -> Road #74",
+          "Road #73 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -5182,14 +5182,14 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          662161961
+        ],
+        "turns": [
           "Road #19 -> Road #20",
           "Road #19 -> Road #16",
           "Road #15 -> Road #20",
           "Road #15 -> Road #16"
-        ],
-        "osm_node_ids": [
-          662161961
         ],
         "type": "intersection"
       },
@@ -5227,14 +5227,14 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          662161900
+        ],
+        "turns": [
           "Road #20 -> Road #13",
           "Road #20 -> Road #21",
           "Road #12 -> Road #13",
           "Road #12 -> Road #21"
-        ],
-        "osm_node_ids": [
-          662161900
         ],
         "type": "intersection"
       },
@@ -5272,8 +5272,8 @@
         "control": "Uncontrolled",
         "id": 17,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5310,8 +5310,8 @@
         "control": "Uncontrolled",
         "id": 18,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5356,12 +5356,12 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #69 -> Road #70",
-          "Road #23 -> Road #70"
-        ],
         "osm_node_ids": [
           2137955866
+        ],
+        "turns": [
+          "Road #69 -> Road #70",
+          "Road #23 -> Road #70"
         ],
         "type": "intersection"
       },
@@ -5399,8 +5399,8 @@
         "control": "Uncontrolled",
         "id": 20,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5437,8 +5437,8 @@
         "control": "Uncontrolled",
         "id": 22,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5499,15 +5499,15 @@
         "control": "Signalled",
         "id": 23,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          656416189
+        ],
+        "turns": [
           "Road #80 -> Road #120",
           "Road #80 -> Road #28",
           "Road #27 -> Road #67",
           "Road #27 -> Road #120",
           "Road #27 -> Road #28"
-        ],
-        "osm_node_ids": [
-          656416189
         ],
         "type": "intersection"
       },
@@ -5545,8 +5545,8 @@
         "control": "Uncontrolled",
         "id": 24,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5583,8 +5583,8 @@
         "control": "Uncontrolled",
         "id": 28,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5621,8 +5621,8 @@
         "control": "Uncontrolled",
         "id": 29,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5659,8 +5659,8 @@
         "control": "Uncontrolled",
         "id": 31,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5709,14 +5709,14 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          662161907
+        ],
+        "turns": [
           "Road #40 -> Road #41",
           "Road #40 -> Road #14",
           "Road #13 -> Road #41",
           "Road #13 -> Road #14"
-        ],
-        "osm_node_ids": [
-          662161907
         ],
         "type": "intersection"
       },
@@ -5754,8 +5754,8 @@
         "control": "Uncontrolled",
         "id": 33,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5792,8 +5792,8 @@
         "control": "Uncontrolled",
         "id": 34,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -5850,11 +5850,11 @@
         "control": "Signed",
         "id": 35,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #11 -> Road #12"
-        ],
         "osm_node_ids": [
           4335733886
+        ],
+        "turns": [
+          "Road #11 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -5900,11 +5900,11 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #16 -> Road #17"
-        ],
         "osm_node_ids": [
           4335735090
+        ],
+        "turns": [
+          "Road #16 -> Road #17"
         ],
         "type": "intersection"
       },
@@ -5958,11 +5958,11 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #18 -> Road #19"
-        ],
         "osm_node_ids": [
           8807946195
+        ],
+        "turns": [
+          "Road #18 -> Road #19"
         ],
         "type": "intersection"
       },
@@ -6000,8 +6000,8 @@
         "control": "Uncontrolled",
         "id": 38,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6058,10 +6058,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4335733874
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6118,11 +6118,11 @@
         "control": "Signed",
         "id": 40,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #30 -> Road #31"
-        ],
         "osm_node_ids": [
           4335733877
+        ],
+        "turns": [
+          "Road #30 -> Road #31"
         ],
         "type": "intersection"
       },
@@ -6164,10 +6164,10 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4335733884
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6204,8 +6204,8 @@
         "control": "Uncontrolled",
         "id": 42,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6262,13 +6262,13 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #6 -> Road #7",
-          "Road #7 -> Road #6"
-        ],
         "osm_node_ids": [
           4335733875,
           8807946122
+        ],
+        "turns": [
+          "Road #6 -> Road #7",
+          "Road #7 -> Road #6"
         ],
         "type": "intersection"
       },
@@ -6322,11 +6322,11 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #2 -> Road #3"
-        ],
         "osm_node_ids": [
           8807946132
+        ],
+        "turns": [
+          "Road #2 -> Road #3"
         ],
         "type": "intersection"
       },
@@ -6364,8 +6364,8 @@
         "control": "Uncontrolled",
         "id": 45,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6402,8 +6402,8 @@
         "control": "Uncontrolled",
         "id": 46,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6456,11 +6456,11 @@
         "control": "Signed",
         "id": 48,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #9 -> Road #10"
-        ],
         "osm_node_ids": [
           4568589283
+        ],
+        "turns": [
+          "Road #9 -> Road #10"
         ],
         "type": "intersection"
       },
@@ -6498,8 +6498,8 @@
         "control": "Uncontrolled",
         "id": 49,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6536,8 +6536,8 @@
         "control": "Uncontrolled",
         "id": 50,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6598,16 +6598,16 @@
         "control": "Signalled",
         "id": 51,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          656416186
+        ],
+        "turns": [
           "Road #85 -> Road #75",
           "Road #85 -> Road #72",
           "Road #119 -> Road #75",
           "Road #119 -> Road #72",
           "Road #67 -> Road #75",
           "Road #67 -> Road #72"
-        ],
-        "osm_node_ids": [
-          656416186
         ],
         "type": "intersection"
       },
@@ -6869,7 +6869,15 @@
         "control": "Signalled",
         "id": 52,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          656416158,
+          656416249,
+          656416176,
+          656416177,
+          656416254,
+          656416087
+        ],
+        "turns": [
           "Road #88 -> Road #37",
           "Road #88 -> Road #77",
           "Road #88 -> Road #68",
@@ -6942,14 +6950,6 @@
           "Road #71 -> Road #32",
           "Road #71 -> Road #34"
         ],
-        "osm_node_ids": [
-          656416158,
-          656416249,
-          656416176,
-          656416177,
-          656416254,
-          656416087
-        ],
         "type": "intersection"
       },
       "type": "Feature"
@@ -6986,8 +6986,8 @@
         "control": "Uncontrolled",
         "id": 53,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7024,8 +7024,8 @@
         "control": "Uncontrolled",
         "id": 54,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7062,8 +7062,8 @@
         "control": "Uncontrolled",
         "id": 55,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7100,8 +7100,8 @@
         "control": "Uncontrolled",
         "id": 56,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7150,11 +7150,11 @@
         "control": "Signed",
         "id": 57,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #81 -> Road #82"
-        ],
         "osm_node_ids": [
           4335733878
+        ],
+        "turns": [
+          "Road #81 -> Road #82"
         ],
         "type": "intersection"
       },
@@ -7192,8 +7192,8 @@
         "control": "Uncontrolled",
         "id": 58,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7230,8 +7230,8 @@
         "control": "Uncontrolled",
         "id": 59,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7268,8 +7268,8 @@
         "control": "Uncontrolled",
         "id": 60,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7314,10 +7314,10 @@
         "control": "Signed",
         "id": 61,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4568593108
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7398,16 +7398,16 @@
         "control": "Signed",
         "id": 62,
         "intersection_kind": "Fork",
-        "movements": [
-          "Road #37 -> Road #38",
-          "Road #37 -> Road #71",
-          "Road #70 -> Road #38",
-          "Road #70 -> Road #71"
-        ],
         "osm_node_ids": [
           656416266,
           5246605980,
           4568593109
+        ],
+        "turns": [
+          "Road #37 -> Road #38",
+          "Road #37 -> Road #71",
+          "Road #70 -> Road #38",
+          "Road #70 -> Road #71"
         ],
         "type": "intersection"
       },
@@ -7449,10 +7449,10 @@
         "control": "Signed",
         "id": 64,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5262459478
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7501,11 +7501,11 @@
         "control": "Signed",
         "id": 65,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #22 -> Road #23"
-        ],
         "osm_node_ids": [
           5246605994
+        ],
+        "turns": [
+          "Road #22 -> Road #23"
         ],
         "type": "intersection"
       },
@@ -7543,8 +7543,8 @@
         "control": "Uncontrolled",
         "id": 66,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7589,10 +7589,10 @@
         "control": "Signed",
         "id": 67,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5246605984
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7649,11 +7649,11 @@
         "control": "Signed",
         "id": 68,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #26 -> Road #27"
-        ],
         "osm_node_ids": [
           4335733876
+        ],
+        "turns": [
+          "Road #26 -> Road #27"
         ],
         "type": "intersection"
       },
@@ -7711,11 +7711,11 @@
         "control": "Signed",
         "id": 69,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #91 -> Road #92"
-        ],
         "osm_node_ids": [
           5246605983
+        ],
+        "turns": [
+          "Road #91 -> Road #92"
         ],
         "type": "intersection"
       },
@@ -7769,11 +7769,11 @@
         "control": "Signed",
         "id": 70,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           5246605982
+        ],
+        "turns": [
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -7831,11 +7831,11 @@
         "control": "Signed",
         "id": 71,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #34 -> Road #35"
-        ],
         "osm_node_ids": [
           5246605981
+        ],
+        "turns": [
+          "Road #34 -> Road #35"
         ],
         "type": "intersection"
       },
@@ -7881,10 +7881,10 @@
         "control": "Signed",
         "id": 72,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5246605991
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -7933,11 +7933,11 @@
         "control": "Signed",
         "id": 73,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #84 -> Road #85"
-        ],
         "osm_node_ids": [
           5246605986
+        ],
+        "turns": [
+          "Road #84 -> Road #85"
         ],
         "type": "intersection"
       },
@@ -7987,11 +7987,11 @@
         "control": "Signed",
         "id": 74,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #28 -> Road #29"
-        ],
         "osm_node_ids": [
           5246605985
+        ],
+        "turns": [
+          "Road #28 -> Road #29"
         ],
         "type": "intersection"
       },
@@ -8037,10 +8037,10 @@
         "control": "Signed",
         "id": 75,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5246605992
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8085,10 +8085,10 @@
         "control": "Signed",
         "id": 76,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5246605987
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8141,11 +8141,11 @@
         "control": "Signed",
         "id": 77,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #72 -> Road #73"
-        ],
         "osm_node_ids": [
           4335735091
+        ],
+        "turns": [
+          "Road #72 -> Road #73"
         ],
         "type": "intersection"
       },
@@ -8199,11 +8199,11 @@
         "control": "Signed",
         "id": 78,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #77 -> Road #78"
-        ],
         "osm_node_ids": [
           5246605990
+        ],
+        "turns": [
+          "Road #77 -> Road #78"
         ],
         "type": "intersection"
       },
@@ -8273,15 +8273,15 @@
         "control": "Signed",
         "id": 79,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5246605989,
+          5246605988
+        ],
+        "turns": [
           "Road #87 -> Road #90",
           "Road #87 -> Road #88",
           "Road #89 -> Road #90",
           "Road #89 -> Road #88"
-        ],
-        "osm_node_ids": [
-          5246605989,
-          5246605988
         ],
         "type": "intersection"
       },
@@ -8323,10 +8323,10 @@
         "control": "Signed",
         "id": 81,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           4568593153
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8363,8 +8363,8 @@
         "control": "Uncontrolled",
         "id": 83,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8401,8 +8401,8 @@
         "control": "Uncontrolled",
         "id": 84,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8439,8 +8439,8 @@
         "control": "Uncontrolled",
         "id": 85,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8493,11 +8493,11 @@
         "control": "Signed",
         "id": 86,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #117 -> Road #118"
-        ],
         "osm_node_ids": [
           9631713694
+        ],
+        "turns": [
+          "Road #117 -> Road #118"
         ],
         "type": "intersection"
       },
@@ -8547,11 +8547,11 @@
         "control": "Signed",
         "id": 87,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #118 -> Road #119"
-        ],
         "osm_node_ids": [
           9631718924
+        ],
+        "turns": [
+          "Road #118 -> Road #119"
         ],
         "type": "intersection"
       },
@@ -8601,11 +8601,11 @@
         "control": "Signed",
         "id": 88,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #120 -> Road #121"
-        ],
         "osm_node_ids": [
           9631719043
+        ],
+        "turns": [
+          "Road #120 -> Road #121"
         ],
         "type": "intersection"
       },
@@ -8659,11 +8659,11 @@
         "control": "Signed",
         "id": 89,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #121 -> Road #122"
-        ],
         "osm_node_ids": [
           9631713638
+        ],
+        "turns": [
+          "Road #121 -> Road #122"
         ],
         "type": "intersection"
       },
@@ -8701,8 +8701,8 @@
         "control": "Uncontrolled",
         "id": 90,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8739,8 +8739,8 @@
         "control": "Uncontrolled",
         "id": 92,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8777,8 +8777,8 @@
         "control": "Uncontrolled",
         "id": 93,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -8819,10 +8819,10 @@
         "control": "Signed",
         "id": 94,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           8807946124
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/tempe_light_rail/geometry.json
+++ b/tests/src/tempe_light_rail/geometry.json
@@ -2026,8 +2026,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2064,10 +2064,10 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1501648604
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2104,8 +2104,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2142,8 +2142,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2236,7 +2236,13 @@
         "control": "Signalled",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          3756578325,
+          1501648667,
+          330686493,
+          2819230452
+        ],
+        "turns": [
           "Road #21 -> Road #7",
           "Road #21 -> Road #1",
           "Road #21 -> Road #12",
@@ -2251,12 +2257,6 @@
           "Road #11 -> Road #21",
           "Road #11 -> Road #1",
           "Road #11 -> Road #12"
-        ],
-        "osm_node_ids": [
-          3756578325,
-          1501648667,
-          330686493,
-          2819230452
         ],
         "type": "intersection"
       },
@@ -2294,8 +2294,8 @@
         "control": "Uncontrolled",
         "id": 6,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2332,8 +2332,8 @@
         "control": "Uncontrolled",
         "id": 7,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2370,12 +2370,12 @@
         "control": "Signed",
         "id": 8,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #13 -> Road #47",
-          "Road #47 -> Road #13"
-        ],
         "osm_node_ids": [
           4347879967
+        ],
+        "turns": [
+          "Road #13 -> Road #47",
+          "Road #47 -> Road #13"
         ],
         "type": "intersection"
       },
@@ -2413,8 +2413,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2451,12 +2451,12 @@
         "control": "Signed",
         "id": 10,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #18 -> Road #19",
-          "Road #19 -> Road #18"
-        ],
         "osm_node_ids": [
           4347879970
+        ],
+        "turns": [
+          "Road #18 -> Road #19",
+          "Road #19 -> Road #18"
         ],
         "type": "intersection"
       },
@@ -2494,10 +2494,10 @@
         "control": "Signed",
         "id": 11,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5620993577
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2542,16 +2542,16 @@
         "control": "Signed",
         "id": 12,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5620993580
+        ],
+        "turns": [
           "Road #25 -> Road #24",
           "Road #25 -> Road #23",
           "Road #24 -> Road #25",
           "Road #24 -> Road #23",
           "Road #23 -> Road #25",
           "Road #23 -> Road #24"
-        ],
-        "osm_node_ids": [
-          5620993580
         ],
         "type": "intersection"
       },
@@ -2589,10 +2589,10 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           9401432330
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2633,13 +2633,13 @@
         "control": "Signed",
         "id": 15,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          5620993598
+        ],
+        "turns": [
           "Road #27 -> Road #9",
           "Road #8 -> Road #9",
           "Road #8 -> Road #27"
-        ],
-        "osm_node_ids": [
-          5620993598
         ],
         "type": "intersection"
       },
@@ -2681,13 +2681,13 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          5674141377
+        ],
+        "turns": [
           "Road #28 -> Road #4",
           "Road #3 -> Road #28",
           "Road #3 -> Road #4"
-        ],
-        "osm_node_ids": [
-          5674141377
         ],
         "type": "intersection"
       },
@@ -2725,10 +2725,10 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5674141391
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2769,16 +2769,16 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5674141392
+        ],
+        "turns": [
           "Road #17 -> Road #31",
           "Road #17 -> Road #18",
           "Road #31 -> Road #17",
           "Road #31 -> Road #18",
           "Road #18 -> Road #17",
           "Road #18 -> Road #31"
-        ],
-        "osm_node_ids": [
-          5674141392
         ],
         "type": "intersection"
       },
@@ -2816,10 +2816,10 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           5674141393
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2856,8 +2856,8 @@
         "control": "Uncontrolled",
         "id": 22,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2894,8 +2894,8 @@
         "control": "Uncontrolled",
         "id": 23,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2948,11 +2948,11 @@
         "control": "Signed",
         "id": 25,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #1 -> Road #2"
-        ],
         "osm_node_ids": [
           2819230451
+        ],
+        "turns": [
+          "Road #1 -> Road #2"
         ],
         "type": "intersection"
       },
@@ -3006,11 +3006,11 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #5 -> Road #6"
-        ],
         "osm_node_ids": [
           2300341765
+        ],
+        "turns": [
+          "Road #5 -> Road #6"
         ],
         "type": "intersection"
       },
@@ -3064,12 +3064,12 @@
         "control": "Signed",
         "id": 27,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #20 -> Road #21",
-          "Road #21 -> Road #20"
-        ],
         "osm_node_ids": [
           7259876531
+        ],
+        "turns": [
+          "Road #20 -> Road #21",
+          "Road #21 -> Road #20"
         ],
         "type": "intersection"
       },
@@ -3127,11 +3127,11 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #8"
-        ],
         "osm_node_ids": [
           2300341766
+        ],
+        "turns": [
+          "Road #7 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -3185,11 +3185,11 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #10 -> Road #11"
-        ],
         "osm_node_ids": [
           2300341723
+        ],
+        "turns": [
+          "Road #10 -> Road #11"
         ],
         "type": "intersection"
       },
@@ -3239,12 +3239,12 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #12 -> Road #13",
-          "Road #13 -> Road #12"
-        ],
         "osm_node_ids": [
           2819230435
+        ],
+        "turns": [
+          "Road #12 -> Road #13",
+          "Road #13 -> Road #12"
         ],
         "type": "intersection"
       },
@@ -3286,16 +3286,16 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          7509154720
+        ],
+        "turns": [
           "Road #19 -> Road #45",
           "Road #19 -> Road #20",
           "Road #45 -> Road #19",
           "Road #45 -> Road #20",
           "Road #20 -> Road #19",
           "Road #20 -> Road #45"
-        ],
-        "osm_node_ids": [
-          7509154720
         ],
         "type": "intersection"
       },
@@ -3337,13 +3337,13 @@
         "control": "Signed",
         "id": 32,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          7509154723
+        ],
+        "turns": [
           "Road #45 -> Road #5",
           "Road #4 -> Road #45",
           "Road #4 -> Road #5"
-        ],
-        "osm_node_ids": [
-          7509154723
         ],
         "type": "intersection"
       },
@@ -3385,16 +3385,16 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5620993585
+        ],
+        "turns": [
           "Road #46 -> Road #24",
           "Road #46 -> Road #25",
           "Road #24 -> Road #46",
           "Road #24 -> Road #25",
           "Road #25 -> Road #46",
           "Road #25 -> Road #24"
-        ],
-        "osm_node_ids": [
-          5620993585
         ],
         "type": "intersection"
       },
@@ -3436,16 +3436,16 @@
         "control": "Signed",
         "id": 34,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          5620993581
+        ],
+        "turns": [
           "Road #22 -> Road #46",
           "Road #22 -> Road #23",
           "Road #46 -> Road #22",
           "Road #46 -> Road #23",
           "Road #23 -> Road #22",
           "Road #23 -> Road #46"
-        ],
-        "osm_node_ids": [
-          5620993581
         ],
         "type": "intersection"
       },
@@ -3483,8 +3483,8 @@
         "control": "Uncontrolled",
         "id": 35,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3521,8 +3521,8 @@
         "control": "Uncontrolled",
         "id": 36,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3575,10 +3575,10 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2300341753
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3623,10 +3623,10 @@
         "control": "Signed",
         "id": 39,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           1501648682
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3663,8 +3663,8 @@
         "control": "Uncontrolled",
         "id": 40,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3701,8 +3701,8 @@
         "control": "Uncontrolled",
         "id": 41,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3751,10 +3751,10 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2300341738
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3807,10 +3807,10 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           2300341735
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3847,8 +3847,8 @@
         "control": "Uncontrolled",
         "id": 45,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/tempe_split/geometry.json
+++ b/tests/src/tempe_split/geometry.json
@@ -2165,8 +2165,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2263,7 +2263,12 @@
         "control": "Signalled",
         "id": 2,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          2941419917,
+          41662590,
+          2239876831
+        ],
+        "turns": [
           "Road #8 -> Road #2",
           "Road #8 -> Road #15",
           "Road #8 -> Road #0",
@@ -2279,11 +2284,6 @@
           "Road #13 -> Road #2",
           "Road #13 -> Road #15",
           "Road #13 -> Road #0"
-        ],
-        "osm_node_ids": [
-          2941419917,
-          41662590,
-          2239876831
         ],
         "type": "intersection"
       },
@@ -2321,8 +2321,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2359,8 +2359,8 @@
         "control": "Uncontrolled",
         "id": 4,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2397,8 +2397,8 @@
         "control": "Uncontrolled",
         "id": 5,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2435,11 +2435,11 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #6 -> Road #7"
-        ],
         "osm_node_ids": [
           4346581618
+        ],
+        "turns": [
+          "Road #6 -> Road #7"
         ],
         "type": "intersection"
       },
@@ -2477,11 +2477,11 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #18 -> Road #9"
-        ],
         "osm_node_ids": [
           4346605157
+        ],
+        "turns": [
+          "Road #18 -> Road #9"
         ],
         "type": "intersection"
       },
@@ -2519,8 +2519,8 @@
         "control": "Uncontrolled",
         "id": 8,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2557,8 +2557,8 @@
         "control": "Uncontrolled",
         "id": 9,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2595,8 +2595,8 @@
         "control": "Uncontrolled",
         "id": 10,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2633,8 +2633,8 @@
         "control": "Uncontrolled",
         "id": 11,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2671,8 +2671,8 @@
         "control": "Uncontrolled",
         "id": 12,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2717,10 +2717,10 @@
         "control": "Signed",
         "id": 13,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           10249787574
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -2785,15 +2785,15 @@
         "control": "Signed",
         "id": 14,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          2239876836,
+          2860653268
+        ],
+        "turns": [
           "Road #10 -> Road #11",
           "Road #10 -> Road #16",
           "Road #15 -> Road #11",
           "Road #15 -> Road #16"
-        ],
-        "osm_node_ids": [
-          2239876836,
-          2860653268
         ],
         "type": "intersection"
       },
@@ -2847,11 +2847,11 @@
         "control": "Signed",
         "id": 16,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #2 -> Road #3"
-        ],
         "osm_node_ids": [
           2941419918
+        ],
+        "turns": [
+          "Road #2 -> Road #3"
         ],
         "type": "intersection"
       },
@@ -2909,11 +2909,11 @@
         "control": "Signed",
         "id": 17,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #7 -> Road #8"
-        ],
         "osm_node_ids": [
           2239876863
+        ],
+        "turns": [
+          "Road #7 -> Road #8"
         ],
         "type": "intersection"
       },
@@ -2971,11 +2971,11 @@
         "control": "Signed",
         "id": 19,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #0 -> Road #1"
-        ],
         "osm_node_ids": [
           2239876816
+        ],
+        "turns": [
+          "Road #0 -> Road #1"
         ],
         "type": "intersection"
       },
@@ -3029,11 +3029,11 @@
         "control": "Signed",
         "id": 20,
         "intersection_kind": "Connection",
-        "movements": [
-          "Road #4 -> Road #5"
-        ],
         "osm_node_ids": [
           2941419915
+        ],
+        "turns": [
+          "Road #4 -> Road #5"
         ],
         "type": "intersection"
       },
@@ -3083,10 +3083,10 @@
         "control": "Signed",
         "id": 21,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5415307213
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3127,13 +3127,13 @@
         "control": "Signed",
         "id": 22,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          5707494413
+        ],
+        "turns": [
           "Road #34 -> Road #10",
           "Road #9 -> Road #34",
           "Road #9 -> Road #10"
-        ],
-        "osm_node_ids": [
-          5707494413
         ],
         "type": "intersection"
       },
@@ -3183,12 +3183,12 @@
         "control": "Signed",
         "id": 23,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #35 -> Road #34",
-          "Road #34 -> Road #35"
-        ],
         "osm_node_ids": [
           5717678154
+        ],
+        "turns": [
+          "Road #35 -> Road #34",
+          "Road #34 -> Road #35"
         ],
         "type": "intersection"
       },
@@ -3226,8 +3226,8 @@
         "control": "Uncontrolled",
         "id": 24,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3264,8 +3264,8 @@
         "control": "Uncontrolled",
         "id": 25,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3314,16 +3314,16 @@
         "control": "Signed",
         "id": 26,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6672814189
+        ],
+        "turns": [
           "Road #14 -> Road #13",
           "Road #14 -> Road #39",
           "Road #13 -> Road #14",
           "Road #13 -> Road #39",
           "Road #39 -> Road #14",
           "Road #39 -> Road #13"
-        ],
-        "osm_node_ids": [
-          6672814189
         ],
         "type": "intersection"
       },
@@ -3361,10 +3361,10 @@
         "control": "Signed",
         "id": 28,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           6672807665
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3409,16 +3409,16 @@
         "control": "Signed",
         "id": 29,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          6672807663
+        ],
+        "turns": [
           "Road #36 -> Road #41",
           "Road #36 -> Road #35",
           "Road #41 -> Road #36",
           "Road #41 -> Road #35",
           "Road #35 -> Road #36",
           "Road #35 -> Road #41"
-        ],
-        "osm_node_ids": [
-          6672807663
         ],
         "type": "intersection"
       },
@@ -3460,10 +3460,10 @@
         "control": "Signed",
         "id": 30,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           7069576316
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3508,16 +3508,16 @@
         "control": "Signed",
         "id": 31,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          7069576315
+        ],
+        "turns": [
           "Road #42 -> Road #37",
           "Road #42 -> Road #36",
           "Road #37 -> Road #42",
           "Road #37 -> Road #36",
           "Road #36 -> Road #42",
           "Road #36 -> Road #37"
-        ],
-        "osm_node_ids": [
-          7069576315
         ],
         "type": "intersection"
       },
@@ -3555,8 +3555,8 @@
         "control": "Uncontrolled",
         "id": 32,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3597,16 +3597,16 @@
         "control": "Signed",
         "id": 33,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          7121900772
+        ],
+        "turns": [
           "Road #38 -> Road #43",
           "Road #38 -> Road #37",
           "Road #43 -> Road #38",
           "Road #43 -> Road #37",
           "Road #37 -> Road #38",
           "Road #37 -> Road #43"
-        ],
-        "osm_node_ids": [
-          7121900772
         ],
         "type": "intersection"
       },
@@ -3644,8 +3644,8 @@
         "control": "Uncontrolled",
         "id": 34,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3682,8 +3682,8 @@
         "control": "Uncontrolled",
         "id": 35,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3736,12 +3736,12 @@
         "control": "Signed",
         "id": 36,
         "intersection_kind": "Intersection",
-        "movements": [
-          "Road #48 -> Road #47",
-          "Road #47 -> Road #48"
-        ],
         "osm_node_ids": [
           10271040773
+        ],
+        "turns": [
+          "Road #48 -> Road #47",
+          "Road #47 -> Road #48"
         ],
         "type": "intersection"
       },
@@ -3783,13 +3783,13 @@
         "control": "Signed",
         "id": 37,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          1698683885
+        ],
+        "turns": [
           "Road #48 -> Road #17",
           "Road #16 -> Road #17",
           "Road #16 -> Road #48"
-        ],
-        "osm_node_ids": [
-          1698683885
         ],
         "type": "intersection"
       },
@@ -3827,8 +3827,8 @@
         "control": "Uncontrolled",
         "id": 38,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3865,8 +3865,8 @@
         "control": "Uncontrolled",
         "id": 39,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3903,8 +3903,8 @@
         "control": "Uncontrolled",
         "id": 40,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -3957,10 +3957,10 @@
         "control": "Signed",
         "id": 41,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9934553247
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4001,10 +4001,10 @@
         "control": "Signed",
         "id": 42,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           9934553365
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4049,10 +4049,10 @@
         "control": "Signed",
         "id": 43,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           5415307199
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4093,10 +4093,10 @@
         "control": "Signed",
         "id": 44,
         "intersection_kind": "Connection",
-        "movements": [],
         "osm_node_ids": [
           6149033522
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -4133,8 +4133,8 @@
         "control": "Uncontrolled",
         "id": 45,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/tiny_loop/geometry.json
+++ b/tests/src/tiny_loop/geometry.json
@@ -544,8 +544,8 @@
         "control": "Uncontrolled",
         "id": 0,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -582,8 +582,8 @@
         "control": "Uncontrolled",
         "id": 1,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -628,16 +628,16 @@
         "control": "Signed",
         "id": 2,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          233087044
+        ],
+        "turns": [
           "Road #2 -> Road #1",
           "Road #2 -> Road #5",
           "Road #1 -> Road #2",
           "Road #1 -> Road #5",
           "Road #5 -> Road #2",
           "Road #5 -> Road #1"
-        ],
-        "osm_node_ids": [
-          233087044
         ],
         "type": "intersection"
       },
@@ -679,16 +679,16 @@
         "control": "Signed",
         "id": 3,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          233087070
+        ],
+        "turns": [
           "Road #4 -> Road #3",
           "Road #4 -> Road #5",
           "Road #3 -> Road #4",
           "Road #3 -> Road #5",
           "Road #5 -> Road #4",
           "Road #5 -> Road #3"
-        ],
-        "osm_node_ids": [
-          233087070
         ],
         "type": "intersection"
       },
@@ -726,10 +726,10 @@
         "control": "Signed",
         "id": 4,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           233138961
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -770,16 +770,16 @@
         "control": "Signed",
         "id": 5,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          233087041
+        ],
+        "turns": [
           "Road #1 -> Road #6",
           "Road #1 -> Road #0",
           "Road #6 -> Road #1",
           "Road #6 -> Road #0",
           "Road #0 -> Road #1",
           "Road #0 -> Road #6"
-        ],
-        "osm_node_ids": [
-          233087041
         ],
         "type": "intersection"
       },
@@ -825,16 +825,16 @@
         "control": "Signed",
         "id": 6,
         "intersection_kind": "Intersection",
-        "movements": [
+        "osm_node_ids": [
+          233087064
+        ],
+        "turns": [
           "Road #3 -> Road #7",
           "Road #3 -> Road #2",
           "Road #7 -> Road #3",
           "Road #7 -> Road #2",
           "Road #2 -> Road #3",
           "Road #2 -> Road #7"
-        ],
-        "osm_node_ids": [
-          233087064
         ],
         "type": "intersection"
       },
@@ -872,10 +872,10 @@
         "control": "Signed",
         "id": 7,
         "intersection_kind": "Terminus",
-        "movements": [],
         "osm_node_ids": [
           233170569
         ],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"

--- a/tests/src/tiny_roundabout/geometry.json
+++ b/tests/src/tiny_roundabout/geometry.json
@@ -300,13 +300,13 @@
         "control": "Signed",
         "id": 0,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          2435502177
+        ],
+        "turns": [
           "Road #3 -> Road #0",
           "Road #1 -> Road #3",
           "Road #1 -> Road #0"
-        ],
-        "osm_node_ids": [
-          2435502177
         ],
         "type": "intersection"
       },
@@ -352,13 +352,13 @@
         "control": "Signed",
         "id": 1,
         "intersection_kind": "Fork",
-        "movements": [
+        "osm_node_ids": [
+          2435502175
+        ],
+        "turns": [
           "Road #0 -> Road #1",
           "Road #0 -> Road #2",
           "Road #2 -> Road #1"
-        ],
-        "osm_node_ids": [
-          2435502175
         ],
         "type": "intersection"
       },
@@ -396,8 +396,8 @@
         "control": "Uncontrolled",
         "id": 2,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"
@@ -434,8 +434,8 @@
         "control": "Uncontrolled",
         "id": 3,
         "intersection_kind": "MapEdge",
-        "movements": [],
         "osm_node_ids": [],
+        "turns": [],
         "type": "intersection"
       },
       "type": "Feature"


### PR DESCRIPTION
We don't need all of this before merging, but here's the plan so far:
- [x] Rename `Movement` -> `Turn` (road level), add `TurnMovement` (lane level)
- [x] Calculate `TurnMovement`s for degenerate (2 road) intersections
- [ ] Calculate movements for `IntersectionKind::Connection`s with more than two roads.
- [ ] Do some default allocations for arbitrarily complex intersections.
- [ ] Add `TurnKind` to determine what kind of lane markings the `TurnMovement`s get.
- [x] Render "turn guide" lane markings for "turn" turns.
- [ ] Render ordinary lane markings for "continuation" turns (ideally, reusing the normal logic).

This is making some good progress towards lane level movements. In fact, some movements are calculated and drawn! I added the movement centrelines in post, the left edge of the movements are being drawn:
 
![image](https://user-images.githubusercontent.com/3784591/222956403-4425c462-ace9-4c0f-9b16-065a63c50564.png)

We need angled road ends, #95, to draw these markings properly. 