### PR TITLE
Trace a large block around sidewalks and crossings only

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -251,9 +251,9 @@ impl JsStreetNetwork {
     }
 
     #[wasm_bindgen(js_name = findBlock)]
-    pub fn find_block(&self, road: usize, left: bool) -> Result<String, JsValue> {
+    pub fn find_block(&self, road: usize, left: bool, sidewalks: bool) -> Result<String, JsValue> {
         self.inner
-            .find_block(RoadID(road), left)
+            .find_block(RoadID(road), left, sidewalks)
             .map_err(err_to_js)?
             .render_polygon(&self.inner)
             .map_err(err_to_js)

--- a/web/src/street-explorer/LanePopup.svelte
+++ b/web/src/street-explorer/LanePopup.svelte
@@ -24,9 +24,9 @@
     close();
   }
 
-  function findBlock(left: boolean) {
+  function findBlock(left: boolean, sidewalks: boolean) {
     try {
-      blockGj.set(JSON.parse($network!.findBlock(props.road, left)));
+      blockGj.set(JSON.parse($network!.findBlock(props.road, left, sidewalks)));
     } catch (err) {
       window.alert(err);
     }
@@ -73,11 +73,19 @@
   <button type="button" on:click={zip}>Zip side-path</button>
 </div>
 <div>
-  <button type="button" on:click={() => findBlock(true)}
+  <button type="button" on:click={() => findBlock(true, false)}
     >Find block on left</button
   >
-  <button type="button" on:click={() => findBlock(false)}
+  <button type="button" on:click={() => findBlock(false, false)}
     >Find block on right</button
+  >
+</div>
+<div>
+  <button type="button" on:click={() => findBlock(true, true)}
+    >Trace sidewalks on left</button
+  >
+  <button type="button" on:click={() => findBlock(false, true)}
+    >Trace sidewalks on right</button
   >
 </div>
 


### PR DESCRIPTION
A simple next step towards #248 --when tracing a block, if we only consider crossings and sidewalks AND the road has sidewalks on both sides, then we wind up with a nice grouping for the "entire" junction or "entire" road including side-paths.

Here are some junctions of varying complexity:
![image](https://github.com/a-b-street/osm2streets/assets/1664407/6166c8ff-33cc-475e-99ce-9d5a8e1170a1)
![image](https://github.com/a-b-street/osm2streets/assets/1664407/e2f9a233-aba9-46ba-94ac-88f7a2dc4969)
![image](https://github.com/a-b-street/osm2streets/assets/1664407/99694c51-df78-435e-9925-004aa887f7fa)

And some roads:
![image](https://github.com/a-b-street/osm2streets/assets/1664407/62ae0df6-f966-403b-bf14-962c41b5b0a6)
![image](https://github.com/a-b-street/osm2streets/assets/1664407/613cf4d6-2869-44b5-b9d0-8efc071b10bd)

I think this approach of grouping entire "bundles" of roads or junctions could be used for various purposes:

- for od2net or other route network generation, a way to simplify the network topology either before or after the routing. CC @Robinlovelace and also see https://github.com/nptscot/networkmerge
- for producing a simpler graph for interactive routing. Sidepaths and the main road could all be grouped together, then a cost function can look at any separated cycleways. CC @tordans
- for generating movements across a complex junction or reasoning about building-to-building width. CC @sgreenbury and @andrewphilipsmith
- for rendering or inferring geometry in this library

I'll merge this so people can play with it at https://osm2streets.org. Click a sidewalk, then "Trace sidewalks on left/right" (the direction is... not always consistent, but one should work). Please do comment with any interesting test cases you find, either working or not!