### PR TITLE
Add speed limit to Roads

### DIFF
--- a/osm2streets/src/geometry/mod.rs
+++ b/osm2streets/src/geometry/mod.rs
@@ -69,6 +69,7 @@ impl InputRoad {
             name: None,
             internal_junction_road: false,
             layer: 0,
+            speed_limit: None,
             reference_line: PolyLine::dummy(),
             reference_line_placement: crate::lanes::Placement::Transition,
             trim_start: Distance::ZERO,

--- a/osm2streets/src/render.rs
+++ b/osm2streets/src/render.rs
@@ -110,6 +110,7 @@ impl StreetNetwork {
                         ("type", format!("{:?}", lane.lt).into()),
                         ("road", road.id.0.into()),
                         ("layer", road.layer.into()),
+                        ("speed_limit", format!("{:?}", road.speed_limit).into()),
                         ("index", idx.into()),
                         ("width", lane.width.inner_meters().into()),
                         ("direction", format!("{:?}", lane.dir).into()),


### PR DESCRIPTION
I need this for https://github.com/acteng/atip/issues/69 (so CC @Sparrow0hawk and @Pete-Y-CS).

I'm choosing an implementation that has less magic/guessing than https://github.com/a-b-street/abstreet/blob/6c44da83d36d0b3197525b8ca834e57a66493d24/map_model/src/objects/road.rs#L246, and also one much simpler (in terms of error reporting especially!) than https://github.com/a-b-street/osm2lanes/blob/0c166e5917748cd2dcb6eb3b798cf38136e776e6/osm2lanes/src/metric.rs.

In the future, it'd be awesome to integrate with https://github.com/westnordost/osm-legal-default-speeds.