### PR TITLE
Porting 3 types of markings from A/B Street to increase visual detail

### DIFF
--- a/web/src/common/layers/RenderLaneMarkings.svelte
+++ b/web/src/common/layers/RenderLaneMarkings.svelte
@@ -30,6 +30,7 @@
           "buffer stripe": general_road_marking,
           "parking hatch": general_road_marking,
           "vehicle stop line": general_road_marking,
+          "sidewalk line": "#BBBBBB",
           "bike stop line": "green",
         },
         "red",

--- a/web/src/common/layers/RenderLaneMarkings.svelte
+++ b/web/src/common/layers/RenderLaneMarkings.svelte
@@ -9,6 +9,8 @@
   $: gj = $network
     ? JSON.parse($network.toLaneMarkingsGeojson())
     : emptyGeojson();
+
+  let general_road_marking = "white";
 </script>
 
 <GeoJSON data={gj}>
@@ -22,11 +24,12 @@
         "type",
         {
           "center line": "yellow",
-          "lane separator": "white",
-          "lane arrow": "white",
-          "buffer edge": "white",
-          "buffer stripe": "white",
-          "vehicle stop line": "white",
+          "lane separator": general_road_marking,
+          "lane arrow": general_road_marking,
+          "buffer edge": general_road_marking,
+          "buffer stripe": general_road_marking,
+          "parking hatch": general_road_marking,
+          "vehicle stop line": general_road_marking,
           "bike stop line": "green",
         },
         "red",

--- a/web/src/common/layers/RenderLaneMarkings.svelte
+++ b/web/src/common/layers/RenderLaneMarkings.svelte
@@ -32,6 +32,7 @@
           "vehicle stop line": general_road_marking,
           "sidewalk line": "#BBBBBB",
           "bike stop line": "green",
+          "path outline": "black",
         },
         "red",
       ),

--- a/web/src/common/layers/RenderLanePolygons.svelte
+++ b/web/src/common/layers/RenderLanePolygons.svelte
@@ -35,7 +35,7 @@
           Construction: "#FF6D00",
           LightRail: "#844204",
           Footway: "#DDDDE8",
-          SharedUse: "#E5E1BB",
+          SharedUse: "#DED68A",
           // This is the only type used currently
           "Buffer(Planters)": "#555555",
         },


### PR DESCRIPTION
#240 

Sidewalk lines and path outlines:
![image](https://github.com/a-b-street/osm2streets/assets/1664407/9d99d50a-bf6d-4488-9fa1-b73daecba722)

Parking hatches:
![image](https://github.com/a-b-street/osm2streets/assets/1664407/6bf323df-1690-41d0-ad0b-3d349690aded)

CC @ginnyTheCat