### PR TITLE
Start handling highway=crossing nodes

### DIFF
--- a/osm2streets/src/intersection.rs
+++ b/osm2streets/src/intersection.rs
@@ -29,6 +29,8 @@ pub struct Intersection {
     pub roads: Vec<RoadID>,
     pub movements: Vec<Movement>,
 
+    pub crossing: Option<Crossing>,
+
     // true if src_i matches this intersection (or the deleted/consolidated one, whatever)
     // TODO Store start/end trim distance on _every_ road
     #[serde(
@@ -88,6 +90,25 @@ pub enum IntersectionControl {
     Construction,
 }
 
+/// When an Intersection is a pedestrian (and/or bike) crossing, represents details.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Crossing {
+    pub kind: CrossingKind,
+    /// Is there a pedestrian/traffic island/refuge?
+    pub has_island: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum CrossingKind {
+    /// Controlled by a traffic signal
+    Signalized,
+    /// Often a zebra crossing. The semantics of which road user has priority is region-specific.
+    Marked,
+    /// No paint markings, but maybe still a de facto crossing due to a nearby curb cut or an
+    /// island on this crossing.
+    Unmarked,
+}
+
 /// The path that some group of adjacent lanes of traffic can take through an intersection.
 pub type Movement = (RoadID, RoadID);
 
@@ -140,6 +161,7 @@ impl StreetNetwork {
                 // Filled out later
                 roads: Vec::new(),
                 movements: Vec::new(),
+                crossing: None,
                 trim_roads_for_merging: BTreeMap::new(),
             },
         );

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -15,7 +15,8 @@ pub use self::geometry::{intersection_polygon, InputRoad};
 pub(crate) use self::ids::RoadWithEndpoints;
 pub use self::ids::{CommonEndpoint, IntersectionID, LaneID, RoadID};
 pub use self::intersection::{
-    Intersection, IntersectionControl, IntersectionKind, Movement, TrafficConflict,
+    Crossing, CrossingKind, Intersection, IntersectionControl, IntersectionKind, Movement,
+    TrafficConflict,
 };
 pub use self::operations::zip_sidepath::Sidepath;
 pub use self::render::Filter;

--- a/osm2streets/src/render/mod.rs
+++ b/osm2streets/src/render/mod.rs
@@ -78,6 +78,7 @@ impl StreetNetwork {
             );
             f.set_property("intersection_kind", format!("{:?}", intersection.kind));
             f.set_property("control", format!("{:?}", intersection.control));
+            f.set_property("crossing", serde_json::to_value(&intersection.crossing)?);
             f.set_property(
                 "movements",
                 Value::Array(

--- a/streets_reader/src/split_ways.rs
+++ b/streets_reader/src/split_ways.rs
@@ -286,12 +286,14 @@ pub fn split_up_roads(
         }
     }
 
-    timer.start_iter(
-        "match signalized crossings",
-        input.signalized_crossings.len(),
-    );
-    for pt in input.signalized_crossings {
+    timer.start_iter("match crossings", input.crossings.len());
+    for (pt, crossing) in input.crossings {
         timer.next();
+
+        if let Some(i) = pt_to_intersection_id.get(&pt) {
+            streets.intersections.get_mut(&i).unwrap().crossing = Some(crossing);
+        }
+
         if let Some(road) = pt_to_road.get(&pt).and_then(|r| streets.roads.get_mut(r)) {
             if let Some((dist, _)) = road.reference_line.dist_along_of_point(pt.to_pt2d()) {
                 // We don't know the direction. Arbitrarily snap to the start or end if it's within

--- a/tests/src/arizona_highways/geometry.json
+++ b/tests/src/arizona_highways/geometry.json
@@ -3475,6 +3475,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Fork",
         "movements": [
@@ -3522,6 +3523,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Fork",
         "movements": [
@@ -3565,6 +3567,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Connection",
         "movements": [
@@ -3607,6 +3610,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3645,6 +3649,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3683,6 +3688,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Connection",
         "movements": [
@@ -3725,6 +3731,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Connection",
         "movements": [
@@ -3767,6 +3774,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Connection",
         "movements": [
@@ -3809,6 +3817,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3847,6 +3856,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [
@@ -3889,6 +3899,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [
@@ -3931,6 +3942,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3973,6 +3985,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Fork",
         "movements": [
@@ -4016,6 +4029,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4058,6 +4072,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Fork",
         "movements": [
@@ -4101,6 +4116,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [
@@ -4155,6 +4171,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Fork",
         "movements": [
@@ -4199,6 +4216,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4237,6 +4255,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4283,6 +4302,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4338,6 +4358,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4383,6 +4404,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4425,6 +4447,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4472,6 +4495,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4510,6 +4534,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4552,6 +4577,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4599,6 +4625,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4645,6 +4672,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4708,6 +4736,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4772,6 +4801,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4837,6 +4867,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Fork",
         "movements": [
@@ -4899,6 +4930,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4943,6 +4975,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Connection",
         "movements": [
@@ -4985,6 +5018,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5039,6 +5073,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5146,6 +5181,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5210,6 +5246,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Fork",
         "movements": [
@@ -5262,6 +5299,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Fork",
         "movements": [
@@ -5313,6 +5351,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Fork",
         "movements": [
@@ -5364,6 +5403,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Fork",
         "movements": [
@@ -5407,6 +5447,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5445,6 +5486,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5483,6 +5525,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5529,6 +5572,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Fork",
         "movements": [
@@ -5572,6 +5616,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Connection",
         "movements": [
@@ -5614,6 +5659,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [
@@ -5656,6 +5702,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5694,6 +5741,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [
@@ -5736,6 +5784,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [
@@ -5778,6 +5827,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5816,6 +5866,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Connection",
         "movements": [
@@ -5862,6 +5913,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Fork",
         "movements": [
@@ -5905,6 +5957,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [
@@ -5947,6 +6000,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [
@@ -5989,6 +6043,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [
@@ -6031,6 +6086,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6069,6 +6125,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [
@@ -6115,6 +6172,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6164,6 +6222,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6209,6 +6268,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6247,6 +6307,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6285,6 +6346,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [
@@ -6327,6 +6389,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6365,6 +6428,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6403,6 +6467,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6441,6 +6506,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 73,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6479,6 +6545,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 74,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6526,6 +6593,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Fork",
         "movements": [
@@ -6570,6 +6638,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6608,6 +6677,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/aurora_sausage_link/geometry.json
+++ b/tests/src/aurora_sausage_link/geometry.json
@@ -2368,6 +2368,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2415,6 +2416,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2457,6 +2459,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Connection",
         "movements": [
@@ -2500,6 +2503,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2538,6 +2542,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2576,6 +2581,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2614,6 +2620,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2656,6 +2663,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Connection",
         "movements": [
@@ -2703,6 +2711,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2751,6 +2760,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2795,6 +2805,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2835,6 +2846,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2875,6 +2887,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2919,6 +2932,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2975,6 +2989,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3020,6 +3035,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3072,6 +3088,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 20,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3115,6 +3135,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3155,6 +3176,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3211,6 +3233,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3254,6 +3280,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3302,6 +3329,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3354,6 +3382,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3402,6 +3431,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3442,6 +3472,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3484,6 +3515,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3524,6 +3556,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3564,6 +3597,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3608,6 +3642,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3652,6 +3687,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3704,6 +3740,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3744,6 +3781,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3794,6 +3832,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Unmarked"
+        },
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [
@@ -3852,6 +3894,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Unmarked"
+        },
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [
@@ -3906,6 +3952,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Unmarked"
+        },
         "id": 42,
         "intersection_kind": "Connection",
         "movements": [
@@ -3948,6 +3998,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4020,6 +4071,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Unmarked"
+        },
         "id": 45,
         "intersection_kind": "Fork",
         "movements": [
@@ -4065,6 +4120,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4105,6 +4161,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4159,6 +4216,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 49,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4202,6 +4263,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4240,6 +4302,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4290,6 +4353,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4330,6 +4394,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4368,6 +4433,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4406,6 +4472,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4446,6 +4513,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4484,6 +4552,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/borough_sausage_links/geometry.json
+++ b/tests/src/borough_sausage_links/geometry.json
@@ -4882,6 +4882,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -4922,6 +4923,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4960,6 +4962,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5006,6 +5009,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5058,6 +5062,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Connection",
         "movements": [
@@ -5101,6 +5106,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5139,6 +5145,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5177,6 +5184,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5225,6 +5233,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5265,6 +5274,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5303,6 +5313,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5347,6 +5358,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5387,6 +5399,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5435,6 +5448,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5483,6 +5497,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5523,6 +5538,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5561,6 +5577,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5601,6 +5618,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5643,6 +5661,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [
@@ -5690,6 +5709,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -5745,6 +5765,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5810,6 +5831,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5859,6 +5881,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [
@@ -5906,6 +5929,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Connection",
         "movements": [
@@ -5965,6 +5989,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6014,6 +6039,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [
@@ -6061,6 +6087,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Fork",
         "movements": [
@@ -6120,6 +6147,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6181,6 +6209,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6234,6 +6263,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Fork",
         "movements": [
@@ -6281,6 +6311,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Fork",
         "movements": [
@@ -6340,6 +6371,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6388,6 +6420,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6444,6 +6477,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 36,
         "intersection_kind": "Connection",
         "movements": [
@@ -6486,6 +6523,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6526,6 +6564,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6586,6 +6625,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [
@@ -6629,6 +6672,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6669,6 +6713,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6709,6 +6754,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6765,6 +6811,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 44,
         "intersection_kind": "Connection",
         "movements": [
@@ -6807,6 +6857,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6863,6 +6914,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [
@@ -6906,6 +6958,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6958,6 +7011,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7007,6 +7061,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7059,6 +7114,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7107,6 +7163,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7171,6 +7228,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7216,6 +7274,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7254,6 +7313,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [
@@ -7308,6 +7368,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [
@@ -7354,6 +7418,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Fork",
         "movements": [
@@ -7417,6 +7482,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [
@@ -7461,6 +7527,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7501,6 +7568,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7541,6 +7609,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7581,6 +7650,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [
@@ -7631,6 +7701,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "Fork",
         "movements": [
@@ -7675,6 +7746,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7713,6 +7785,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7753,6 +7826,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 73,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7791,6 +7865,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7843,6 +7918,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 76,
         "intersection_kind": "Connection",
         "movements": [
@@ -7885,6 +7964,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7925,6 +8005,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7989,6 +8070,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "Connection",
         "movements": [
@@ -8032,6 +8114,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8072,6 +8155,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8128,6 +8212,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 83,
         "intersection_kind": "Connection",
         "movements": [
@@ -8170,6 +8258,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8230,6 +8319,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 85,
         "intersection_kind": "Connection",
         "movements": [
@@ -8288,6 +8381,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 86,
         "intersection_kind": "Connection",
         "movements": [
@@ -8330,6 +8427,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8374,6 +8472,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [
@@ -8437,6 +8536,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 91,
         "intersection_kind": "Connection",
         "movements": [
@@ -8481,6 +8581,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 92,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8521,6 +8622,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8559,6 +8661,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8615,6 +8718,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 95,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8659,6 +8763,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8703,6 +8808,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8757,6 +8863,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "Connection",
         "movements": [

--- a/tests/src/bristol_contraflow_cycleway/geometry.json
+++ b/tests/src/bristol_contraflow_cycleway/geometry.json
@@ -1375,6 +1375,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1413,6 +1414,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1451,6 +1453,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1497,6 +1500,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1544,6 +1548,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1582,6 +1587,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1620,6 +1626,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -1660,6 +1667,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1706,6 +1714,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Fork",
         "movements": [
@@ -1750,6 +1759,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1788,6 +1798,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -1836,6 +1847,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Fork",
         "movements": [
@@ -1900,6 +1912,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1946,6 +1959,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1984,6 +1998,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -2024,6 +2039,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2074,6 +2090,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 20,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2123,6 +2143,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2163,6 +2184,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2201,6 +2223,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2239,6 +2262,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2277,6 +2301,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2319,6 +2344,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Connection",
         "movements": [
@@ -2366,6 +2392,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Connection",
         "movements": [
@@ -2417,6 +2444,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [
@@ -2468,6 +2496,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2536,6 +2565,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2591,6 +2621,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [
@@ -2646,6 +2677,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Fork",
         "movements": [
@@ -2690,6 +2722,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -2730,6 +2763,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/bristol_sausage_links/geometry.json
+++ b/tests/src/bristol_sausage_links/geometry.json
@@ -1823,6 +1823,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1865,6 +1866,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -1909,6 +1911,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1951,6 +1954,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -1995,6 +1999,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2041,6 +2046,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2086,6 +2092,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2132,6 +2139,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2172,6 +2180,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2218,6 +2227,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2263,6 +2273,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2301,6 +2312,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2347,6 +2359,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2394,6 +2407,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2440,6 +2454,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2480,6 +2495,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Connection",
         "movements": [
@@ -2526,6 +2542,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Fork",
         "movements": [
@@ -2570,6 +2587,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [
@@ -2628,6 +2646,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2672,6 +2691,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2714,6 +2734,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [
@@ -2768,6 +2789,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -2826,6 +2848,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2878,6 +2901,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Fork",
         "movements": [
@@ -2938,6 +2962,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2999,6 +3024,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [
@@ -3057,6 +3083,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3102,6 +3129,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3140,6 +3168,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3182,6 +3211,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [
@@ -3228,6 +3258,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [
@@ -3278,6 +3309,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [
@@ -3322,6 +3354,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3362,6 +3395,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3418,6 +3452,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Connection",
         "movements": [
@@ -3460,6 +3495,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/cycleway_rejoin_road/geometry.json
+++ b/tests/src/cycleway_rejoin_road/geometry.json
@@ -3192,6 +3192,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3239,6 +3240,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3285,6 +3287,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3354,6 +3357,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3400,6 +3404,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3446,6 +3451,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3499,6 +3505,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3547,6 +3554,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Fork",
         "movements": [
@@ -3590,6 +3598,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Connection",
         "movements": [
@@ -3636,6 +3645,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3683,6 +3693,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3729,6 +3740,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3776,6 +3788,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3814,6 +3827,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3852,6 +3866,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Connection",
         "movements": [
@@ -3894,6 +3909,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3936,6 +3952,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [
@@ -3987,6 +4004,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Fork",
         "movements": [
@@ -4030,6 +4048,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -4074,6 +4093,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [
@@ -4116,6 +4136,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -4158,6 +4179,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Connection",
         "movements": [
@@ -4204,6 +4226,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4249,6 +4272,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4299,6 +4323,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [
@@ -4358,6 +4383,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4404,6 +4430,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4446,6 +4473,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4490,6 +4518,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4538,6 +4567,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [
@@ -4581,6 +4611,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4627,6 +4658,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [
@@ -4670,6 +4702,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4712,6 +4745,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [
@@ -4755,6 +4789,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4797,6 +4832,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4837,6 +4873,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4877,6 +4914,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4917,6 +4955,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4955,6 +4994,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5011,6 +5051,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5059,6 +5100,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5097,6 +5139,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5147,6 +5190,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5194,6 +5238,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -5238,6 +5283,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [
@@ -5284,6 +5330,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [
@@ -5326,6 +5373,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5364,6 +5412,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5402,6 +5451,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5440,6 +5490,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5482,6 +5533,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [
@@ -5524,6 +5576,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5564,6 +5617,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5602,6 +5656,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5640,6 +5695,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5678,6 +5734,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5730,6 +5787,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5782,6 +5840,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [
@@ -5832,6 +5891,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5872,6 +5932,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5910,6 +5971,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5952,6 +6014,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5992,6 +6055,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6044,6 +6108,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 69,
         "intersection_kind": "Connection",
         "movements": [
@@ -6087,6 +6155,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6143,6 +6212,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "Connection",
         "movements": [

--- a/tests/src/degenerate_bug/geometry.json
+++ b/tests/src/degenerate_bug/geometry.json
@@ -530,6 +530,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -568,6 +569,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -606,6 +608,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -652,6 +655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -707,6 +711,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Intersection",
         "movements": [
@@ -762,6 +767,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -810,6 +816,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Fork",
         "movements": [
@@ -854,6 +861,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -902,6 +910,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Intersection",
         "movements": [
@@ -949,6 +958,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Terminus",
         "movements": [],

--- a/tests/src/frederiksted/geometry.json
+++ b/tests/src/frederiksted/geometry.json
@@ -4643,6 +4643,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4692,6 +4693,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4753,6 +4755,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4810,6 +4813,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -4854,6 +4858,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4901,6 +4906,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -4949,6 +4955,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5000,6 +5007,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Fork",
         "movements": [
@@ -5048,6 +5056,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5111,6 +5120,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5172,6 +5182,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5235,6 +5246,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5304,6 +5316,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5373,6 +5386,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5442,6 +5456,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5499,6 +5514,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5546,6 +5562,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5593,6 +5610,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5644,6 +5662,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5711,6 +5730,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5780,6 +5800,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5849,6 +5870,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5918,6 +5940,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5971,6 +5994,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -6019,6 +6043,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6086,6 +6111,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6159,6 +6185,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6224,6 +6251,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6293,6 +6321,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6346,6 +6375,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -6394,6 +6424,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6441,6 +6472,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -6489,6 +6521,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6536,6 +6569,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -6576,6 +6610,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -6620,6 +6655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6675,6 +6711,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6732,6 +6769,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6779,6 +6817,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -6827,6 +6866,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6882,6 +6922,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6933,6 +6974,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6984,6 +7026,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7031,6 +7074,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -7071,6 +7115,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -7123,6 +7168,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7176,6 +7222,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -7224,6 +7271,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7287,6 +7335,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7360,6 +7409,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7429,6 +7479,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7502,6 +7553,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7575,6 +7627,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7628,6 +7681,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7668,6 +7722,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7711,6 +7766,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7751,6 +7807,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7799,6 +7856,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7847,6 +7905,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7890,6 +7949,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -7934,6 +7994,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7982,6 +8043,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8025,6 +8087,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8072,6 +8135,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8112,6 +8176,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8160,6 +8225,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8215,6 +8281,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8266,6 +8333,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Fork",
         "movements": [
@@ -8314,6 +8382,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Fork",
         "movements": [
@@ -8366,6 +8435,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8413,6 +8483,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -8453,6 +8524,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "Terminus",
         "movements": [],

--- a/tests/src/fremantle_placement/geometry.json
+++ b/tests/src/fremantle_placement/geometry.json
@@ -2796,6 +2796,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Fork",
         "movements": [
@@ -2843,6 +2844,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -2894,6 +2896,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Fork",
         "movements": [
@@ -2937,6 +2940,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2983,6 +2987,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Fork",
         "movements": [
@@ -3042,6 +3047,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3087,6 +3093,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3133,6 +3140,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Fork",
         "movements": [
@@ -3184,6 +3192,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3228,6 +3237,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3266,6 +3276,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3320,6 +3331,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [
@@ -3366,6 +3378,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3406,6 +3419,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3466,6 +3480,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3520,6 +3535,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -3579,6 +3595,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [
@@ -3625,6 +3645,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Fork",
         "movements": [
@@ -3684,6 +3705,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3732,6 +3754,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Fork",
         "movements": [
@@ -3783,6 +3806,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Fork",
         "movements": [
@@ -3830,6 +3854,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Fork",
         "movements": [
@@ -3873,6 +3898,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3927,6 +3953,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3979,6 +4006,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Fork",
         "movements": [
@@ -4022,6 +4050,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4060,6 +4089,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4102,6 +4132,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Fork",
         "movements": [
@@ -4161,6 +4192,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [
@@ -4203,6 +4238,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [
@@ -4249,6 +4285,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4293,6 +4330,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4335,6 +4373,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Fork",
         "movements": [
@@ -4378,6 +4417,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4416,6 +4456,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4470,6 +4511,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [
@@ -4512,6 +4557,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [
@@ -4570,6 +4616,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4632,6 +4679,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4677,6 +4725,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4715,6 +4764,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4753,6 +4803,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4791,6 +4842,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Connection",
         "movements": [
@@ -4833,6 +4885,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4871,6 +4924,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4909,6 +4963,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4949,6 +5004,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5003,6 +5059,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [
@@ -5085,6 +5142,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5147,6 +5205,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [

--- a/tests/src/i5_exit_ramp/geometry.json
+++ b/tests/src/i5_exit_ramp/geometry.json
@@ -6943,6 +6943,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Fork",
         "movements": [
@@ -6986,6 +6987,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7028,6 +7030,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Fork",
         "movements": [
@@ -7071,6 +7074,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7109,6 +7113,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7169,6 +7174,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7216,6 +7222,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7258,6 +7265,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7298,6 +7306,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7338,6 +7347,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7381,6 +7391,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7419,6 +7430,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7457,6 +7469,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7497,6 +7510,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7535,6 +7549,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7585,6 +7600,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7632,6 +7648,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7694,6 +7711,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7756,6 +7774,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7809,6 +7828,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7856,6 +7876,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7922,6 +7943,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7979,6 +8001,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8022,6 +8045,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [
@@ -8064,6 +8088,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -8124,6 +8149,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [
@@ -8166,6 +8192,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8204,6 +8231,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8244,6 +8272,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8284,6 +8313,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8322,6 +8352,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -8370,6 +8401,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8414,6 +8446,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [
@@ -8456,6 +8489,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8494,6 +8528,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8532,6 +8567,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8595,6 +8631,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 37,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8639,6 +8679,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8677,6 +8718,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8715,6 +8757,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8753,6 +8796,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8793,6 +8837,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8831,6 +8876,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8889,6 +8935,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8937,6 +8984,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8981,6 +9029,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9021,6 +9070,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9067,6 +9117,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9111,6 +9162,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9151,6 +9203,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9189,6 +9242,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9229,6 +9283,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9283,6 +9338,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [
@@ -9334,6 +9393,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9379,6 +9439,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9417,6 +9478,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9459,6 +9521,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9515,6 +9578,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9555,6 +9619,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9593,6 +9658,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9635,6 +9701,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9682,6 +9749,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9720,6 +9788,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9770,6 +9839,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9814,6 +9884,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9862,6 +9933,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9902,6 +9974,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9946,6 +10019,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9986,6 +10060,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10058,6 +10133,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [
@@ -10109,6 +10185,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 74,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10149,6 +10226,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10187,6 +10265,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10233,6 +10312,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10285,6 +10365,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10325,6 +10406,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10367,6 +10449,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10411,6 +10494,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10459,6 +10543,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10499,6 +10584,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 83,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10553,6 +10639,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10593,6 +10680,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10633,6 +10721,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10673,6 +10762,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 88,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10725,6 +10815,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 89,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10777,6 +10871,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [
@@ -10835,6 +10933,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 91,
         "intersection_kind": "Connection",
         "movements": [
@@ -10877,6 +10979,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 92,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10917,6 +11020,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10973,6 +11077,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 94,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11016,6 +11124,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 95,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11060,6 +11169,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11100,6 +11210,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11156,6 +11267,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11208,6 +11320,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 99,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11248,6 +11361,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11288,6 +11402,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -11326,6 +11441,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 103,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11378,6 +11494,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 104,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11421,6 +11541,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 105,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11468,6 +11589,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 106,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11508,6 +11630,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 107,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11556,6 +11679,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 108,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11616,6 +11740,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 109,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11675,6 +11803,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 110,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11718,6 +11850,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11766,6 +11899,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11814,6 +11948,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11866,6 +12001,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 115,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11906,6 +12042,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 116,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11946,6 +12083,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 117,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12000,6 +12138,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 118,
         "intersection_kind": "Connection",
         "movements": [
@@ -12042,6 +12184,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 119,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12088,6 +12231,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 120,
         "intersection_kind": "Intersection",
         "movements": [
@@ -12131,6 +12278,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 121,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12175,6 +12323,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 122,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12215,6 +12364,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 123,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12263,6 +12413,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 124,
         "intersection_kind": "Intersection",
         "movements": [
@@ -12310,6 +12461,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 125,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12350,6 +12502,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 126,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12388,6 +12541,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12426,6 +12580,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 129,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12474,6 +12629,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 130,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12514,6 +12670,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 131,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12552,6 +12709,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 132,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12590,6 +12748,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 133,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12628,6 +12787,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 135,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12666,6 +12826,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 136,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -12708,6 +12869,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 137,
         "intersection_kind": "Intersection",
         "movements": [
@@ -12769,6 +12931,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 138,
         "intersection_kind": "Connection",
         "movements": [
@@ -12811,6 +12974,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 139,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12855,6 +13019,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 140,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12895,6 +13060,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 141,
         "intersection_kind": "Connection",
         "movements": [],
@@ -12943,6 +13109,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 143,
         "intersection_kind": "Intersection",
         "movements": [
@@ -12994,6 +13161,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 145,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -13034,6 +13205,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 146,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13090,6 +13262,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 147,
         "intersection_kind": "Intersection",
         "movements": [
@@ -13133,6 +13309,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 148,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13187,6 +13364,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 149,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13235,6 +13413,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 150,
         "intersection_kind": "Intersection",
         "movements": [
@@ -13278,6 +13457,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 151,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/kingsway_junction/geometry.json
+++ b/tests/src/kingsway_junction/geometry.json
@@ -6243,6 +6243,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 0,
         "intersection_kind": "Connection",
         "movements": [
@@ -6293,6 +6297,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -6376,6 +6381,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Connection",
         "movements": [
@@ -6424,6 +6430,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -6479,6 +6486,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6529,6 +6537,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Fork",
         "movements": [
@@ -6576,6 +6585,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Fork",
         "movements": [
@@ -6643,6 +6653,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6688,6 +6699,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6726,6 +6738,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6778,6 +6791,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [
@@ -6820,6 +6834,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6862,6 +6877,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Fork",
         "movements": [
@@ -6913,6 +6929,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6957,6 +6974,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6995,6 +7013,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7045,6 +7064,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7096,6 +7116,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7143,6 +7164,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7185,6 +7207,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Fork",
         "movements": [
@@ -7229,6 +7252,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7267,6 +7291,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [
@@ -7365,6 +7390,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Fork",
         "movements": [
@@ -7413,6 +7439,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7459,6 +7486,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7503,6 +7531,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7543,6 +7572,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -7587,6 +7617,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7627,6 +7658,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7675,6 +7707,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7715,6 +7748,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7773,6 +7807,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [
@@ -7816,6 +7851,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7854,6 +7890,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [
@@ -7896,6 +7933,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [
@@ -7938,6 +7976,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [
@@ -7980,6 +8019,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Connection",
         "movements": [
@@ -8022,6 +8062,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8076,6 +8117,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8132,6 +8174,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8176,6 +8219,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8220,6 +8264,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [
@@ -8262,6 +8307,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -8302,6 +8348,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8348,6 +8395,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8388,6 +8436,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8428,6 +8477,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8468,6 +8518,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8508,6 +8559,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8552,6 +8604,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8600,6 +8653,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8640,6 +8694,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8680,6 +8735,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8728,6 +8784,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8776,6 +8833,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8829,6 +8887,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8873,6 +8932,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -8913,6 +8973,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8953,6 +9014,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8993,6 +9055,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9039,6 +9102,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9083,6 +9147,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9123,6 +9188,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -9163,6 +9229,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9209,6 +9276,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9249,6 +9317,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9287,6 +9356,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9333,6 +9403,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9389,6 +9460,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 73,
         "intersection_kind": "Connection",
         "movements": [
@@ -9439,6 +9514,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 74,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9491,6 +9567,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9551,6 +9628,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 76,
         "intersection_kind": "Connection",
         "movements": [
@@ -9593,6 +9674,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9647,6 +9729,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 78,
         "intersection_kind": "Connection",
         "movements": [
@@ -9705,6 +9791,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9771,6 +9858,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [
@@ -9821,6 +9912,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9881,6 +9973,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 83,
         "intersection_kind": "Connection",
         "movements": [
@@ -9943,6 +10039,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 84,
         "intersection_kind": "Connection",
         "movements": [
@@ -9993,6 +10093,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10037,6 +10138,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 86,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10093,6 +10195,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [
@@ -10151,6 +10257,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 88,
         "intersection_kind": "Connection",
         "movements": [
@@ -10193,6 +10303,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10233,6 +10344,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10287,6 +10399,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Connection",
         "movements": [
@@ -10330,6 +10443,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10368,6 +10482,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10426,6 +10541,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Marked"
+        },
         "id": 99,
         "intersection_kind": "Connection",
         "movements": [
@@ -10468,6 +10587,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10506,6 +10626,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10566,6 +10687,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 102,
         "intersection_kind": "Connection",
         "movements": [
@@ -10624,6 +10749,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 103,
         "intersection_kind": "Connection",
         "movements": [
@@ -10678,6 +10807,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 104,
         "intersection_kind": "Connection",
         "movements": [
@@ -10720,6 +10853,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 105,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10758,6 +10892,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 106,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10804,6 +10939,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 107,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10844,6 +10980,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 108,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10898,6 +11035,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 110,
         "intersection_kind": "Connection",
         "movements": [
@@ -10941,6 +11079,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "Connection",
         "movements": [],
@@ -10981,6 +11120,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11037,6 +11177,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 113,
         "intersection_kind": "Connection",
         "movements": [
@@ -11080,6 +11221,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11120,6 +11262,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 115,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -11158,6 +11301,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 117,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11218,6 +11362,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 118,
         "intersection_kind": "Connection",
         "movements": [
@@ -11261,6 +11409,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 119,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -11299,6 +11448,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 120,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -11345,6 +11495,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 122,
         "intersection_kind": "Connection",
         "movements": [],
@@ -11385,6 +11536,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 126,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -11423,6 +11575,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -11473,6 +11626,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 128,
         "intersection_kind": "Intersection",
         "movements": [

--- a/tests/src/leeds_cycleway/geometry.json
+++ b/tests/src/leeds_cycleway/geometry.json
@@ -22977,6 +22977,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Fork",
         "movements": [
@@ -23020,6 +23021,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23062,6 +23064,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Fork",
         "movements": [
@@ -23105,6 +23108,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Connection",
         "movements": [
@@ -23175,6 +23179,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Intersection",
         "movements": [
@@ -23231,6 +23236,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -23278,6 +23284,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Fork",
         "movements": [
@@ -23325,6 +23332,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Fork",
         "movements": [
@@ -23380,6 +23388,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Connection",
         "movements": [
@@ -23423,6 +23432,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23473,6 +23483,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Intersection",
         "movements": [
@@ -23522,6 +23533,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [
@@ -23572,6 +23584,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -23628,6 +23641,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Intersection",
         "movements": [
@@ -23673,6 +23687,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23719,6 +23734,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -23766,6 +23782,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Fork",
         "movements": [
@@ -23809,6 +23826,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23847,6 +23865,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23885,6 +23904,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23923,6 +23943,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -23963,6 +23984,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24001,6 +24023,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24041,6 +24064,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24081,6 +24105,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24123,6 +24148,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Fork",
         "movements": [
@@ -24170,6 +24196,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24215,6 +24242,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24269,6 +24297,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Fork",
         "movements": [
@@ -24316,6 +24345,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24356,6 +24386,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24398,6 +24429,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [
@@ -24444,6 +24476,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Fork",
         "movements": [
@@ -24488,6 +24521,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -24552,6 +24586,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Fork",
         "movements": [
@@ -24599,6 +24634,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Connection",
         "movements": [
@@ -24657,6 +24693,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24707,6 +24744,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -24751,6 +24789,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Fork",
         "movements": [
@@ -24802,6 +24841,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Fork",
         "movements": [
@@ -24853,6 +24893,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24897,6 +24938,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -24941,6 +24983,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24988,6 +25031,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -25032,6 +25076,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Fork",
         "movements": [
@@ -25083,6 +25128,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [
@@ -25141,6 +25187,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [
@@ -25188,6 +25235,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25232,6 +25280,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Fork",
         "movements": [
@@ -25275,6 +25324,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -25315,6 +25365,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25381,6 +25432,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25443,6 +25495,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Fork",
         "movements": [
@@ -25490,6 +25543,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Fork",
         "movements": [
@@ -25533,6 +25587,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Connection",
         "movements": [
@@ -25603,6 +25658,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25691,6 +25747,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25738,6 +25795,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [
@@ -25788,6 +25846,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Fork",
         "movements": [
@@ -25835,6 +25894,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [
@@ -25881,6 +25941,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Fork",
         "movements": [
@@ -25932,6 +25993,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "Fork",
         "movements": [
@@ -25991,6 +26053,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26040,6 +26103,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [
@@ -26082,6 +26146,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -26120,6 +26185,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -26158,6 +26224,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -26200,6 +26267,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "Fork",
         "movements": [
@@ -26263,6 +26331,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [
@@ -26326,6 +26395,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 74,
         "intersection_kind": "Connection",
         "movements": [
@@ -26368,6 +26441,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26412,6 +26486,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "Fork",
         "movements": [
@@ -26459,6 +26534,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "Fork",
         "movements": [
@@ -26502,6 +26578,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -26556,6 +26633,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "Connection",
         "movements": [
@@ -26614,6 +26692,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [
@@ -26672,6 +26754,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "Connection",
         "movements": [
@@ -26730,6 +26813,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26787,6 +26871,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 83,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26837,6 +26922,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26892,6 +26978,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26947,6 +27034,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 86,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27006,6 +27094,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [
@@ -27049,6 +27138,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 88,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27087,6 +27177,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27139,6 +27230,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27179,6 +27271,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 91,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27217,6 +27310,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 92,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -27257,6 +27351,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27303,6 +27398,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27350,6 +27446,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 95,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -27410,6 +27507,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Fork",
         "movements": [
@@ -27453,6 +27551,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27495,6 +27594,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "Fork",
         "movements": [
@@ -27538,6 +27638,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 99,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27576,6 +27677,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27622,6 +27724,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27662,6 +27765,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 102,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27706,6 +27810,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 104,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27750,6 +27855,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 105,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27794,6 +27900,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 107,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27834,6 +27941,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 108,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27872,6 +27980,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 109,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27912,6 +28021,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 110,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27952,6 +28062,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27990,6 +28101,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28030,6 +28142,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 113,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -28074,6 +28187,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28114,6 +28228,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 115,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28170,6 +28285,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 116,
         "intersection_kind": "Connection",
         "movements": [
@@ -28212,6 +28331,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 117,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28268,6 +28388,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 118,
         "intersection_kind": "Connection",
         "movements": [
@@ -28315,6 +28436,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 119,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -28363,6 +28485,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 120,
         "intersection_kind": "Fork",
         "movements": [
@@ -28414,6 +28537,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 121,
         "intersection_kind": "Fork",
         "movements": [
@@ -28469,6 +28593,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 122,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28509,6 +28634,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 123,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28565,6 +28691,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 124,
         "intersection_kind": "Connection",
         "movements": [
@@ -28615,6 +28745,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 125,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28655,6 +28786,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 126,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28703,6 +28835,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28751,6 +28884,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 128,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28807,6 +28941,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 129,
         "intersection_kind": "Connection",
         "movements": [
@@ -28857,6 +28995,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 130,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28909,6 +29048,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 131,
         "intersection_kind": "Connection",
         "movements": [
@@ -28951,6 +29094,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 132,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29003,6 +29147,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 133,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29043,6 +29188,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 134,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29083,6 +29229,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 135,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29121,6 +29268,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 136,
         "intersection_kind": "Connection",
         "movements": [
@@ -29163,6 +29311,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 137,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29201,6 +29350,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 138,
         "intersection_kind": "Connection",
         "movements": [
@@ -29243,6 +29393,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 139,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29281,6 +29432,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 182,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29321,6 +29473,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 193,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29381,6 +29534,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 210,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29432,6 +29586,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 211,
         "intersection_kind": "Fork",
         "movements": [
@@ -29480,6 +29635,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 212,
         "intersection_kind": "Fork",
         "movements": [
@@ -29535,6 +29691,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 213,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -29575,6 +29732,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 214,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29615,6 +29773,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 215,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29655,6 +29814,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 216,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29693,6 +29853,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 217,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29747,6 +29908,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 218,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29792,6 +29954,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 220,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29839,6 +30002,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 221,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -29879,6 +30043,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 222,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29917,6 +30082,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 223,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29971,6 +30137,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 224,
         "intersection_kind": "Connection",
         "movements": [
@@ -30017,6 +30184,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 226,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30073,6 +30241,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 227,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30129,6 +30298,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 229,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30182,6 +30352,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 230,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30220,6 +30391,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 231,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -30260,6 +30432,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 232,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30298,6 +30471,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 233,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30342,6 +30516,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 234,
         "intersection_kind": "Connection",
         "movements": [
@@ -30400,6 +30575,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 235,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30440,6 +30616,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 236,
         "intersection_kind": "Connection",
         "movements": [
@@ -30482,6 +30659,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 237,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30520,6 +30698,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 238,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30578,6 +30757,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 239,
         "intersection_kind": "Connection",
         "movements": [
@@ -30632,6 +30812,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 240,
         "intersection_kind": "Connection",
         "movements": [
@@ -30690,6 +30871,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 241,
         "intersection_kind": "Connection",
         "movements": [
@@ -30740,6 +30925,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 242,
         "intersection_kind": "Connection",
         "movements": [
@@ -30782,6 +30968,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 245,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30824,6 +31011,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 246,
         "intersection_kind": "Connection",
         "movements": [
@@ -30870,6 +31058,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 247,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30910,6 +31099,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 248,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -30950,6 +31140,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 249,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30996,6 +31187,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 251,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31059,6 +31251,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 252,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31111,6 +31304,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 253,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31159,6 +31353,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 254,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31199,6 +31394,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 255,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31239,6 +31435,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 256,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31279,6 +31476,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 258,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31319,6 +31517,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 259,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31359,6 +31558,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 260,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31399,6 +31599,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 261,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31439,6 +31640,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 262,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31483,6 +31685,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 263,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31531,6 +31734,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 265,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31579,6 +31783,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 266,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31624,6 +31829,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 267,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31664,6 +31870,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 268,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31718,6 +31925,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 269,
         "intersection_kind": "Connection",
         "movements": [
@@ -31772,6 +31980,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 271,
         "intersection_kind": "Connection",
         "movements": [
@@ -31826,6 +32038,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 272,
         "intersection_kind": "Connection",
         "movements": [
@@ -31884,6 +32100,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 273,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31949,6 +32166,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 274,
         "intersection_kind": "Connection",
         "movements": [
@@ -31991,6 +32212,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 276,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -32029,6 +32251,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 277,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -32067,6 +32290,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 278,
         "intersection_kind": "Connection",
         "movements": [
@@ -32109,6 +32333,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 279,
         "intersection_kind": "Connection",
         "movements": [
@@ -32155,6 +32380,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 280,
         "intersection_kind": "Fork",
         "movements": [
@@ -32214,6 +32440,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 281,
         "intersection_kind": "Fork",
         "movements": [
@@ -32269,6 +32499,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 282,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32313,6 +32544,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 283,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32365,6 +32597,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 284,
         "intersection_kind": "Connection",
         "movements": [
@@ -32415,6 +32648,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 285,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32459,6 +32693,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 286,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32503,6 +32738,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 287,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32555,6 +32791,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 288,
         "intersection_kind": "Connection",
         "movements": [
@@ -32609,6 +32846,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 289,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32653,6 +32894,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 290,
         "intersection_kind": "Connection",
         "movements": [
@@ -32732,6 +32974,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 291,
         "intersection_kind": "Fork",
         "movements": [
@@ -32786,6 +33029,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 293,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32830,6 +33074,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 294,
         "intersection_kind": "Connection",
         "movements": [
@@ -32876,6 +33121,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 295,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32932,6 +33178,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 298,
         "intersection_kind": "Connection",
         "movements": [
@@ -33007,6 +33257,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 299,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33054,6 +33308,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 300,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33098,6 +33353,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 301,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33138,6 +33394,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 302,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33214,6 +33471,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 303,
         "intersection_kind": "Connection",
         "movements": [
@@ -33278,6 +33536,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 305,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33342,6 +33601,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 306,
         "intersection_kind": "Fork",
         "movements": [
@@ -33388,6 +33648,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 308,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33468,6 +33729,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 309,
         "intersection_kind": "Connection",
         "movements": [
@@ -33511,6 +33776,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 311,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33595,6 +33861,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 313,
         "intersection_kind": "Fork",
         "movements": [
@@ -33644,6 +33914,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 314,
         "intersection_kind": "Connection",
         "movements": [
@@ -33686,6 +33957,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 315,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33724,6 +33996,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 316,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33766,6 +34039,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 317,
         "intersection_kind": "Connection",
         "movements": [
@@ -33812,6 +34086,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 318,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33860,6 +34135,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 319,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33920,6 +34196,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 320,
         "intersection_kind": "Connection",
         "movements": [],
@@ -33960,6 +34237,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 321,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34004,6 +34282,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 322,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34052,6 +34331,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 324,
         "intersection_kind": "Connection",
         "movements": [
@@ -34095,6 +34375,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 326,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34147,6 +34428,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 327,
         "intersection_kind": "Connection",
         "movements": [
@@ -34205,6 +34490,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 328,
         "intersection_kind": "Connection",
         "movements": [
@@ -34252,6 +34541,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 329,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34300,6 +34590,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 330,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34344,6 +34635,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 331,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34384,6 +34676,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 332,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -34424,6 +34717,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 333,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34472,6 +34766,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 334,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34528,6 +34826,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 335,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34568,6 +34867,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 337,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34616,6 +34916,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 338,
         "intersection_kind": "Fork",
         "movements": [
@@ -34667,6 +34968,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 339,
         "intersection_kind": "Fork",
         "movements": [
@@ -34719,6 +35021,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 341,
         "intersection_kind": "Connection",
         "movements": [
@@ -34765,6 +35071,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 342,
         "intersection_kind": "Connection",
         "movements": [],
@@ -34805,6 +35112,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 343,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -34845,6 +35153,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 344,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -34887,6 +35196,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 345,
         "intersection_kind": "Intersection",
         "movements": [
@@ -34938,6 +35248,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 346,
         "intersection_kind": "Intersection",
         "movements": [
@@ -34985,6 +35296,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 347,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -35043,6 +35355,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 348,
         "intersection_kind": "Connection",
         "movements": [
@@ -35105,6 +35421,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 349,
         "intersection_kind": "Connection",
         "movements": [
@@ -35155,6 +35475,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 350,
         "intersection_kind": "Connection",
         "movements": [
@@ -35209,6 +35530,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 351,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35253,6 +35575,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 352,
         "intersection_kind": "Connection",
         "movements": [
@@ -35296,6 +35619,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 353,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35336,6 +35660,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 354,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35376,6 +35701,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 355,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -35440,6 +35766,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 356,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35517,6 +35844,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 357,
         "intersection_kind": "Intersection",
         "movements": [
@@ -35595,6 +35926,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 358,
         "intersection_kind": "Connection",
         "movements": [
@@ -35650,6 +35982,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 359,
         "intersection_kind": "Connection",
         "movements": [
@@ -35692,6 +36028,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 360,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -35754,6 +36091,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 361,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35795,6 +36133,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 362,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35851,6 +36190,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 363,
         "intersection_kind": "Intersection",
         "movements": [
@@ -35899,6 +36239,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 364,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -35941,6 +36282,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 365,
         "intersection_kind": "Connection",
         "movements": [],
@@ -35981,6 +36323,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 366,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -36023,6 +36366,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 368,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36067,6 +36411,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 371,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36123,6 +36468,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 372,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36163,6 +36509,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 373,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36207,6 +36554,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 374,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36279,6 +36627,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 375,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36544,6 +36893,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 377,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36593,6 +36943,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 380,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36645,6 +36996,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 381,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36693,6 +37045,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 382,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36737,6 +37090,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 383,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36781,6 +37135,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 384,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36841,6 +37196,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 386,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36890,6 +37246,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 387,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36930,6 +37287,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 388,
         "intersection_kind": "Connection",
         "movements": [],
@@ -36990,6 +37348,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 389,
         "intersection_kind": "Connection",
         "movements": [
@@ -37033,6 +37395,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 391,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37085,6 +37448,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 392,
         "intersection_kind": "Connection",
         "movements": [
@@ -37127,6 +37494,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 393,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37179,6 +37547,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 394,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37231,6 +37600,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 395,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37287,6 +37657,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 396,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37335,6 +37706,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 397,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37375,6 +37747,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 398,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37431,6 +37804,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 399,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37471,6 +37845,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 401,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37519,6 +37894,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 403,
         "intersection_kind": "Connection",
         "movements": [
@@ -37561,6 +37940,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 404,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -37613,6 +37993,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 405,
         "intersection_kind": "Connection",
         "movements": [
@@ -37660,6 +38041,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 406,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37708,6 +38090,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 407,
         "intersection_kind": "Connection",
         "movements": [
@@ -37755,6 +38138,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 411,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37795,6 +38182,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 412,
         "intersection_kind": "Connection",
         "movements": [
@@ -37837,6 +38225,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 413,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -37875,6 +38264,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 414,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -37929,6 +38319,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 415,
         "intersection_kind": "Connection",
         "movements": [],
@@ -37977,6 +38371,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 416,
         "intersection_kind": "Connection",
         "movements": [],
@@ -38045,6 +38440,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 417,
         "intersection_kind": "Connection",
         "movements": [
@@ -38092,6 +38491,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 419,
         "intersection_kind": "Connection",
         "movements": [],
@@ -38156,6 +38556,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 420,
         "intersection_kind": "Connection",
         "movements": [],
@@ -38197,6 +38598,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 422,
         "intersection_kind": "Connection",
         "movements": [],
@@ -38241,6 +38643,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 423,
         "intersection_kind": "Intersection",
         "movements": [
@@ -38285,6 +38688,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 424,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -38333,6 +38737,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 427,
         "intersection_kind": "Connection",
         "movements": [
@@ -38376,6 +38781,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 428,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -38430,6 +38836,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 429,
         "intersection_kind": "Connection",
         "movements": [
@@ -38484,6 +38891,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 430,
         "intersection_kind": "Connection",
         "movements": [
@@ -38546,6 +38957,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": true,
+          "kind": "Signalized"
+        },
         "id": 431,
         "intersection_kind": "Fork",
         "movements": [
@@ -38594,6 +39009,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 432,
         "intersection_kind": "Connection",
         "movements": [],
@@ -38690,6 +39106,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 434,
         "intersection_kind": "Fork",
         "movements": [
@@ -38763,6 +39183,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 435,
         "intersection_kind": "Connection",
         "movements": [],
@@ -38804,6 +39225,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 436,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -38846,6 +39268,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 437,
         "intersection_kind": "Connection",
         "movements": [
@@ -38888,6 +39311,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 438,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -38926,6 +39350,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 439,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -38964,6 +39389,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 440,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -39006,6 +39432,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 441,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39046,6 +39473,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 442,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -39092,6 +39520,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 443,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39132,6 +39561,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 444,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -39178,6 +39608,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 445,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39226,6 +39657,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 446,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39282,6 +39714,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 447,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39322,6 +39755,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 448,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -39360,6 +39794,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 449,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -39434,6 +39869,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 450,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39475,6 +39911,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 452,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39531,6 +39968,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 453,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39587,6 +40028,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 454,
         "intersection_kind": "Connection",
         "movements": [
@@ -39645,6 +40090,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 455,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39686,6 +40132,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 456,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39730,6 +40177,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 457,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39774,6 +40222,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 458,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39822,6 +40271,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 459,
         "intersection_kind": "Connection",
         "movements": [
@@ -39869,6 +40319,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 460,
         "intersection_kind": "Connection",
         "movements": [
@@ -39920,6 +40371,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 461,
         "intersection_kind": "Connection",
         "movements": [],
@@ -39972,6 +40424,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 462,
         "intersection_kind": "Connection",
         "movements": [
@@ -40023,6 +40476,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 463,
         "intersection_kind": "Connection",
         "movements": [],
@@ -40063,6 +40517,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 464,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -40105,6 +40560,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 465,
         "intersection_kind": "Connection",
         "movements": [
@@ -40151,6 +40607,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 466,
         "intersection_kind": "Intersection",
         "movements": [
@@ -40198,6 +40655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 467,
         "intersection_kind": "Connection",
         "movements": [],
@@ -40246,6 +40704,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 468,
         "intersection_kind": "Connection",
         "movements": [],
@@ -40294,6 +40753,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 469,
         "intersection_kind": "Connection",
         "movements": [],
@@ -40338,6 +40798,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 470,
         "intersection_kind": "Connection",
         "movements": [
@@ -40384,6 +40845,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 474,
         "intersection_kind": "Connection",
         "movements": [
@@ -40427,6 +40889,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 475,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -40465,6 +40928,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 476,
         "intersection_kind": "Intersection",
         "movements": [
@@ -40509,6 +40973,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 477,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -40553,6 +41018,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 478,
         "intersection_kind": "Fork",
         "movements": [
@@ -40609,6 +41075,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 479,
         "intersection_kind": "Connection",
         "movements": [
@@ -40656,6 +41126,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 480,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -40708,6 +41182,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 482,
         "intersection_kind": "Connection",
         "movements": [
@@ -40754,6 +41229,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 483,
         "intersection_kind": "Fork",
         "movements": [
@@ -40798,6 +41274,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 484,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -40842,6 +41319,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 485,
         "intersection_kind": "Intersection",
         "movements": [
@@ -40889,6 +41367,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 486,
         "intersection_kind": "Connection",
         "movements": [
@@ -40932,6 +41411,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 487,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -40972,6 +41452,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 489,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -41014,6 +41495,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 490,
         "intersection_kind": "Connection",
         "movements": [],
@@ -41054,6 +41536,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 491,
         "intersection_kind": "Connection",
         "movements": [],
@@ -41094,6 +41577,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 492,
         "intersection_kind": "Connection",
         "movements": [],
@@ -41134,6 +41618,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 493,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -41184,6 +41669,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 496,
         "intersection_kind": "Connection",
         "movements": [
@@ -41226,6 +41712,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 497,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -41264,6 +41751,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 498,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -41326,6 +41814,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 499,
         "intersection_kind": "Connection",
         "movements": [],

--- a/tests/src/montlake_roundabout/geometry.json
+++ b/tests/src/montlake_roundabout/geometry.json
@@ -1927,6 +1927,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1969,6 +1970,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -2013,6 +2015,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2059,6 +2062,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -2103,6 +2107,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2153,6 +2158,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2206,6 +2212,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Fork",
         "movements": [
@@ -2250,6 +2257,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2296,6 +2304,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2340,6 +2349,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2380,6 +2390,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2436,6 +2447,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 11,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2479,6 +2494,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2519,6 +2535,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2557,6 +2574,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2595,6 +2613,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2637,6 +2656,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2677,6 +2697,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2715,6 +2736,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2771,6 +2793,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 20,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2826,6 +2852,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2867,6 +2894,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2913,6 +2941,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2953,6 +2982,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2991,6 +3021,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3029,6 +3060,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3069,6 +3101,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3109,6 +3142,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3147,6 +3181,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3189,6 +3224,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3245,6 +3281,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 34,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3305,6 +3345,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3357,6 +3398,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3405,6 +3447,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3445,6 +3488,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3495,6 +3539,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 40,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3538,6 +3586,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/northgate_dual_carriageway/geometry.json
+++ b/tests/src/northgate_dual_carriageway/geometry.json
@@ -17072,6 +17072,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17125,6 +17126,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Fork",
         "movements": [
@@ -17169,6 +17171,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -17207,6 +17210,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17250,6 +17254,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -17296,6 +17301,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17341,6 +17347,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Fork",
         "movements": [
@@ -17384,6 +17391,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17433,6 +17441,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17478,6 +17487,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Fork",
         "movements": [
@@ -17521,6 +17531,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Fork",
         "movements": [
@@ -17568,6 +17579,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17617,6 +17629,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17662,6 +17675,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -17709,6 +17723,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Fork",
         "movements": [
@@ -17748,6 +17763,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Connection",
         "movements": [
@@ -17798,6 +17814,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17847,6 +17864,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Fork",
         "movements": [
@@ -17890,6 +17908,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Fork",
         "movements": [
@@ -17933,6 +17952,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Intersection",
         "movements": [
@@ -17978,6 +17998,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Fork",
         "movements": [
@@ -18021,6 +18042,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18059,6 +18081,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18116,6 +18139,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18166,6 +18190,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Fork",
         "movements": [
@@ -18209,6 +18234,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18257,6 +18283,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18306,6 +18333,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18355,6 +18383,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18408,6 +18437,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18453,6 +18483,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18502,6 +18533,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18547,6 +18579,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18592,6 +18625,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18645,6 +18679,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18698,6 +18733,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18747,6 +18783,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18798,6 +18835,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18847,6 +18885,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18896,6 +18935,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18957,6 +18997,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19013,6 +19054,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19066,6 +19108,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19115,6 +19158,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Fork",
         "movements": [
@@ -19170,6 +19214,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19219,6 +19264,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19268,6 +19314,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Fork",
         "movements": [
@@ -19307,6 +19354,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [
@@ -19349,6 +19397,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19398,6 +19447,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19447,6 +19497,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Fork",
         "movements": [
@@ -19490,6 +19541,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Connection",
         "movements": [
@@ -19532,6 +19584,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19580,6 +19633,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [
@@ -19622,6 +19676,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [
@@ -19668,6 +19723,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [
@@ -19711,6 +19767,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19753,6 +19810,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [
@@ -19796,6 +19854,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19839,6 +19898,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19877,6 +19937,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19917,6 +19978,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19955,6 +20017,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19993,6 +20056,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20048,6 +20112,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20146,6 +20211,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20206,6 +20272,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [
@@ -20257,6 +20324,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 73,
         "intersection_kind": "Fork",
         "movements": [
@@ -20301,6 +20369,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 74,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20343,6 +20412,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Fork",
         "movements": [
@@ -20406,6 +20476,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20451,6 +20522,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20501,6 +20573,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20541,6 +20614,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20583,6 +20657,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20643,6 +20718,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 81,
         "intersection_kind": "Connection",
         "movements": [
@@ -20686,6 +20765,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20728,6 +20808,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 83,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20775,6 +20856,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20813,6 +20895,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Fork",
         "movements": [
@@ -20860,6 +20943,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 86,
         "intersection_kind": "Fork",
         "movements": [
@@ -20903,6 +20987,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [
@@ -20945,6 +21030,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [
@@ -21003,6 +21089,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 92,
         "intersection_kind": "Connection",
         "movements": [
@@ -21045,6 +21135,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Connection",
         "movements": [
@@ -21091,6 +21182,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "Fork",
         "movements": [
@@ -21134,6 +21226,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 95,
         "intersection_kind": "Connection",
         "movements": [
@@ -21176,6 +21269,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Connection",
         "movements": [
@@ -21218,6 +21312,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21258,6 +21353,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21310,6 +21406,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 99,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21362,6 +21459,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "Intersection",
         "movements": [
@@ -21405,6 +21503,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21449,6 +21548,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 102,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21497,6 +21597,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 103,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21537,6 +21638,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 104,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21577,6 +21679,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 105,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21633,6 +21736,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 106,
         "intersection_kind": "Connection",
         "movements": [
@@ -21695,6 +21802,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 107,
         "intersection_kind": "Connection",
         "movements": [
@@ -21737,6 +21848,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 108,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21777,6 +21889,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 109,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -21817,6 +21930,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 110,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -21861,6 +21975,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "Fork",
         "movements": [
@@ -21913,6 +22028,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Fork",
         "movements": [
@@ -21960,6 +22076,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 113,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22008,6 +22125,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Fork",
         "movements": [
@@ -22052,6 +22170,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 115,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22098,6 +22217,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 116,
         "intersection_kind": "Fork",
         "movements": [
@@ -22142,6 +22262,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 118,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22182,6 +22303,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 124,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22222,6 +22344,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 125,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22260,6 +22383,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 126,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22302,6 +22426,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22346,6 +22471,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 128,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22386,6 +22512,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 129,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22426,6 +22553,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 130,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22472,6 +22600,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 131,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22523,6 +22652,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 132,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22572,6 +22702,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 133,
         "intersection_kind": "Fork",
         "movements": [
@@ -22620,6 +22751,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 134,
         "intersection_kind": "Fork",
         "movements": [
@@ -22664,6 +22796,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 135,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22722,6 +22855,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 136,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22770,6 +22904,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 137,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22810,6 +22945,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 139,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22850,6 +22986,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 140,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22890,6 +23027,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 141,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22930,6 +23068,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 142,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22968,6 +23107,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 143,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23008,6 +23148,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 144,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23048,6 +23189,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 145,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23104,6 +23246,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 146,
         "intersection_kind": "Connection",
         "movements": [
@@ -23166,6 +23312,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 147,
         "intersection_kind": "Connection",
         "movements": [
@@ -23209,6 +23359,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 149,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23247,6 +23398,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 150,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23291,6 +23443,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 153,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23343,6 +23496,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 156,
         "intersection_kind": "Intersection",
         "movements": [
@@ -23402,6 +23559,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 157,
         "intersection_kind": "Intersection",
         "movements": [
@@ -23455,6 +23613,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 158,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23493,6 +23652,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 159,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23539,6 +23699,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 160,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23579,6 +23740,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 161,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23635,6 +23797,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 162,
         "intersection_kind": "Connection",
         "movements": [
@@ -23689,6 +23855,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 163,
         "intersection_kind": "Connection",
         "movements": [
@@ -23731,6 +23901,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 164,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23779,6 +23950,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 165,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23827,6 +23999,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 166,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23879,6 +24052,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 167,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23931,6 +24105,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 168,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23975,6 +24150,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 169,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24023,6 +24199,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 170,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24063,6 +24240,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 171,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24103,6 +24281,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 172,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24163,6 +24342,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 173,
         "intersection_kind": "Connection",
         "movements": [
@@ -24225,6 +24408,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 174,
         "intersection_kind": "Connection",
         "movements": [
@@ -24275,6 +24462,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 175,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24315,6 +24503,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 176,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24371,6 +24560,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 177,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24414,6 +24607,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 178,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24470,6 +24664,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 179,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24514,6 +24709,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 180,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24558,6 +24754,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 181,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24605,6 +24802,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 182,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24647,6 +24845,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 183,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24694,6 +24893,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 184,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24745,6 +24945,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 187,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24785,6 +24986,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 188,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24825,6 +25027,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 189,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24863,6 +25066,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 190,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24903,6 +25107,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 191,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24943,6 +25148,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 192,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24987,6 +25193,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 193,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25027,6 +25234,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 194,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25065,6 +25273,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 195,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25121,6 +25330,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 196,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25166,6 +25376,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 197,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25208,6 +25419,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 198,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25256,6 +25468,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 199,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25296,6 +25509,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 200,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25336,6 +25550,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 201,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25392,6 +25607,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 202,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25435,6 +25654,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 203,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25475,6 +25695,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 204,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25521,6 +25742,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 205,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25561,6 +25783,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 206,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25617,6 +25840,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 207,
         "intersection_kind": "Connection",
         "movements": [
@@ -25691,6 +25918,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 208,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25737,6 +25968,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 210,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25777,6 +26009,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 211,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25817,6 +26050,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 212,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25871,6 +26105,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 213,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25914,6 +26152,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 214,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25962,6 +26201,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 215,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26018,6 +26258,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 217,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26062,6 +26303,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 219,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26102,6 +26344,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 220,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26158,6 +26401,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 221,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26201,6 +26448,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 222,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26257,6 +26505,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 224,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26301,6 +26550,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 226,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26341,6 +26591,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 227,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26385,6 +26636,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 228,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26465,6 +26717,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 229,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26513,6 +26769,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 231,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26553,6 +26810,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 232,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26597,6 +26855,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 233,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26637,6 +26896,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 234,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26677,6 +26937,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 235,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26717,6 +26978,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 236,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26765,6 +27027,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 237,
         "intersection_kind": "Connection",
         "movements": [
@@ -26807,6 +27073,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 238,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26847,6 +27114,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 239,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26887,6 +27155,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 240,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26927,6 +27196,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 241,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26967,6 +27237,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 242,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27005,6 +27276,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 243,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27047,6 +27319,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 244,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27091,6 +27364,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 245,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27131,6 +27405,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 246,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27169,6 +27444,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 247,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27215,6 +27491,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 248,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27263,6 +27540,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 249,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27303,6 +27581,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 250,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27343,6 +27622,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 251,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27399,6 +27679,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 252,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27443,6 +27724,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 253,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27483,6 +27765,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 254,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27523,6 +27806,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 255,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27563,6 +27847,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 256,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27603,6 +27888,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 257,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27643,6 +27929,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 259,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27681,6 +27968,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 260,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27721,6 +28009,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 261,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27775,6 +28064,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 262,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27819,6 +28109,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 264,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27857,6 +28148,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 265,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27897,6 +28189,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 266,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27937,6 +28230,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 267,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27977,6 +28271,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 268,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28033,6 +28328,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 269,
         "intersection_kind": "Intersection",
         "movements": [
@@ -28076,6 +28375,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 270,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28116,6 +28416,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 271,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28156,6 +28457,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 273,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28196,6 +28498,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 274,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28236,6 +28539,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 275,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28276,6 +28580,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 276,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28316,6 +28621,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 277,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28356,6 +28662,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 278,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28396,6 +28703,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 279,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28440,6 +28748,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 280,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28480,6 +28789,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 281,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28536,6 +28846,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 282,
         "intersection_kind": "Intersection",
         "movements": [
@@ -28583,6 +28897,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 283,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28623,6 +28938,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 284,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -28661,6 +28977,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 285,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28701,6 +29018,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 286,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -28751,6 +29069,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 287,
         "intersection_kind": "Intersection",
         "movements": [
@@ -28794,6 +29116,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 288,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28834,6 +29157,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 289,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28886,6 +29210,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 290,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28926,6 +29254,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 291,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28966,6 +29295,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 292,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29022,6 +29352,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 293,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29065,6 +29399,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 294,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29125,6 +29460,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 295,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29168,6 +29507,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 296,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29224,6 +29564,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 298,
         "intersection_kind": "Connection",
         "movements": [
@@ -29270,6 +29614,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 299,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29310,6 +29655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 300,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29350,6 +29696,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 301,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29402,6 +29749,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 302,
         "intersection_kind": "Connection",
         "movements": [
@@ -29444,6 +29795,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 303,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29484,6 +29836,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 304,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29524,6 +29877,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 305,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29564,6 +29918,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 306,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29616,6 +29971,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 307,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29663,6 +30022,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 308,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29706,6 +30069,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 309,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29750,6 +30114,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 312,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29790,6 +30155,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 313,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29834,6 +30200,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 314,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29874,6 +30241,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 316,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -29912,6 +30280,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 317,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29972,6 +30341,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 319,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30015,6 +30388,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 320,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30067,6 +30441,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 321,
         "intersection_kind": "Connection",
         "movements": [
@@ -30109,6 +30487,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 322,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30149,6 +30528,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 323,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30197,6 +30577,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 324,
         "intersection_kind": "Connection",
         "movements": [
@@ -30239,6 +30623,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 325,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30279,6 +30664,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 326,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30331,6 +30717,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 327,
         "intersection_kind": "Connection",
         "movements": [
@@ -30373,6 +30763,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 328,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30417,6 +30808,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 329,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30461,6 +30853,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 330,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30501,6 +30894,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 331,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30545,6 +30939,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 332,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30601,6 +30996,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 334,
         "intersection_kind": "Connection",
         "movements": [
@@ -30643,6 +31042,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 335,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30687,6 +31087,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 336,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30731,6 +31132,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 337,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30779,6 +31181,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 338,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30823,6 +31226,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 339,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30863,6 +31267,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 340,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30903,6 +31308,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 341,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30945,6 +31351,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 343,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30985,6 +31392,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 344,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31025,6 +31433,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 345,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31069,6 +31478,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 346,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31113,6 +31523,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 347,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31156,6 +31567,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 350,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31196,6 +31608,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 353,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31240,6 +31653,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 354,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31280,6 +31694,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 355,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31324,6 +31739,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 356,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31372,6 +31788,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 357,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31412,6 +31829,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 359,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31462,6 +31880,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 360,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31505,6 +31927,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 361,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31543,6 +31966,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 364,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31581,6 +32005,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 365,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31621,6 +32046,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 366,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31659,6 +32085,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 368,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31701,6 +32128,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 369,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31741,6 +32169,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 370,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31781,6 +32210,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 371,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31833,6 +32263,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 372,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31876,6 +32310,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 373,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31914,6 +32349,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 374,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -31952,6 +32388,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 375,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/oneway_loop/geometry.json
+++ b/tests/src/oneway_loop/geometry.json
@@ -2868,6 +2868,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2906,6 +2907,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2954,6 +2956,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3010,6 +3013,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -3054,6 +3058,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3092,6 +3097,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3130,6 +3136,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3168,6 +3175,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3206,6 +3214,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3256,6 +3265,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Fork",
         "movements": [
@@ -3308,6 +3318,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Connection",
         "movements": [
@@ -3354,6 +3365,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3410,6 +3422,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [
@@ -3452,6 +3465,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3502,6 +3516,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3550,6 +3565,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3606,6 +3622,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [
@@ -3652,6 +3669,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Connection",
         "movements": [
@@ -3694,6 +3712,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3752,6 +3771,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3801,6 +3821,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3853,6 +3874,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [
@@ -3895,6 +3920,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -3939,6 +3965,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [
@@ -3981,6 +4008,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4019,6 +4047,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4057,6 +4086,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4095,6 +4125,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4137,6 +4168,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [
@@ -4179,6 +4211,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4221,6 +4254,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Fork",
         "movements": [
@@ -4265,6 +4299,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4303,6 +4338,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4349,6 +4385,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [
@@ -4391,6 +4428,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4433,6 +4471,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4477,6 +4516,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -4521,6 +4561,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4565,6 +4606,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -4613,6 +4655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4664,6 +4707,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [
@@ -4707,6 +4751,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Connection",
         "movements": [
@@ -4753,6 +4798,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4797,6 +4843,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4839,6 +4886,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Connection",
         "movements": [
@@ -4890,6 +4938,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4934,6 +4983,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4982,6 +5032,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5026,6 +5077,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Connection",
         "movements": [
@@ -5072,6 +5124,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5112,6 +5165,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5160,6 +5214,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5208,6 +5263,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5248,6 +5304,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5286,6 +5343,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [
@@ -5332,6 +5390,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Fork",
         "movements": [

--- a/tests/src/overlapping_service_roads/geometry.json
+++ b/tests/src/overlapping_service_roads/geometry.json
@@ -623,6 +623,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -661,6 +662,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -703,6 +705,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -754,6 +757,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -817,6 +821,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Intersection",
         "movements": [
@@ -876,6 +881,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [
@@ -929,6 +935,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Intersection",
         "movements": [
@@ -984,6 +991,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1031,6 +1039,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -1075,6 +1084,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1122,6 +1132,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/perth_peanut_roundabout/geometry.json
+++ b/tests/src/perth_peanut_roundabout/geometry.json
@@ -2620,6 +2620,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -2663,6 +2664,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2705,6 +2707,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -2749,6 +2752,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2791,6 +2795,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -2839,6 +2844,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2886,6 +2892,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2924,6 +2931,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Connection",
         "movements": [
@@ -2979,6 +2987,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3034,6 +3043,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Fork",
         "movements": [
@@ -3078,6 +3088,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3116,6 +3127,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3158,6 +3170,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -3209,6 +3222,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Fork",
         "movements": [
@@ -3272,6 +3286,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3330,6 +3345,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Fork",
         "movements": [
@@ -3381,6 +3397,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Fork",
         "movements": [
@@ -3428,6 +3445,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Fork",
         "movements": [
@@ -3471,6 +3489,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3509,6 +3528,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3547,6 +3567,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3585,6 +3606,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3623,6 +3645,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3677,6 +3700,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [
@@ -3720,6 +3747,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3766,6 +3794,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3826,6 +3855,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 34,
         "intersection_kind": "Fork",
         "movements": [
@@ -3880,6 +3913,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3928,6 +3962,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3984,6 +4019,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [
@@ -4042,6 +4081,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [
@@ -4088,6 +4131,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4132,6 +4176,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4172,6 +4217,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4210,6 +4256,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4296,6 +4343,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Fork",
         "movements": [
@@ -4356,6 +4404,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4396,6 +4445,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4442,6 +4492,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4482,6 +4533,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4520,6 +4572,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4568,6 +4621,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4612,6 +4666,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4652,6 +4707,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4706,6 +4762,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Connection",
         "movements": [

--- a/tests/src/perth_stretched_lights/geometry.json
+++ b/tests/src/perth_stretched_lights/geometry.json
@@ -1667,6 +1667,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Fork",
         "movements": [
@@ -1711,6 +1712,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1757,6 +1759,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1806,6 +1809,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1851,6 +1855,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1897,6 +1902,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1943,6 +1949,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1981,6 +1988,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2019,6 +2027,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2057,6 +2066,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2095,6 +2105,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2133,6 +2144,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2173,6 +2185,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2211,6 +2224,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2249,6 +2263,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2287,6 +2302,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2333,6 +2349,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2401,6 +2418,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 17,
         "intersection_kind": "Fork",
         "movements": [
@@ -2455,6 +2476,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2503,6 +2525,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2551,6 +2574,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -2602,6 +2629,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2646,6 +2674,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2702,6 +2731,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 24,
         "intersection_kind": "Connection",
         "movements": [
@@ -2753,6 +2786,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2801,6 +2835,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2857,6 +2892,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 27,
         "intersection_kind": "Connection",
         "movements": [
@@ -2908,6 +2947,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2956,6 +2996,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3012,6 +3053,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [
@@ -3063,6 +3108,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3103,6 +3149,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/quad_intersection/geometry.json
+++ b/tests/src/quad_intersection/geometry.json
@@ -3926,6 +3926,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3964,6 +3965,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4002,6 +4004,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Connection",
         "movements": [
@@ -4048,6 +4051,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4093,6 +4097,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4135,6 +4140,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Fork",
         "movements": [
@@ -4187,6 +4193,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4234,6 +4241,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4272,6 +4280,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4310,6 +4319,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Connection",
         "movements": [
@@ -4352,6 +4362,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4390,6 +4401,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [
@@ -4440,6 +4452,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4480,6 +4493,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4522,6 +4536,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Connection",
         "movements": [
@@ -4565,6 +4580,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4667,6 +4683,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4726,6 +4743,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4764,6 +4782,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4806,6 +4825,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Fork",
         "movements": [
@@ -4849,6 +4869,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4887,6 +4908,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4925,6 +4947,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4963,6 +4986,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Connection",
         "movements": [
@@ -5005,6 +5029,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5043,6 +5068,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [
@@ -5085,6 +5111,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [
@@ -5127,6 +5154,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [
@@ -5169,6 +5197,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [
@@ -5211,6 +5240,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Connection",
         "movements": [
@@ -5253,6 +5283,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5291,6 +5322,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5329,6 +5361,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5369,6 +5402,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5407,6 +5441,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5463,6 +5498,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 40,
         "intersection_kind": "Connection",
         "movements": [
@@ -5505,6 +5544,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5545,6 +5585,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5583,6 +5624,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5621,6 +5663,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5659,6 +5702,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5703,6 +5747,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5767,6 +5812,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5811,6 +5857,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5859,6 +5906,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5899,6 +5947,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5955,6 +6004,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 53,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5998,6 +6051,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6054,6 +6108,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 55,
         "intersection_kind": "Connection",
         "movements": [
@@ -6100,6 +6158,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Fork",
         "movements": [
@@ -6143,6 +6202,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6181,6 +6241,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6219,6 +6280,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6259,6 +6321,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6299,6 +6362,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6339,6 +6403,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6407,6 +6472,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 64,
         "intersection_kind": "Fork",
         "movements": [
@@ -6453,6 +6522,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6493,6 +6563,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6531,6 +6602,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Connection",
         "movements": [
@@ -6573,6 +6645,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6611,6 +6684,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6667,6 +6741,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 73,
         "intersection_kind": "Connection",
         "movements": [
@@ -6725,6 +6803,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 74,
         "intersection_kind": "Connection",
         "movements": [
@@ -6779,6 +6861,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6819,6 +6902,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6875,6 +6959,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 78,
         "intersection_kind": "Connection",
         "movements": [
@@ -6929,6 +7017,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 79,
         "intersection_kind": "Connection",
         "movements": [
@@ -6971,6 +7063,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7011,6 +7104,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7049,6 +7143,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7101,6 +7196,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 83,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7142,6 +7238,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7200,6 +7297,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Fork",
         "movements": [
@@ -7243,6 +7341,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 86,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7301,6 +7400,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [
@@ -7359,6 +7462,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 88,
         "intersection_kind": "Connection",
         "movements": [
@@ -7401,6 +7508,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7439,6 +7547,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7493,6 +7602,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 92,
         "intersection_kind": "Connection",
         "movements": [
@@ -7555,6 +7665,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7595,6 +7706,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/roosevelt_cycletrack/geometry.json
+++ b/tests/src/roosevelt_cycletrack/geometry.json
@@ -18226,6 +18226,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18268,6 +18269,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -18312,6 +18314,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18358,6 +18361,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -18402,6 +18406,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18460,6 +18465,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -18509,6 +18515,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18553,6 +18560,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18591,6 +18599,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18629,6 +18638,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18675,6 +18685,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Fork",
         "movements": [
@@ -18718,6 +18729,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18756,6 +18768,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18802,6 +18815,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Intersection",
         "movements": [
@@ -18847,6 +18861,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18889,6 +18904,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -18933,6 +18949,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18979,6 +18996,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Fork",
         "movements": [
@@ -19027,6 +19045,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19067,6 +19086,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19107,6 +19127,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19153,6 +19174,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19198,6 +19220,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19238,6 +19261,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19278,6 +19302,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19316,6 +19341,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19354,6 +19380,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19398,6 +19425,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19445,6 +19473,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19485,6 +19514,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19525,6 +19555,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19569,6 +19600,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19617,6 +19649,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19661,6 +19694,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19701,6 +19735,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Fork",
         "movements": [
@@ -19744,6 +19779,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19784,6 +19820,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -19840,6 +19877,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Intersection",
         "movements": [
@@ -19888,6 +19926,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [
@@ -19930,6 +19969,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [
@@ -19980,6 +20020,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "Fork",
         "movements": [
@@ -20023,6 +20064,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20075,6 +20117,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20115,6 +20158,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20165,6 +20209,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20205,6 +20250,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20245,6 +20291,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20317,6 +20364,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 61,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20389,6 +20440,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20431,6 +20483,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20469,6 +20522,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20521,6 +20575,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 65,
         "intersection_kind": "Intersection",
         "movements": [
@@ -20564,6 +20622,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20604,6 +20663,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20650,6 +20710,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20690,6 +20751,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20730,6 +20792,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20768,6 +20831,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20820,6 +20884,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 73,
         "intersection_kind": "Connection",
         "movements": [
@@ -20863,6 +20931,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20915,6 +20984,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 76,
         "intersection_kind": "Connection",
         "movements": [
@@ -20957,6 +21030,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20997,6 +21071,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21037,6 +21112,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21093,6 +21169,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 82,
         "intersection_kind": "Connection",
         "movements": [
@@ -21139,6 +21219,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 83,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21179,6 +21260,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21219,6 +21301,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21275,6 +21358,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21315,6 +21399,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 88,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21355,6 +21440,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21409,6 +21495,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [
@@ -21475,6 +21562,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 91,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21516,6 +21604,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21564,6 +21653,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21624,6 +21714,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 95,
         "intersection_kind": "Intersection",
         "movements": [
@@ -21677,6 +21771,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21717,6 +21812,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21765,6 +21861,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21813,6 +21910,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 99,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21853,6 +21951,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21913,6 +22012,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "Connection",
         "movements": [
@@ -21955,6 +22055,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 103,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22005,6 +22106,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 105,
         "intersection_kind": "Connection",
         "movements": [
@@ -22047,6 +22152,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 106,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22095,6 +22201,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 107,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22143,6 +22250,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 109,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22183,6 +22291,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 110,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22227,6 +22336,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22267,6 +22377,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22323,6 +22434,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 113,
         "intersection_kind": "Connection",
         "movements": [
@@ -22366,6 +22481,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22406,6 +22522,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 115,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22446,6 +22563,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 116,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22490,6 +22608,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 117,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22530,6 +22649,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 118,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22578,6 +22698,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 121,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22626,6 +22747,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 122,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22666,6 +22788,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 123,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22718,6 +22841,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 124,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22762,6 +22886,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 125,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22806,6 +22931,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 126,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22846,6 +22972,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22898,6 +23025,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 128,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22947,6 +23075,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 129,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22987,6 +23116,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 130,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23035,6 +23165,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 131,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23075,6 +23206,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 132,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23113,6 +23245,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 133,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23151,6 +23284,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 134,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23195,6 +23329,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 135,
         "intersection_kind": "Connection",
         "movements": [
@@ -23237,6 +23372,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 136,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23275,6 +23411,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 138,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23321,6 +23458,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 139,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23369,6 +23507,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 140,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23413,6 +23552,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 142,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23473,6 +23613,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 143,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23513,6 +23654,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 144,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23553,6 +23695,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 145,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23609,6 +23752,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 146,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23649,6 +23793,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 148,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23701,6 +23846,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 149,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23749,6 +23895,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 150,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23789,6 +23936,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 151,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23829,6 +23977,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 152,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23867,6 +24016,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 153,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23907,6 +24057,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 154,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23947,6 +24098,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 155,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23999,6 +24151,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 156,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24058,6 +24214,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 158,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24102,6 +24259,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 160,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24152,6 +24310,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 161,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24192,6 +24351,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 162,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24232,6 +24392,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 163,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24284,6 +24445,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 164,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24340,6 +24502,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 165,
         "intersection_kind": "Connection",
         "movements": [
@@ -24382,6 +24548,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 166,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24422,6 +24589,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 168,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24462,6 +24630,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 169,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24518,6 +24687,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 170,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24558,6 +24728,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 171,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24598,6 +24769,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 172,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24636,6 +24808,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 173,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24674,6 +24847,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 174,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24714,6 +24888,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 175,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24754,6 +24929,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 176,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24810,6 +24986,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 177,
         "intersection_kind": "Connection",
         "movements": [
@@ -24852,6 +25032,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 178,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24892,6 +25073,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 179,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24932,6 +25114,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 180,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24988,6 +25171,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 181,
         "intersection_kind": "Connection",
         "movements": [
@@ -25030,6 +25217,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 182,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25082,6 +25270,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 183,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25122,6 +25311,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 184,
         "intersection_kind": "Connection",
         "movements": [
@@ -25168,6 +25358,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 185,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -25216,6 +25407,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 186,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25275,6 +25467,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 187,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25315,6 +25508,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 188,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25355,6 +25549,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 189,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25415,6 +25610,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 190,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25458,6 +25657,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 191,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25502,6 +25702,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 192,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25546,6 +25747,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 193,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25586,6 +25788,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 194,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25630,6 +25833,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 195,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25674,6 +25878,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 196,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25718,6 +25923,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 197,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25770,6 +25976,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 198,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25810,6 +26017,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 199,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25860,6 +26068,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 200,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25911,6 +26120,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 201,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25951,6 +26161,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 202,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25989,6 +26200,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 203,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26045,6 +26257,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 205,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26085,6 +26298,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 206,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26141,6 +26355,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 207,
         "intersection_kind": "Connection",
         "movements": [
@@ -26203,6 +26421,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 208,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26262,6 +26484,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 209,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26302,6 +26525,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 210,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26354,6 +26578,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 211,
         "intersection_kind": "Connection",
         "movements": [
@@ -26396,6 +26624,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 212,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26448,6 +26677,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 213,
         "intersection_kind": "Connection",
         "movements": [
@@ -26490,6 +26723,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 214,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26530,6 +26764,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 215,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26578,6 +26813,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 216,
         "intersection_kind": "Connection",
         "movements": [
@@ -26632,6 +26871,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 217,
         "intersection_kind": "Intersection",
         "movements": [
@@ -26675,6 +26918,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 218,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26715,6 +26959,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 219,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26755,6 +27000,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 220,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26799,6 +27045,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 221,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26855,6 +27102,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 222,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26895,6 +27143,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 223,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26939,6 +27188,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 224,
         "intersection_kind": "Connection",
         "movements": [],
@@ -26979,6 +27229,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 225,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27035,6 +27286,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 226,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27078,6 +27333,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 227,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27118,6 +27374,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 228,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27172,6 +27429,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 229,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27216,6 +27474,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 230,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27256,6 +27515,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 231,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27298,6 +27558,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 232,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27346,6 +27607,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 233,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27386,6 +27648,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 234,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27424,6 +27687,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 235,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27464,6 +27728,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 236,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27520,6 +27785,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 237,
         "intersection_kind": "Intersection",
         "movements": [
@@ -27563,6 +27832,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 238,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27603,6 +27873,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 239,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27659,6 +27930,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 240,
         "intersection_kind": "Connection",
         "movements": [
@@ -27701,6 +27976,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 241,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27757,6 +28033,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 242,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27797,6 +28074,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 243,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -27835,6 +28113,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 244,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27879,6 +28158,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 245,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27919,6 +28199,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 246,
         "intersection_kind": "Connection",
         "movements": [],
@@ -27963,6 +28244,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 247,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28007,6 +28289,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 248,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28047,6 +28330,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 249,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28087,6 +28371,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 250,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28127,6 +28412,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 251,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -28181,6 +28467,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 252,
         "intersection_kind": "Connection",
         "movements": [
@@ -28239,6 +28529,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 253,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28279,6 +28570,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 254,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28319,6 +28611,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 255,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -28373,6 +28666,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 256,
         "intersection_kind": "Intersection",
         "movements": [
@@ -28428,6 +28722,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 257,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28481,6 +28776,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 259,
         "intersection_kind": "Connection",
         "movements": [
@@ -28523,6 +28822,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 260,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28583,6 +28883,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 261,
         "intersection_kind": "Intersection",
         "movements": [
@@ -28630,6 +28934,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 262,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28670,6 +28975,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 263,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -28736,6 +29042,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 265,
         "intersection_kind": "Intersection",
         "movements": [
@@ -28781,6 +29088,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 266,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -28831,6 +29139,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 267,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28875,6 +29184,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 268,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28923,6 +29233,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 269,
         "intersection_kind": "Connection",
         "movements": [],
@@ -28975,6 +29286,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 270,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29031,6 +29343,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 271,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29074,6 +29390,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 272,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29130,6 +29447,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 273,
         "intersection_kind": "Connection",
         "movements": [
@@ -29172,6 +29493,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 274,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29212,6 +29534,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 275,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29252,6 +29575,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 276,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29304,6 +29628,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 277,
         "intersection_kind": "Connection",
         "movements": [],
@@ -29348,6 +29673,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 278,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29399,6 +29725,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 279,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -29443,6 +29770,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 281,
         "intersection_kind": "Fork",
         "movements": [
@@ -29491,6 +29819,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 282,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -29535,6 +29864,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 283,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29598,6 +29928,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 284,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29653,6 +29984,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 285,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29700,6 +30032,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 286,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29748,6 +30081,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 287,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29800,6 +30134,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 288,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29851,6 +30186,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 289,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29898,6 +30234,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 290,
         "intersection_kind": "Intersection",
         "movements": [
@@ -29958,6 +30295,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 291,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30022,6 +30360,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 292,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30065,6 +30407,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 293,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -30109,6 +30452,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 294,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30173,6 +30517,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 295,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30216,6 +30564,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 296,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30254,6 +30603,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 297,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -30306,6 +30656,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 298,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30361,6 +30715,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 299,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30404,6 +30762,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 300,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30444,6 +30803,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 301,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30492,6 +30852,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 302,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30540,6 +30901,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 303,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30588,6 +30950,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 304,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30632,6 +30995,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 305,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30676,6 +31040,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 306,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30724,6 +31089,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 307,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30764,6 +31130,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 308,
         "intersection_kind": "Intersection",
         "movements": [
@@ -30807,6 +31174,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 309,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -30845,6 +31213,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 310,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30901,6 +31270,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 311,
         "intersection_kind": "Connection",
         "movements": [],
@@ -30973,6 +31346,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 312,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31021,6 +31398,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 314,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31073,6 +31454,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 315,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31124,6 +31509,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 316,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31176,6 +31565,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 317,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31232,6 +31625,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 318,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31291,6 +31688,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 319,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31347,6 +31748,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 320,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31399,6 +31804,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 321,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31450,6 +31859,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 322,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31506,6 +31919,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 325,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31562,6 +31979,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 326,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31621,6 +32042,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 327,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31677,6 +32102,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 328,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31733,6 +32162,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 329,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31792,6 +32222,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 330,
         "intersection_kind": "Connection",
         "movements": [],
@@ -31876,6 +32310,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 331,
         "intersection_kind": "Intersection",
         "movements": [
@@ -31944,6 +32382,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 333,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32000,6 +32442,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 334,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32048,6 +32494,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 335,
         "intersection_kind": "Connection",
         "movements": [
@@ -32106,6 +32553,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 337,
         "intersection_kind": "Connection",
         "movements": [],
@@ -32146,6 +32597,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 338,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -32236,6 +32688,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 342,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32291,6 +32747,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 343,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32347,6 +32804,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 344,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32390,6 +32848,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 345,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -32434,6 +32893,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 346,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32493,6 +32953,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 347,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32548,6 +33009,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 348,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32613,6 +33075,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 353,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32682,6 +33145,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 356,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32741,6 +33205,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 357,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32792,6 +33257,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 358,
         "intersection_kind": "Fork",
         "movements": [
@@ -32872,6 +33338,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 359,
         "intersection_kind": "Fork",
         "movements": [
@@ -32933,6 +33400,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 361,
         "intersection_kind": "Intersection",
         "movements": [
@@ -32996,6 +33467,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 362,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33039,6 +33514,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 363,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33093,6 +33569,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 364,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33137,6 +33617,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 365,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33183,6 +33664,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 366,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33246,6 +33728,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 367,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33289,6 +33772,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 368,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -33329,6 +33813,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 369,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33383,6 +33868,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 370,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33439,6 +33928,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 371,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33482,6 +33975,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 372,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33520,6 +34014,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 373,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33574,6 +34069,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 374,
         "intersection_kind": "Intersection",
         "movements": [
@@ -33618,6 +34117,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 375,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33656,6 +34156,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 377,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33694,6 +34195,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 378,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33732,6 +34234,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 380,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -33770,6 +34273,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 381,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/seattle_slip_lane/geometry.json
+++ b/tests/src/seattle_slip_lane/geometry.json
@@ -6249,6 +6249,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6296,6 +6297,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6334,6 +6336,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6376,6 +6379,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6421,6 +6425,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6467,6 +6472,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6512,6 +6518,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6550,6 +6557,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6593,6 +6601,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6631,6 +6640,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -6681,6 +6691,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Fork",
         "movements": [
@@ -6724,6 +6735,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6782,6 +6794,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6829,6 +6842,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6889,6 +6903,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [
@@ -6931,6 +6949,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6983,6 +7002,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7023,6 +7043,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7061,6 +7082,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7103,6 +7125,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7143,6 +7166,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7181,6 +7205,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7227,6 +7252,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7267,6 +7293,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7307,6 +7334,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7359,6 +7387,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 42,
         "intersection_kind": "Connection",
         "movements": [
@@ -7402,6 +7434,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7440,6 +7473,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7492,6 +7526,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7541,6 +7576,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7601,6 +7637,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 49,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7646,6 +7686,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7692,6 +7733,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7736,6 +7778,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7792,6 +7835,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [
@@ -7834,6 +7881,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7892,6 +7940,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 56,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7935,6 +7987,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7981,6 +8034,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8021,6 +8075,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8069,6 +8124,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8133,6 +8189,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8190,6 +8247,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 62,
         "intersection_kind": "Intersection",
         "movements": [
@@ -8233,6 +8294,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8281,6 +8343,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8341,6 +8404,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "Connection",
         "movements": [
@@ -8383,6 +8447,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8421,6 +8486,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8471,6 +8537,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 70,
         "intersection_kind": "Connection",
         "movements": [
@@ -8513,6 +8583,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8561,6 +8632,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8609,6 +8681,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 73,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8665,6 +8738,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 74,
         "intersection_kind": "Connection",
         "movements": [
@@ -8707,6 +8781,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8749,6 +8824,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 77,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8789,6 +8865,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8827,6 +8904,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 80,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -8869,6 +8947,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8921,6 +9000,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "Connection",
         "movements": [],
@@ -8970,6 +9050,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9010,6 +9091,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 86,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9066,6 +9148,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 87,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9110,6 +9196,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 88,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9148,6 +9235,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9196,6 +9284,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9236,6 +9325,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 91,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9274,6 +9364,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 92,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9316,6 +9407,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9365,6 +9457,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 95,
         "intersection_kind": "Fork",
         "movements": [
@@ -9425,6 +9518,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9468,6 +9562,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9506,6 +9601,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9556,6 +9652,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 99,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9599,6 +9699,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9642,6 +9743,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9680,6 +9782,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 102,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9726,6 +9829,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 103,
         "intersection_kind": "Connection",
         "movements": [
@@ -9784,6 +9888,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 105,
         "intersection_kind": "Connection",
         "movements": [],
@@ -9824,6 +9932,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 106,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -9870,6 +9979,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 107,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9930,6 +10040,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 108,
         "intersection_kind": "Intersection",
         "movements": [
@@ -9989,6 +10100,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 109,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10040,6 +10152,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 110,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10084,6 +10197,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "Connection",
         "movements": [
@@ -10134,6 +10248,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10179,6 +10294,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 113,
         "intersection_kind": "Connection",
         "movements": [
@@ -10225,6 +10341,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10322,6 +10439,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 115,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10373,6 +10494,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 116,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10415,6 +10537,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 117,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10474,6 +10597,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 118,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10529,6 +10653,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 119,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10594,6 +10719,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 124,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10663,6 +10789,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10722,6 +10849,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 128,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10773,6 +10901,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 129,
         "intersection_kind": "Fork",
         "movements": [
@@ -10825,6 +10954,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 130,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10872,6 +11002,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 131,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -10918,6 +11049,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 132,
         "intersection_kind": "Intersection",
         "movements": [
@@ -10981,6 +11113,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 133,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11036,6 +11169,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 134,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11083,6 +11217,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 135,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11135,6 +11270,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 136,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11198,6 +11334,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 137,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11257,6 +11394,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 138,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11310,6 +11448,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 139,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11361,6 +11500,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 144,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11412,6 +11552,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 145,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11463,6 +11604,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 146,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11510,6 +11652,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 147,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11561,6 +11704,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 149,
         "intersection_kind": "Intersection",
         "movements": [
@@ -11612,6 +11756,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 151,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -11656,6 +11801,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 152,
         "intersection_kind": "Terminus",
         "movements": [],

--- a/tests/src/seattle_triangle/geometry.json
+++ b/tests/src/seattle_triangle/geometry.json
@@ -3281,6 +3281,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3331,6 +3332,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3396,6 +3398,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3460,6 +3463,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3510,6 +3514,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3556,6 +3561,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3599,6 +3605,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3637,6 +3644,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3675,6 +3683,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3713,6 +3722,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3759,6 +3769,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3807,6 +3818,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3847,6 +3859,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3885,6 +3898,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3923,6 +3937,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3969,6 +3984,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4009,6 +4025,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4047,6 +4064,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4089,6 +4107,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4129,6 +4148,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4173,6 +4193,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4225,6 +4246,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 23,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4268,6 +4293,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4308,6 +4334,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4364,6 +4391,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4407,6 +4438,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4455,6 +4487,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4495,6 +4528,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4535,6 +4569,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4575,6 +4610,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4619,6 +4655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4663,6 +4700,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4703,6 +4741,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4759,6 +4798,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 36,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4811,6 +4854,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4859,6 +4903,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4907,6 +4952,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4947,6 +4993,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4985,6 +5032,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5041,6 +5089,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 43,
         "intersection_kind": "Connection",
         "movements": [
@@ -5099,6 +5151,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 44,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5142,6 +5198,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5186,6 +5243,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5234,6 +5292,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5274,6 +5333,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5332,6 +5392,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5388,6 +5449,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 50,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5443,6 +5508,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5491,6 +5557,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 52,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5550,6 +5620,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5606,6 +5677,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [
@@ -5648,6 +5723,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5698,6 +5774,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 56,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5741,6 +5821,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5795,6 +5876,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [
@@ -5838,6 +5923,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5876,6 +5962,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 60,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5914,6 +6001,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5954,6 +6042,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5998,6 +6087,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6038,6 +6128,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6076,6 +6167,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6114,6 +6206,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6160,6 +6253,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [],

--- a/tests/src/service_road_loop/geometry.json
+++ b/tests/src/service_road_loop/geometry.json
@@ -1055,6 +1055,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1093,6 +1094,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1131,6 +1133,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1173,6 +1176,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Connection",
         "movements": [
@@ -1220,6 +1224,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Connection",
         "movements": [
@@ -1263,6 +1268,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1301,6 +1307,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1343,6 +1350,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1398,6 +1406,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1443,6 +1452,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Connection",
         "movements": [
@@ -1485,6 +1495,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Connection",
         "movements": [
@@ -1535,6 +1546,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1584,6 +1596,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1633,6 +1646,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1690,6 +1704,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Connection",
         "movements": [
@@ -1740,6 +1755,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -1787,6 +1803,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Fork",
         "movements": [
@@ -1842,6 +1859,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [
@@ -1884,6 +1902,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -1922,6 +1941,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/st_georges_cycletrack/geometry.json
+++ b/tests/src/st_georges_cycletrack/geometry.json
@@ -13047,6 +13047,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13101,6 +13102,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -13145,6 +13147,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13203,6 +13206,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Fork",
         "movements": [
@@ -13247,6 +13251,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13305,6 +13310,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Fork",
         "movements": [
@@ -13353,6 +13359,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Intersection",
         "movements": [
@@ -13417,6 +13424,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Connection",
         "movements": [
@@ -13460,6 +13468,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13498,6 +13507,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13548,6 +13558,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13600,6 +13611,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13640,6 +13652,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13686,6 +13699,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [
@@ -13729,6 +13743,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13769,6 +13784,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13813,6 +13829,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13853,6 +13870,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -13891,6 +13909,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13947,6 +13966,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Connection",
         "movements": [],
@@ -13991,6 +14011,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Connection",
         "movements": [],
@@ -14039,6 +14060,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Intersection",
         "movements": [
@@ -14083,6 +14105,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -14123,6 +14146,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14161,6 +14185,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14227,6 +14252,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Fork",
         "movements": [
@@ -14271,6 +14297,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14321,6 +14348,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Connection",
         "movements": [
@@ -14367,6 +14395,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Connection",
         "movements": [],
@@ -14407,6 +14436,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14449,6 +14479,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [
@@ -14491,6 +14522,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14537,6 +14569,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [
@@ -14587,6 +14620,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "Intersection",
         "movements": [
@@ -14634,6 +14668,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14676,6 +14711,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Intersection",
         "movements": [
@@ -14720,6 +14756,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -14772,6 +14809,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "Intersection",
         "movements": [
@@ -14821,6 +14859,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "Connection",
         "movements": [
@@ -14863,6 +14902,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14913,6 +14953,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [
@@ -14955,6 +14996,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -14993,6 +15035,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "Intersection",
         "movements": [
@@ -15040,6 +15083,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -15082,6 +15126,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Connection",
         "movements": [],
@@ -15134,6 +15179,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "Connection",
         "movements": [],
@@ -15182,6 +15228,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "Connection",
         "movements": [
@@ -15233,6 +15280,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [
@@ -15319,6 +15367,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 59,
         "intersection_kind": "Intersection",
         "movements": [
@@ -15380,6 +15432,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [
@@ -15442,6 +15498,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [
@@ -15484,6 +15544,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 62,
         "intersection_kind": "Connection",
         "movements": [
@@ -15534,6 +15595,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [
@@ -15592,6 +15654,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 64,
         "intersection_kind": "Connection",
         "movements": [
@@ -15635,6 +15701,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "Connection",
         "movements": [
@@ -15677,6 +15744,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [
@@ -15719,6 +15787,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 67,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -15759,6 +15828,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -15807,6 +15877,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 69,
         "intersection_kind": "Fork",
         "movements": [
@@ -15874,6 +15945,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Fork",
         "movements": [
@@ -15918,6 +15990,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -15964,6 +16037,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [
@@ -16011,6 +16085,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 73,
         "intersection_kind": "Connection",
         "movements": [
@@ -16062,6 +16137,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16122,6 +16198,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "Connection",
         "movements": [
@@ -16167,6 +16244,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16207,6 +16285,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16247,6 +16326,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 80,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -16297,6 +16377,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "Intersection",
         "movements": [
@@ -16344,6 +16425,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 82,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16384,6 +16466,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 83,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16432,6 +16515,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 85,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16476,6 +16560,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 86,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16516,6 +16601,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "Connection",
         "movements": [
@@ -16575,6 +16661,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 88,
         "intersection_kind": "Fork",
         "movements": [
@@ -16626,6 +16713,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "Fork",
         "movements": [
@@ -16689,6 +16777,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 90,
         "intersection_kind": "Connection",
         "movements": [
@@ -16756,6 +16845,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 91,
         "intersection_kind": "Connection",
         "movements": [
@@ -16804,6 +16894,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 92,
         "intersection_kind": "Connection",
         "movements": [],
@@ -16849,6 +16940,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 93,
         "intersection_kind": "Connection",
         "movements": [
@@ -16943,6 +17035,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 94,
         "intersection_kind": "Intersection",
         "movements": [
@@ -16996,6 +17089,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 95,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17044,6 +17138,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 96,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17092,6 +17187,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 97,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17136,6 +17232,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 98,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17176,6 +17273,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 100,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -17230,6 +17328,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 101,
         "intersection_kind": "Connection",
         "movements": [
@@ -17293,6 +17392,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 102,
         "intersection_kind": "Connection",
         "movements": [
@@ -17360,6 +17460,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 103,
         "intersection_kind": "Fork",
         "movements": [
@@ -17428,6 +17529,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 104,
         "intersection_kind": "Fork",
         "movements": [
@@ -17484,6 +17586,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 106,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17528,6 +17631,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 107,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17572,6 +17676,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 111,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17612,6 +17717,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 112,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17656,6 +17762,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 113,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17696,6 +17803,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 114,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17736,6 +17844,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 116,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -17790,6 +17899,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 117,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17830,6 +17940,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 118,
         "intersection_kind": "Connection",
         "movements": [
@@ -17872,6 +17983,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 119,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -17910,6 +18022,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 120,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -17956,6 +18069,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 121,
         "intersection_kind": "Connection",
         "movements": [],
@@ -17996,6 +18110,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 122,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18036,6 +18151,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 123,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18076,6 +18192,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 124,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18114,6 +18231,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 125,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18154,6 +18272,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 126,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18194,6 +18313,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 127,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18232,6 +18352,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 128,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18270,6 +18391,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 129,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18314,6 +18436,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 130,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18354,6 +18477,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 131,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18396,6 +18520,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 132,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18440,6 +18565,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 133,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18480,6 +18606,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 134,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18522,6 +18649,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 135,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18562,6 +18690,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 136,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18600,6 +18729,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 137,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18640,6 +18770,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 138,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18680,6 +18811,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 139,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18720,6 +18852,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 140,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -18758,6 +18891,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 141,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18798,6 +18932,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 142,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18838,6 +18973,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 143,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18878,6 +19014,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 144,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18918,6 +19055,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 145,
         "intersection_kind": "Connection",
         "movements": [],
@@ -18962,6 +19100,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 146,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19002,6 +19141,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 147,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19042,6 +19182,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 148,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19082,6 +19223,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 149,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19122,6 +19264,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 150,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19162,6 +19305,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 151,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19202,6 +19346,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 152,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19242,6 +19387,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 153,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19282,6 +19428,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 154,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19322,6 +19469,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 155,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19362,6 +19510,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 156,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19400,6 +19549,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 157,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19438,6 +19588,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 158,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19476,6 +19627,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 159,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19516,6 +19668,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 160,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -19554,6 +19707,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 161,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19594,6 +19748,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 162,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19858,6 +20013,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 163,
         "intersection_kind": "Connection",
         "movements": [],
@@ -19898,6 +20054,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 164,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20162,6 +20319,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 165,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20202,6 +20360,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 166,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20466,6 +20625,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 167,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20506,6 +20666,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 168,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20552,6 +20713,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 169,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20592,6 +20754,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 170,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20638,6 +20801,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 171,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20678,6 +20842,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 172,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20716,6 +20881,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 173,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20754,6 +20920,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 174,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20792,6 +20959,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 175,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20830,6 +20998,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 176,
         "intersection_kind": "Connection",
         "movements": [],
@@ -20870,6 +21039,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 177,
         "intersection_kind": "Connection",
         "movements": [
@@ -20912,6 +21082,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 178,
         "intersection_kind": "Connection",
         "movements": [
@@ -20954,6 +21125,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 179,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -20992,6 +21164,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 180,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21030,6 +21203,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 181,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21078,6 +21252,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 182,
         "intersection_kind": "Intersection",
         "movements": [
@@ -21125,6 +21300,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 183,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -21165,6 +21341,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 184,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21205,6 +21382,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 186,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21245,6 +21423,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 187,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21309,6 +21488,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 188,
         "intersection_kind": "Connection",
         "movements": [
@@ -21369,6 +21549,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 191,
         "intersection_kind": "Connection",
         "movements": [
@@ -21413,6 +21594,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 193,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21459,6 +21641,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 195,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21499,6 +21682,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 196,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21539,6 +21723,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 197,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21591,6 +21776,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 198,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21631,6 +21817,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 199,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21687,6 +21874,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 200,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21727,6 +21915,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 201,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21765,6 +21954,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 202,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21803,6 +21993,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 203,
         "intersection_kind": "Connection",
         "movements": [],
@@ -21863,6 +22054,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 204,
         "intersection_kind": "Connection",
         "movements": [
@@ -21906,6 +22101,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 206,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21944,6 +22140,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 207,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -21982,6 +22179,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 208,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22028,6 +22226,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 209,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22072,6 +22271,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 210,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22112,6 +22312,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 213,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22168,6 +22369,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 215,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22209,6 +22411,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 217,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22265,6 +22468,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 221,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22305,6 +22512,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 222,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22349,6 +22557,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 223,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22389,6 +22598,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 225,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22429,6 +22639,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 230,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22469,6 +22680,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 232,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22529,6 +22741,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 233,
         "intersection_kind": "Connection",
         "movements": [
@@ -22595,6 +22811,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 234,
         "intersection_kind": "Connection",
         "movements": [
@@ -22637,6 +22854,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 235,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22675,6 +22893,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 236,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22715,6 +22934,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 238,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -22753,6 +22973,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 240,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22793,6 +23014,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 241,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22833,6 +23055,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 242,
         "intersection_kind": "Connection",
         "movements": [],
@@ -22877,6 +23100,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 243,
         "intersection_kind": "Intersection",
         "movements": [
@@ -22924,6 +23148,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 244,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -22964,6 +23189,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 245,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23006,6 +23232,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 246,
         "intersection_kind": "Connection",
         "movements": [
@@ -23073,6 +23300,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 247,
         "intersection_kind": "Connection",
         "movements": [
@@ -23116,6 +23344,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 249,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23162,6 +23391,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 251,
         "intersection_kind": "Connection",
         "movements": [
@@ -23212,6 +23445,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 252,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23257,6 +23494,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 254,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23522,6 +23763,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 255,
         "intersection_kind": "Connection",
         "movements": [
@@ -23564,6 +23806,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 256,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23602,6 +23845,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 257,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23644,6 +23888,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 258,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23688,6 +23933,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 259,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23732,6 +23978,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 260,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23780,6 +24027,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 261,
         "intersection_kind": "Connection",
         "movements": [
@@ -23823,6 +24071,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 262,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -23869,6 +24118,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 263,
         "intersection_kind": "Connection",
         "movements": [
@@ -23919,6 +24169,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 264,
         "intersection_kind": "Connection",
         "movements": [],
@@ -23967,6 +24218,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 265,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24015,6 +24267,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 266,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24059,6 +24312,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 267,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24103,6 +24357,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 268,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24147,6 +24402,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 269,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24187,6 +24443,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 270,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24233,6 +24490,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 271,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24305,6 +24563,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 272,
         "intersection_kind": "Fork",
         "movements": [
@@ -24366,6 +24625,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 275,
         "intersection_kind": "Connection",
         "movements": [
@@ -24409,6 +24672,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 277,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24465,6 +24729,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 278,
         "intersection_kind": "Connection",
         "movements": [
@@ -24507,6 +24775,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 279,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24547,6 +24816,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 280,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24591,6 +24861,10 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 281,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24631,6 +24905,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 282,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24675,6 +24950,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 283,
         "intersection_kind": "Connection",
         "movements": [
@@ -24721,6 +24997,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 284,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24765,6 +25042,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 285,
         "intersection_kind": "Intersection",
         "movements": [
@@ -24809,6 +25087,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 286,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24847,6 +25126,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 287,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -24885,6 +25165,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 288,
         "intersection_kind": "Connection",
         "movements": [],
@@ -24929,6 +25210,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 289,
         "intersection_kind": "Connection",
         "movements": [
@@ -24972,6 +25254,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 290,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -25016,6 +25299,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 291,
         "intersection_kind": "Intersection",
         "movements": [
@@ -25063,6 +25347,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 292,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25113,6 +25398,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 293,
         "intersection_kind": "Connection",
         "movements": [],
@@ -25153,6 +25439,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 294,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -25191,6 +25478,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 295,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/taipei/geometry.json
+++ b/tests/src/taipei/geometry.json
@@ -4183,6 +4183,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4221,6 +4222,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4267,6 +4269,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Fork",
         "movements": [
@@ -4330,6 +4333,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4376,6 +4380,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4422,6 +4427,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Fork",
         "movements": [
@@ -4466,6 +4472,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4512,6 +4519,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Fork",
         "movements": [
@@ -4555,6 +4563,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4593,6 +4602,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4631,6 +4641,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4669,6 +4680,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Fork",
         "movements": [
@@ -4712,6 +4724,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Fork",
         "movements": [
@@ -4771,6 +4784,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4828,6 +4842,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4873,6 +4888,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4911,6 +4927,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 18,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4949,6 +4966,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4987,6 +5005,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -5029,6 +5048,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5083,6 +5103,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5127,6 +5148,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5209,6 +5231,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5266,6 +5289,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5304,6 +5328,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5342,6 +5367,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5392,6 +5418,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5437,6 +5464,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5479,6 +5507,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5535,6 +5564,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 35,
         "intersection_kind": "Connection",
         "movements": [
@@ -5577,6 +5610,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5619,6 +5653,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5675,6 +5710,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 38,
         "intersection_kind": "Connection",
         "movements": [
@@ -5721,6 +5760,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5765,6 +5805,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5821,6 +5862,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [
@@ -5863,6 +5908,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5901,6 +5947,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5947,6 +5994,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6003,6 +6051,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 45,
         "intersection_kind": "Connection",
         "movements": [
@@ -6045,6 +6097,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6083,6 +6136,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6185,6 +6239,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Intersection",
         "movements": [
@@ -6254,6 +6309,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 50,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6292,6 +6348,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6330,6 +6387,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 52,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6368,6 +6426,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6446,6 +6505,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 54,
         "intersection_kind": "Fork",
         "movements": [
@@ -6491,6 +6554,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6529,6 +6593,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6567,6 +6632,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6637,6 +6703,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Connection",
         "movements": [
@@ -6692,6 +6759,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 60,
         "intersection_kind": "Connection",
         "movements": [
@@ -6738,6 +6809,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6806,6 +6878,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 62,
         "intersection_kind": "Fork",
         "movements": [
@@ -6850,6 +6926,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -6904,6 +6981,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 64,
         "intersection_kind": "Connection",
         "movements": [
@@ -6966,6 +7047,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 65,
         "intersection_kind": "Connection",
         "movements": [
@@ -7024,6 +7109,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [
@@ -7086,6 +7175,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [
@@ -7136,6 +7229,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7212,6 +7306,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 69,
         "intersection_kind": "Connection",
         "movements": [
@@ -7271,6 +7369,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 71,
         "intersection_kind": "Connection",
         "movements": [
@@ -7329,6 +7431,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 72,
         "intersection_kind": "Connection",
         "movements": [
@@ -7403,6 +7509,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 73,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7457,6 +7567,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 75,
         "intersection_kind": "Connection",
         "movements": [],
@@ -7533,6 +7644,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 76,
         "intersection_kind": "Intersection",
         "movements": [
@@ -7578,6 +7690,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 78,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7616,6 +7729,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 79,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7670,6 +7784,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 80,
         "intersection_kind": "Connection",
         "movements": [
@@ -7712,6 +7830,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 81,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7766,6 +7885,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 83,
         "intersection_kind": "Connection",
         "movements": [
@@ -7808,6 +7931,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 84,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7846,6 +7970,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 87,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7884,6 +8009,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 88,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -7926,6 +8052,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 89,
         "intersection_kind": "Connection",
         "movements": [],

--- a/tests/src/tempe_light_rail/geometry.json
+++ b/tests/src/tempe_light_rail/geometry.json
@@ -3177,6 +3177,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3215,6 +3216,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Connection",
         "movements": [],
@@ -3255,6 +3257,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3293,6 +3296,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3387,6 +3391,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3445,6 +3450,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3483,6 +3489,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3521,6 +3528,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3564,6 +3572,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3602,6 +3611,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3645,6 +3655,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -3693,6 +3704,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3740,6 +3752,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 14,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -3784,6 +3797,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 15,
         "intersection_kind": "Fork",
         "movements": [
@@ -3832,6 +3846,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Fork",
         "movements": [
@@ -3876,6 +3891,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 17,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -3920,6 +3936,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 19,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3967,6 +3984,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 20,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -4007,6 +4025,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4045,6 +4064,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4087,6 +4107,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4143,6 +4164,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 25,
         "intersection_kind": "Connection",
         "movements": [
@@ -4201,6 +4226,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 26,
         "intersection_kind": "Connection",
         "movements": [
@@ -4255,6 +4284,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 27,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4299,6 +4329,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4350,6 +4381,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 30,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4401,6 +4433,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4448,6 +4481,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4486,6 +4520,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4532,6 +4567,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 36,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4572,6 +4611,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4610,6 +4650,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4664,6 +4705,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4704,6 +4749,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 42,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4742,6 +4788,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4788,6 +4835,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4855,6 +4903,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Fork",
         "movements": [
@@ -4900,6 +4949,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4940,6 +4990,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 47,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4986,6 +5037,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 48,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5034,6 +5086,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 49,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5089,6 +5142,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 51,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5140,6 +5194,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 53,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5196,6 +5251,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 54,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5239,6 +5295,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 55,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5277,6 +5334,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 56,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5315,6 +5373,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 57,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5369,6 +5428,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 58,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5416,6 +5476,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 59,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5471,6 +5532,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 60,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5522,6 +5587,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 61,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5578,6 +5644,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 62,
         "intersection_kind": "Intersection",
         "movements": [
@@ -5629,6 +5699,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 63,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5669,6 +5740,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 64,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5707,6 +5779,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 65,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -5761,6 +5834,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 66,
         "intersection_kind": "Connection",
         "movements": [
@@ -5815,6 +5892,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 67,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5871,6 +5952,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Unmarked"
+        },
         "id": 68,
         "intersection_kind": "Connection",
         "movements": [],
@@ -5927,6 +6012,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 69,
         "intersection_kind": "Connection",
         "movements": [
@@ -5973,6 +6062,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 70,
         "intersection_kind": "Connection",
         "movements": [],
@@ -6013,6 +6103,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 71,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/tests/src/tempe_split/geometry.json
+++ b/tests/src/tempe_split/geometry.json
@@ -2207,6 +2207,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2301,6 +2302,7 @@
       },
       "properties": {
         "control": "Signalled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -2359,6 +2361,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2397,6 +2400,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2435,6 +2439,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2473,6 +2478,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Connection",
         "movements": [
@@ -2515,6 +2521,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Connection",
         "movements": [
@@ -2557,6 +2564,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2595,6 +2603,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2633,6 +2642,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 10,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2671,6 +2681,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 11,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2709,6 +2720,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 12,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -2763,6 +2775,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 13,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2827,6 +2840,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 14,
         "intersection_kind": "Fork",
         "movements": [
@@ -2889,6 +2906,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 16,
         "intersection_kind": "Connection",
         "movements": [],
@@ -2945,6 +2963,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 17,
         "intersection_kind": "Connection",
         "movements": [
@@ -3015,6 +3037,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 18,
         "intersection_kind": "Connection",
         "movements": [
@@ -3074,6 +3100,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 20,
         "intersection_kind": "Connection",
         "movements": [
@@ -3128,6 +3158,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Signalized"
+        },
         "id": 21,
         "intersection_kind": "Connection",
         "movements": [
@@ -3174,6 +3208,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 22,
         "intersection_kind": "Fork",
         "movements": [
@@ -3230,6 +3265,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 23,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3273,6 +3309,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 24,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3311,6 +3348,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 25,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3361,6 +3399,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 26,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3408,6 +3447,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 28,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -3456,6 +3496,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 29,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3503,6 +3544,10 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": {
+          "has_island": false,
+          "kind": "Marked"
+        },
         "id": 30,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -3551,6 +3596,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 31,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3598,6 +3644,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 32,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3640,6 +3687,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 33,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3687,6 +3735,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 34,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3725,6 +3774,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 35,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3783,6 +3833,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 36,
         "intersection_kind": "Intersection",
         "movements": [
@@ -3830,6 +3881,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 37,
         "intersection_kind": "Fork",
         "movements": [
@@ -3874,6 +3926,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 38,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3912,6 +3965,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 39,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -3950,6 +4004,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 40,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4004,6 +4059,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 41,
         "intersection_kind": "Connection",
         "movements": [],
@@ -4044,6 +4100,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 43,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4082,6 +4139,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 44,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -4132,6 +4190,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 45,
         "intersection_kind": "Intersection",
         "movements": [
@@ -4175,6 +4234,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 46,
         "intersection_kind": "Connection",
         "movements": [],

--- a/tests/src/tiny_loop/geometry.json
+++ b/tests/src/tiny_loop/geometry.json
@@ -799,6 +799,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -837,6 +838,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -883,6 +885,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "Intersection",
         "movements": [
@@ -934,6 +937,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "Intersection",
         "movements": [
@@ -981,6 +985,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 4,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -1025,6 +1030,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 5,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1080,6 +1086,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 6,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1127,6 +1134,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 7,
         "intersection_kind": "Terminus",
         "movements": [],
@@ -1171,6 +1179,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 8,
         "intersection_kind": "Intersection",
         "movements": [
@@ -1226,6 +1235,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 9,
         "intersection_kind": "Intersection",
         "movements": [

--- a/tests/src/tiny_roundabout/geometry.json
+++ b/tests/src/tiny_roundabout/geometry.json
@@ -303,6 +303,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 0,
         "intersection_kind": "Fork",
         "movements": [
@@ -355,6 +356,7 @@
       },
       "properties": {
         "control": "Signed",
+        "crossing": null,
         "id": 1,
         "intersection_kind": "Fork",
         "movements": [
@@ -399,6 +401,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 2,
         "intersection_kind": "MapEdge",
         "movements": [],
@@ -437,6 +440,7 @@
       },
       "properties": {
         "control": "Uncontrolled",
+        "crossing": null,
         "id": 3,
         "intersection_kind": "MapEdge",
         "movements": [],

--- a/web/src/common/layers/RenderIntersectionMarkings.svelte
+++ b/web/src/common/layers/RenderIntersectionMarkings.svelte
@@ -22,6 +22,8 @@
         "type",
         {
           "sidewalk corner": "#CCCCCC",
+          "marked crossing line": "white",
+          "unmarked crossing outline": "white",
         },
         "red",
       ),

--- a/web/src/street-explorer/IntersectionPopup.svelte
+++ b/web/src/street-explorer/IntersectionPopup.svelte
@@ -20,6 +20,14 @@
 <p><u>Kind</u>: {props.intersection_kind}</p>
 <p><u>Control</u>: {props.control}</p>
 <p><u>Movements</u>: {props.movements}</p>
+{#if props.crossing}
+  {@const crossing = JSON.parse(props.crossing)}
+  <p>
+    <u>Crossing</u>: {crossing.kind}
+    {#if crossing.has_island}
+      (with an island){/if}
+  </p>
+{/if}
 
 <p>
   <u>OSM nodes</u>:


### PR DESCRIPTION
![image](https://github.com/a-b-street/osm2streets/assets/1664407/929e0101-0abb-4db4-b299-378f382df76d)

This PR starts a fresh attempt to handle pedestrian crossings in osm2streets. Previously, I think @BudgieInWA and I have thought about these as movements/turns across an intersection, having some influence on stop lines, etc. This new approach is much simpler, exploiting the fact that we already have separate Intersection objects that exactly correspond to a `highway=crossing` node such as https://www.openstreetmap.org/node/2819230451. So all we have to do is plumb along some per-Intersection info and render it as markings.

This approach makes sense only in the context of using separately mapped sidewalks (which is kind of the way things are going anyway). Looking at the image above, the idea of a larger "junction" that groups the big Intersection and all of the things around it starts to look a bit more clear. But going back to an old idea with Ben, let's first get the "one-to-one" OSM representation to be pretty good, then we can think about higher-level "views" on top of it.

This is a simple first step, some next steps are in #246. Comments welcome from anyone, particularly @andrewphilipsmith, @ginnyTheCat, @hungerburg (dredging up https://github.com/a-b-street/abstreet/issues/795 -- no more inferred anything!), @SupaplexOSM. (I might merge quickly so osm2streets.org is updated for convenience, but happy for feedback whenever)