### PR TITLE
Add more debugging capabilities to Street Explorer

### DIFF
--- a/street-explorer/index.html
+++ b/street-explorer/index.html
@@ -55,12 +55,12 @@
           <div>
             Sidewalks:
             <label>
-              <input name="sidewalks" type="radio" value="mapped" checked />use mapped
-              footways
+              <input name="sidewalks" type="radio" value="mapped" checked />use
+              mapped footways
             </label>
             <label>
-              <input name="sidewalks" type="radio" value="infer" />infer
-              on roads
+              <input name="sidewalks" type="radio" value="infer" />infer on
+              roads
             </label>
           </div>
         </details>

--- a/street-explorer/js/controls.js
+++ b/street-explorer/js/controls.js
@@ -46,6 +46,26 @@ export class LayerGroup {
     this.layers.push(layer);
   }
 
+  replaceLayer(name, layerData, { lazy = false } = {}) {
+    for (const layer of this.layers) {
+      if (layer.name == name) {
+        if (layer.enabled && layer.data != null) {
+          this.map.removeLayer(layer.data);
+        }
+        if (lazy) {
+          layer.data = null;
+          layer.lazilyMakeData = layerData;
+        } else {
+          layer.data = layerData;
+        }
+        if (layer.enabled) {
+          this.map.addLayer(layer.getData());
+        }
+        break;
+      }
+    }
+  }
+
   // Updates the map, but doesn't re-render any controls
   setEnabled(enabled) {
     this.enabled = enabled;

--- a/street-explorer/js/controls.js
+++ b/street-explorer/js/controls.js
@@ -128,16 +128,20 @@ export class SequentialLayerGroup {
     }
   }
 
+  changeCurrent(newIdx) {
+    this.groups[this.current].setEnabled(false);
+    this.current = newIdx;
+    this.groups[this.current].setEnabled(true);
+
+    // Rerender
+    document.getElementById(this.name).replaceWith(this.renderControls());
+  }
+
   renderControls() {
     const prev = makeButton("Previous");
     prev.disabled = this.current == 0;
     prev.onclick = () => {
-      this.groups[this.current].setEnabled(false);
-      this.current -= 1;
-      this.groups[this.current].setEnabled(true);
-
-      // Rerender
-      document.getElementById(this.name).replaceWith(this.renderControls());
+      this.changeCurrent(this.current - 1);
     };
 
     const label = document.createTextNode(
@@ -147,12 +151,21 @@ export class SequentialLayerGroup {
     const next = makeButton("Next");
     next.disabled = this.current == this.groups.length - 1;
     next.onclick = () => {
-      this.groups[this.current].setEnabled(false);
-      this.current += 1;
-      this.groups[this.current].setEnabled(true);
+      this.changeCurrent(this.current + 1);
+    };
 
-      // Rerender
-      document.getElementById(this.name).replaceWith(this.renderControls());
+    const dropdown = L.DomUtil.create("select");
+    var i = 0;
+    for (let group of this.groups) {
+      const option = L.DomUtil.create("option");
+      option.value = i;
+      option.textContent = `${group.name}`;
+      dropdown.appendChild(option);
+      i++;
+    }
+    dropdown.value = this.current;
+    dropdown.onchange = () => {
+      this.changeCurrent(parseInt(dropdown.value));
     };
 
     var row1 = L.DomUtil.create("u");
@@ -161,6 +174,7 @@ export class SequentialLayerGroup {
     const column = makeDiv([
       row1,
       row2,
+      dropdown,
       this.groups[this.current].renderControls(),
     ]);
     column.id = this.name;

--- a/street-explorer/js/lane_editor.js
+++ b/street-explorer/js/lane_editor.js
@@ -2,7 +2,6 @@ import { downloadGeneratedFile } from "./files.js";
 import {
   makeIntersectionMarkingsLayer,
   makeLaneMarkingsLayer,
-  makePlainGeoJsonLayer,
   lanePolygonStyle,
 } from "./layers.js";
 import { setupLeafletMap } from "./leaflet.js";


### PR DESCRIPTION
There are a bunch of debug steps, so a dropdown is very convenient to jump to the relevant ones:

https://user-images.githubusercontent.com/1664407/224373696-ac85a4c5-adb7-4d6f-a0f6-40a3abd50d88.mp4

And interactively modifying the network can be helpful too:

https://user-images.githubusercontent.com/1664407/224373986-9e7817df-c79c-488d-ba8e-5423677b7b9d.mp4

Next up: a way to experimentally snap one piece of separate cycleway/footway.