### PR TITLE
Reduce dependencies on abstutil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -632,12 +632,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -710,6 +707,7 @@ dependencies = [
  "abstutil",
  "anyhow",
  "enumset",
+ "env_logger",
  "geom",
  "serde",
 ]
@@ -720,6 +718,8 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "console_error_panic_hook",
+ "console_log",
+ "log",
  "osm2lanes",
  "serde-wasm-bindgen",
  "serde_json",
@@ -761,12 +761,15 @@ dependencies = [
  "abstutil",
  "anyhow",
  "console_error_panic_hook",
+ "console_log",
  "experimental",
  "geom",
  "instant",
+ "log",
  "osm2streets",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "streets_reader",
  "wasm-bindgen",
 ]
@@ -1097,6 +1100,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "anyhow",
+ "env_logger",
  "experimental",
  "geom",
  "osm2streets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
     "tests",
 ]
 
+resolver = "2"
+
 # Specify the versions for common dependencies just once here, instead of
 # repeating in a bunch of crates
 [workspace.dependencies]

--- a/osm2lanes-js/Cargo.toml
+++ b/osm2lanes-js/Cargo.toml
@@ -12,6 +12,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 console_error_panic_hook = "0.1.6"
+console_log = "1.0.0"
+log = "0.4.20"
 osm2lanes = { path = "../osm2lanes" }
 wasm-bindgen = "0.2.84"
 serde_json = { workspace = true }

--- a/osm2lanes-js/src/lib.rs
+++ b/osm2lanes-js/src/lib.rs
@@ -1,11 +1,15 @@
+use std::sync::Once;
+
 use wasm_bindgen::prelude::*;
 
 use abstutil::Tags;
-use osm2lanes::{MapConfig, get_lane_specs_ltr};
+use osm2lanes::{get_lane_specs_ltr, MapConfig};
+
+static SETUP_LOGGER: Once = Once::new();
 
 #[wasm_bindgen(js_name = getLaneSpecs)]
 pub fn get_lane_specs(tags: JsValue, config: JsValue) -> Result<String, JsValue> {
-    abstutil::logger::setup();
+    SETUP_LOGGER.call_once(|| console_log::init_with_level(log::Level::Info).unwrap());
     // Panics shouldn't happen, but if they do, console.log them.
     console_error_panic_hook::set_once();
 

--- a/osm2lanes/Cargo.toml
+++ b/osm2lanes/Cargo.toml
@@ -9,3 +9,6 @@ anyhow = { workspace = true }
 enumset = { version = "1.0.12", features=["serde"] }
 geom = { git = "https://github.com/a-b-street/abstreet" }
 serde = { workspace = true }
+
+[dev-dependencies]
+env_logger = "0.10.1"

--- a/osm2lanes/src/tests.rs
+++ b/osm2lanes/src/tests.rs
@@ -1,10 +1,15 @@
+use std::sync::Once;
+
 use abstutil::Tags;
+use env_logger::{Builder, Env};
 
 use crate::{get_lane_specs_ltr, Direction, DrivingSide, MapConfig};
 
+static SETUP_LOGGER: Once = Once::new();
+
 #[test]
 fn test_osm_to_specs() {
-    abstutil::logger::setup();
+    SETUP_LOGGER.call_once(|| Builder::from_env(Env::default().default_filter_or("info")).init());
 
     let mut ok = true;
     for (url, mut input, driving_side, expected_lt, expected_dir) in vec![

--- a/osm2streets-js/Cargo.toml
+++ b/osm2streets-js/Cargo.toml
@@ -13,12 +13,15 @@ crate-type = ["cdylib", "rlib"]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = { workspace = true }
 console_error_panic_hook = "0.1.6"
+console_log = "1.0.0"
 geom = { git = "https://github.com/a-b-street/abstreet" }
 experimental = { path = "../experimental" }
 # TODO Upstream this in abstutil crate. WASM is missing some runtime dep otherwise.
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
+log = "0.4.20"
 osm2streets = { path = "../osm2streets" }
 serde = { workspace = true }
+serde_json = { workspace = true }
 streets_reader = { path = "../streets_reader" }
 wasm-bindgen = "0.2.84"
 serde-wasm-bindgen = "0.5.0"

--- a/osm2streets/src/ids.rs
+++ b/osm2streets/src/ids.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use abstutil::{deserialize_usize, serialize_usize};
 use serde::{Deserialize, Serialize};
 
+use crate::utils::{deserialize_usize, serialize_usize};
 use crate::Road;
 
 /// Opaque and non-contiguous

--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use abstutil::{deserialize_btreemap, serialize_btreemap};
 use geom::{Circle, Distance, Polygon, Pt2D};
 use serde::{Deserialize, Serialize};
 
 use osm2lanes::osm;
 
+use crate::utils::{deserialize_btreemap, serialize_btreemap};
 use crate::{DrivingSide, IntersectionID, RoadID, StreetNetwork};
 use TrafficConflict::*;
 

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -7,8 +7,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use abstutil::{deserialize_btreemap, serialize_btreemap};
 use geom::{GPSBounds, PolyLine, Polygon, Pt2D};
+
+use self::utils::{deserialize_btreemap, serialize_btreemap};
 
 pub use self::geometry::{intersection_polygon, InputRoad};
 pub(crate) use self::ids::RoadWithEndpoints;
@@ -40,6 +41,7 @@ mod render;
 mod road;
 mod transform;
 mod types;
+pub mod utils;
 mod validate;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/osm2streets/src/types.rs
+++ b/osm2streets/src/types.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use abstutil::{deserialize_btreemap, serialize_btreemap, Tags};
+use abstutil::Tags;
+
+use crate::utils::{deserialize_btreemap, serialize_btreemap};
 
 /// None corresponds to the native name
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]

--- a/osm2streets/src/utils.rs
+++ b/osm2streets/src/utils.rs
@@ -1,0 +1,64 @@
+// Copied from https://github.com/a-b-street/abstreet/tree/main/abstutil/src to reduce dependencies
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Format a number with commas
+pub fn prettyprint_usize(x: usize) -> String {
+    let num = format!("{}", x);
+    let mut result = String::new();
+    let mut i = num.len();
+    for c in num.chars() {
+        result.push(c);
+        i -= 1;
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+    }
+    result
+}
+
+/// Serializes a `usize` as a `u32` to save space. Useful when you need `usize` for indexing, but
+/// the values don't exceed 2^32.
+pub fn serialize_usize<S: Serializer>(x: &usize, s: S) -> Result<S::Ok, S::Error> {
+    if let Ok(x) = u32::try_from(*x) {
+        x.serialize(s)
+    } else {
+        Err(serde::ser::Error::custom(format!("{} can't fit in u32", x)))
+    }
+}
+
+/// Deserializes a `usize` from a `u32`.
+pub fn deserialize_usize<'de, D: Deserializer<'de>>(d: D) -> Result<usize, D::Error> {
+    let x = <u32>::deserialize(d)?;
+    Ok(x as usize)
+}
+
+/// Serializes a BTreeMap as a list of tuples. Necessary when the keys are structs; see
+/// https://github.com/serde-rs/json/issues/402.
+pub fn serialize_btreemap<S: Serializer, K: Serialize, V: Serialize>(
+    map: &BTreeMap<K, V>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    map.iter().collect::<Vec<(_, _)>>().serialize(s)
+}
+
+/// Deserializes a BTreeMap from a list of tuples. Necessary when the keys are structs; see
+/// https://github.com/serde-rs/json/issues/402.
+pub fn deserialize_btreemap<
+    'de,
+    D: Deserializer<'de>,
+    K: Deserialize<'de> + Ord,
+    V: Deserialize<'de>,
+>(
+    d: D,
+) -> Result<BTreeMap<K, V>, D::Error> {
+    let vec = <Vec<(K, V)>>::deserialize(d)?;
+    let mut map = BTreeMap::new();
+    for (k, v) in vec {
+        map.insert(k, v);
+    }
+    Ok(map)
+}

--- a/streets_reader/src/osm_reader/reader.rs
+++ b/streets_reader/src/osm_reader/reader.rs
@@ -4,9 +4,10 @@ use std::iter::Peekable;
 use anyhow::Result;
 use xmlparser::Token;
 
-use abstutil::{prettyprint_usize, Tags, Timer};
+use abstutil::{Tags, Timer};
 use geom::{GPSBounds, LonLat};
 use osm2streets::osm::{NodeID, OsmID, RelationID, WayID};
+use osm2streets::utils::prettyprint_usize;
 
 use super::{Document, Node, Relation, Way};
 

--- a/streets_reader/src/split_ways.rs
+++ b/streets_reader/src/split_ways.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use abstutil::{Counter, Timer};
+use abstutil::Timer;
 use geom::{HashablePt2D, PolyLine, Pt2D};
 use osm2streets::{
     Direction, IntersectionControl, IntersectionID, IntersectionKind, Road, RoadID, StreetNetwork,
@@ -23,14 +23,16 @@ pub fn split_up_roads(
 
     // Create intersections for any points shared by at least 2 roads, and for endpoints of every
     // road.
-    let mut counts_per_pt = Counter::new();
+    let mut count_per_pt = HashMap::new();
     let mut pt_to_intersection_id: HashMap<HashablePt2D, IntersectionID> = HashMap::new();
     timer.start_iter("look for common points", input.roads.len());
     for (_, pts, _) in &input.roads {
         timer.next();
         for (idx, pt) in pts.iter().enumerate() {
             let hash_pt = pt.to_hashable();
-            let count = counts_per_pt.inc(hash_pt);
+            let entry = count_per_pt.entry(hash_pt).or_insert(0);
+            *entry += 1;
+            let count = *entry;
 
             if count == 2 || idx == 0 || idx == pts.len() - 1 {
                 if let Entry::Vacant(entry) = pt_to_intersection_id.entry(hash_pt) {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = { workspace = true }
+env_logger = "0.10.1"
 geom = { git = "https://github.com/a-b-street/abstreet" }
 streets_reader = { path = "../streets_reader" }
 serde = { workspace = true }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,15 +1,22 @@
 #[cfg(test)]
 mod tests {
-    use abstutil::Timer;
+    use std::sync::Once;
+
     use anyhow::{bail, Result};
+    use env_logger::{Builder, Env};
+
+    use abstutil::Timer;
     use experimental::RoadNetwork;
     use geom::LonLat;
     use osm2streets::{MapConfig, Transformation};
 
+    static SETUP_LOGGER: Once = Once::new();
+
     include!(concat!(env!("OUT_DIR"), "/tests.rs"));
 
     fn test(path: &str) -> Result<()> {
-        abstutil::logger::setup();
+        SETUP_LOGGER
+            .call_once(|| Builder::from_env(Env::default().default_filter_or("info")).init());
 
         let mut timer = Timer::new("test osm2streets");
 


### PR DESCRIPTION
Currently there's a circular dependency between this repo and abstreet. This repo uses a bunch of utilities from `abstutil`, and a geometry library `geom` from abstreet. The circular dependency makes it a headache to upgrade things like geo dependencies; it takes a few commits and temporarily leaves things in a partly broken state. I want to fix that.

This is a first step, replacing most of the easy abstutil methods. The harder ones are:
- [Timer](https://github.com/a-b-street/abstreet/blob/main/abstutil/src/time.rs). I've started a new implementation in https://github.com/Urban-Analytics-Technology-Platform/od2net/blob/main/od2net/src/timer.rs, but it has a long way to go
- [Tags](https://github.com/a-b-street/abstreet/blob/main/abstutil/src/collections.rs), a simple string-to-string map with some convenience functions. I want to use something external ideally. We could port over a simplified version here, but I don't want it in `osm2streets::utils`, because then osm2lanes crates have to take a huge dependency.

My next step is likely to split `geom` into its own repo.