### PR TITLE
Speed up two slow operations, which were unnecessarily searching all …

### DIFF
--- a/osm2streets/src/pathfinding.rs
+++ b/osm2streets/src/pathfinding.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use geom::Distance;
 use petgraph::graphmap::DiGraphMap;
 
@@ -64,5 +66,29 @@ impl StreetNetwork {
             .map(|pair| *graph.edge_weight(pair[0], pair[1]).unwrap())
             .collect();
         Some(roads)
+    }
+
+    /// Find all roads reachable from `start` up to `rounds` hops away
+    pub fn find_nearby_roads(&self, start: RoadID, rounds: usize) -> BTreeSet<RoadID> {
+        let mut found = BTreeSet::new();
+        found.insert(start);
+
+        let mut queue = vec![start];
+        for _ in 0..rounds {
+            let mut next_queue = Vec::new();
+            for r in queue {
+                for i in self.roads[&r].endpoints() {
+                    for next in &self.intersections[&i].roads {
+                        if !found.contains(next) {
+                            next_queue.push(*next);
+                            found.insert(*next);
+                        }
+                    }
+                }
+            }
+            queue = next_queue;
+        }
+
+        found
     }
 }

--- a/osm2streets/src/transform/collapse_short_road.rs
+++ b/osm2streets/src/transform/collapse_short_road.rs
@@ -1,24 +1,23 @@
-use std::collections::VecDeque;
+use abstutil::Timer;
 
-use crate::{RoadID, StreetNetwork};
+use crate::StreetNetwork;
 
 /// Collapse all roads marked with `junction=intersection`
-pub fn collapse_all_junction_roads(streets: &mut StreetNetwork) {
-    let mut queue: VecDeque<RoadID> = VecDeque::new();
+pub fn collapse_all_junction_roads(streets: &mut StreetNetwork, timer: &mut Timer) {
+    let mut queue = Vec::new();
     for (id, road) in &streets.roads {
         if road.internal_junction_road {
-            queue.push_back(*id);
+            queue.push(*id);
         }
     }
 
-    let mut i = 0;
-    while !queue.is_empty() {
-        let id = queue.pop_front().unwrap();
-        i += 1;
+    timer.start_iter("collapse short roads", queue.len());
+    for (idx, id) in queue.into_iter().enumerate() {
+        timer.next();
         if !streets.roads.contains_key(&id) {
             continue;
         }
-        streets.maybe_start_debug_step(format!("collapse road {i}"));
+        streets.maybe_start_debug_step(format!("collapse road {idx}"));
         streets.debug_road(id, "collapse");
         if let Err(err) = streets.collapse_short_road(id) {
             warn!("Not collapsing short road / junction=intersection: {}", err);

--- a/osm2streets/src/transform/mod.rs
+++ b/osm2streets/src/transform/mod.rs
@@ -83,7 +83,7 @@ impl Transformation {
                 remove_disconnected::remove_disconnected_roads(streets);
             }
             Transformation::CollapseShortRoads => {
-                collapse_short_road::collapse_all_junction_roads(streets);
+                collapse_short_road::collapse_all_junction_roads(streets, timer);
             }
             Transformation::CollapseDegenerateIntersections => {
                 collapse_intersections::collapse(streets);


### PR DESCRIPTION
…roads linearly.

Correctness: Tests stay the same, but we're not currently checking anything that turn restrictions would affect.

I had an enormous map with ~300,000 roads that took 93s to collapse short roads! I don't have access to the computer processing that right now, but I found a smaller map that took 15s each for the two operations (collapsing short roads and degenerate intersections). With this PR, drops down to 0.3s and 2s, so I'll consider this a good-enough win.