### PR TITLE
Support parking:<position>=lane syntax

### DIFF
--- a/osm2streets/src/lanes/classic.rs
+++ b/osm2streets/src/lanes/classic.rs
@@ -462,10 +462,15 @@ fn add_bike_lanes(
 
 fn add_parking_lanes(fwd_side: &mut Vec<LaneSpec>, back_side: &mut Vec<LaneSpec>, tags: &Tags) {
     let has_parking = vec!["parallel", "diagonal", "perpendicular"];
-    let parking_lane_fwd = tags.is_any("parking:lane:right", has_parking.clone())
-        || tags.is_any("parking:lane:both", has_parking.clone());
-    let parking_lane_back = tags.is_any("parking:lane:left", has_parking.clone())
-        || tags.is_any("parking:lane:both", has_parking);
+    let parking_lane_both =
+        tags.is("parking:both", "lane") || tags.is_any("parking:lane:both", has_parking.clone());
+    let parking_lane_fwd = parking_lane_both
+        || tags.is("parking:right", "lane")
+        || tags.is_any("parking:lane:right", has_parking.clone());
+    let parking_lane_back = parking_lane_both
+        || tags.is("parking:left", "lane")
+        || tags.is_any("parking:lane:left", has_parking);
+
     if parking_lane_fwd {
         fwd_side.push(fwd(LaneType::Parking));
     }


### PR DESCRIPTION
Before osm2street would only look at the `parking:lane:<position>=parallel|diagonal|perpendicular` tags. However, as the [wiki notes](https://wiki.openstreetmap.org/wiki/Key:parking:lane), this way of tagging is being replaced by the `parking:<position>=lane` syntax. Because many ways still use the old syntax this PR only adds the new syntax without removing support for the old one.

I'm unsure why `tags.is` requires `Vec` instead of `&Vec`  though.

|Before | After |
| --- | --- |
|![image](https://github.com/a-b-street/osm2streets/assets/35173023/d5fb0109-b67e-4008-bb88-8bf18355915b) | ![image](https://github.com/a-b-street/osm2streets/assets/35173023/f35dcab4-7f2c-4fb8-a486-26161344d6d8) |