### PR TITLE
Add support to switch times of day in the UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "anyhow",
+ "chrono",
  "enumset",
  "env_logger",
  "geom",
@@ -1108,6 +1109,7 @@ version = "0.1.4"
 dependencies = [
  "abstutil",
  "anyhow",
+ "chrono",
  "console_error_panic_hook",
  "console_log",
  "experimental",

--- a/osm2lanes/Cargo.toml
+++ b/osm2lanes/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = { workspace = true }
+chrono = "0.4.35"
 enumset = { version = "1.0.12", features=["serde"] }
 geom = { workspace = true }
 muv-osm = { git = "https://gitlab.com/LeLuxNet/Muv", features = ["serde", "lanes"] }

--- a/osm2lanes/src/lib.rs
+++ b/osm2lanes/src/lib.rs
@@ -9,6 +9,7 @@ mod placement;
 mod tests;
 mod turns;
 
+use chrono::NaiveDateTime;
 use enumset::{EnumSet, EnumSetType};
 use muv_osm::lanes::Lane;
 use std::fmt;
@@ -558,6 +559,7 @@ pub struct MapConfig {
     /// OSM railway=rail will be included as light rail if so. Cosmetic only.
     pub include_railroads: bool,
     pub inferred_kerbs: bool,
+    pub date_time: Option<NaiveDateTime>,
 }
 
 impl MapConfig {
@@ -572,6 +574,7 @@ impl MapConfig {
             turn_on_red: true,
             include_railroads: true,
             inferred_kerbs: true,
+            date_time: None,
         }
     }
 }

--- a/osm2streets-js/Cargo.toml
+++ b/osm2streets-js/Cargo.toml
@@ -25,3 +25,4 @@ serde_json = { workspace = true }
 streets_reader = { path = "../streets_reader" }
 wasm-bindgen = "0.2.84"
 serde-wasm-bindgen = "0.5.0"
+chrono = "0.4.35"

--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Once;
 
 use abstutil::{Tags, Timer};
+use chrono::NaiveDateTime;
 use geom::{Distance, LonLat, PolyLine, Polygon};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -19,7 +20,11 @@ pub struct ImportOptions {
     dual_carriageway_experiment: bool,
     sidepath_zipping_experiment: bool,
     inferred_sidewalks: bool,
+<<<<<<< HEAD
     inferred_kerbs: bool,
+=======
+    date_time: Option<NaiveDateTime>,
+>>>>>>> cedde4a (Add time output)
 }
 
 #[wasm_bindgen]
@@ -58,7 +63,11 @@ impl JsStreetNetwork {
 
         let mut cfg = MapConfig::default();
         cfg.inferred_sidewalks = input.inferred_sidewalks;
+<<<<<<< HEAD
         cfg.inferred_kerbs = input.inferred_kerbs;
+=======
+        cfg.date_time = input.date_time;
+>>>>>>> cedde4a (Add time output)
 
         let mut timer = Timer::throwaway();
         let (mut street_network, doc) =

--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -20,11 +20,8 @@ pub struct ImportOptions {
     dual_carriageway_experiment: bool,
     sidepath_zipping_experiment: bool,
     inferred_sidewalks: bool,
-<<<<<<< HEAD
     inferred_kerbs: bool,
-=======
     date_time: Option<NaiveDateTime>,
->>>>>>> cedde4a (Add time output)
 }
 
 #[wasm_bindgen]
@@ -63,11 +60,8 @@ impl JsStreetNetwork {
 
         let mut cfg = MapConfig::default();
         cfg.inferred_sidewalks = input.inferred_sidewalks;
-<<<<<<< HEAD
         cfg.inferred_kerbs = input.inferred_kerbs;
-=======
         cfg.date_time = input.date_time;
->>>>>>> cedde4a (Add time output)
 
         let mut timer = Timer::throwaway();
         let (mut street_network, doc) =

--- a/web/src/common/import/ImportControls.svelte
+++ b/web/src/common/import/ImportControls.svelte
@@ -22,6 +22,7 @@
     sidepath_zipping_experiment: boolean;
     inferred_sidewalks: boolean;
     inferred_kerbs: boolean;
+    date_time: string | undefined;
   }
 
   type Imported =

--- a/web/src/common/import/Osm2streetsSettings.svelte
+++ b/web/src/common/import/Osm2streetsSettings.svelte
@@ -34,10 +34,6 @@
     />
     Enable sidepath zipping experiment
   </label>
-  <label>
-    <input type="datetime-local" bind:value={date_time} />
-    Change the time of date
-  </label>
   <div>
     Sidewalks:
     <label>
@@ -61,6 +57,12 @@
     <input type="checkbox" bind:checked={settings.inferred_kerbs} />
     Infer kerbs
   </label>
+  <div>
+    Change the time and date:
+    <label>
+      <input type="datetime-local" bind:value={date_time} />
+    </label>
+  </div>
 </details>
 
 <style>
@@ -83,6 +85,9 @@
     display: block;
     margin-inline-start: 1em;
     text-indent: -1em;
+  }
+  div {
+    padding: 0.25em 0;
   }
   div > label {
     white-space: nowrap;

--- a/web/src/common/import/Osm2streetsSettings.svelte
+++ b/web/src/common/import/Osm2streetsSettings.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
+  import LanePopup from "../../street-explorer/LanePopup.svelte";
+
   export let settings = {
     debug_each_step: false,
     dual_carriageway_experiment: false,
     sidepath_zipping_experiment: false,
     inferred_sidewalks: false,
     inferred_kerbs: true,
+    date_time: undefined as string | undefined,
   };
+
+  let date_time: string;
+  $: settings.date_time = date_time && date_time + ":00";
 </script>
 
 <details>
@@ -27,6 +33,10 @@
       bind:checked={settings.sidepath_zipping_experiment}
     />
     Enable sidepath zipping experiment
+  </label>
+  <label>
+    <input type="datetime-local" bind:value={date_time} />
+    Change the time of date
   </label>
   <div>
     Sidewalks:


### PR DESCRIPTION
Not sure whether this is in the scope of osm2streets. In tried it some days ago as a demo and it worked quite well, so before it rots in my local braches you can at least have a look at it.

A [pedestrian tunnel below a train station](https://www.openstreetmap.org/way/29049225) closed at night:
![tunnel marked as no access](https://github.com/a-b-street/osm2streets/assets/35173023/f4e22204-7ee2-4b7d-9040-090850ee2623)

Open during the day:
![tunnel marked as cycleway](https://github.com/a-b-street/osm2streets/assets/35173023/a6d94179-965f-4c97-be9d-988f6372e0c4)
