### PR TITLE
More steps towards blocks and bundles

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -260,8 +260,8 @@ impl JsStreetNetwork {
     }
 
     #[wasm_bindgen(js_name = findAllBlocks)]
-    pub fn find_all_blocks(&self) -> String {
-        self.inner.find_all_blocks().unwrap()
+    pub fn find_all_blocks(&self, sidewalks: bool) -> String {
+        self.inner.find_all_blocks(sidewalks).unwrap()
     }
 }
 

--- a/osm2streets/src/render/intersection_markings.rs
+++ b/osm2streets/src/render/intersection_markings.rs
@@ -140,7 +140,7 @@ fn get_crossing_line_and_min_width(
     let mut roads = Vec::new();
     for r in &intersection.roads {
         let road = &streets.roads[r];
-        if road.lane_specs_ltr.len() == 1 && road.lane_specs_ltr[0].lt.is_walkable() {
+        if road.is_footway() {
             let endpt = center_line_pointed_at(road, intersection).last_pt();
             roads.push((road, endpt));
         }

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -220,6 +220,11 @@ impl Road {
             .any(|spec| spec.lt == LaneType::Driving)
     }
 
+    /// Is it only for walking?
+    pub fn is_footway(&self) -> bool {
+        self.lane_specs_ltr.len() == 1 && self.lane_specs_ltr[0].lt.is_walkable()
+    }
+
     pub fn oneway_for_driving(&self) -> Option<Direction> {
         LaneSpec::oneway_for_driving(&self.lane_specs_ltr)
     }

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -119,6 +119,7 @@ const layerZorder = [
   "movements",
   "connected-roads",
   "block",
+  "block-debug",
   "debug-ids",
 
   // TODO This is specific to lane-editor. Figure out how different apps can

--- a/web/src/street-explorer/LanePopup.svelte
+++ b/web/src/street-explorer/LanePopup.svelte
@@ -27,10 +27,10 @@
   function findBlock(left: boolean, sidewalks: boolean) {
     try {
       blockGj.set(JSON.parse($network!.findBlock(props.road, left, sidewalks)));
+      close();
     } catch (err) {
       window.alert(err);
     }
-    close();
   }
 </script>
 

--- a/web/src/street-explorer/LanePopup.svelte
+++ b/web/src/street-explorer/LanePopup.svelte
@@ -2,7 +2,7 @@
   import type { Polygon } from "geojson";
   import type { FeatureWithProps } from "../common/utils";
   import { network } from "../common";
-  import { blockGj } from "./stores";
+  import { blockGj, showingBundles } from "./stores";
 
   // Note the input is maplibre's GeoJSONFeature, which stringifies nested properties
   export let data: FeatureWithProps<Polygon> | undefined;
@@ -27,6 +27,7 @@
   function findBlock(left: boolean, sidewalks: boolean) {
     try {
       blockGj.set(JSON.parse($network!.findBlock(props.road, left, sidewalks)));
+      showingBundles.set(sidewalks);
       close();
     } catch (err) {
       window.alert(err);

--- a/web/src/street-explorer/RenderBlock.svelte
+++ b/web/src/street-explorer/RenderBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { caseHelper, layerId, emptyGeojson } from "../common/utils";
-  import { Popup, FillLayer, GeoJSON } from "svelte-maplibre";
+  import { Popup, LineLayer, FillLayer, GeoJSON } from "svelte-maplibre";
   import { blockGj } from "./stores";
   import { network, Legend } from "../common";
 
@@ -26,6 +26,7 @@
 <GeoJSON data={$blockGj}>
   <FillLayer
     {...layerId("block")}
+    filter={["==", ["get", "type"], "block"]}
     paint={{
       "fill-color": caseHelper("kind", colors, "red"),
       "fill-opacity": 0.8,
@@ -35,6 +36,24 @@
       <p>{data.properties.kind}</p>
     </Popup>
   </FillLayer>
+
+  <LineLayer
+    {...layerId("block-debug")}
+    filter={["!=", ["get", "type"], "block"]}
+    paint={{
+      "line-color": [
+        "case",
+        ["==", ["get", "type"], "member-road"],
+        "red",
+        "black",
+      ],
+      "line-width": 5,
+    }}
+  >
+    <Popup openOn="hover" let:data>
+      <pre>{JSON.stringify(data.properties, null, "  ")}</pre>
+    </Popup>
+  </LineLayer>
 </GeoJSON>
 
 <div>

--- a/web/src/street-explorer/RenderBlock.svelte
+++ b/web/src/street-explorer/RenderBlock.svelte
@@ -10,8 +10,8 @@
     blockGj.set(emptyGeojson());
   }
 
-  function findAll() {
-    blockGj.set(JSON.parse($network!.findAllBlocks()));
+  function findAll(sidewalks: boolean) {
+    blockGj.set(JSON.parse($network!.findAllBlocks(sidewalks)));
   }
 
   let colors = {
@@ -19,6 +19,9 @@
     RoadAndCycleLane: "orange",
     CycleLaneAndSidewalk: "yellow",
     DualCarriageway: "purple",
+    // Can reuse colors because we won't display blocks and bundles at the same time
+    RoadBundle: "green",
+    IntersectionBundle: "orange",
     Unknown: "blue",
   };
 </script>
@@ -59,7 +62,8 @@
 <div>
   Blocks
   <button on:click={clear} disabled={!active}>Clear</button>
-  <button on:click={findAll}>Find all</button>
+  <button on:click={() => findAll(false)}>Find all blocks</button>
+  <button on:click={() => findAll(true)}>Find all sidewalk bundles</button>
 </div>
 {#if active}
   <Legend rows={Object.entries(colors)} />

--- a/web/src/street-explorer/RenderBlock.svelte
+++ b/web/src/street-explorer/RenderBlock.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { caseHelper, layerId, emptyGeojson } from "../common/utils";
-  import { hoverStateFilter, Popup, LineLayer, FillLayer, GeoJSON } from "svelte-maplibre";
-  import { blockGj } from "./stores";
+  import {
+    hoverStateFilter,
+    Popup,
+    LineLayer,
+    FillLayer,
+    GeoJSON,
+  } from "svelte-maplibre";
+  import { showingBundles, blockGj } from "./stores";
   import { network, Legend } from "../common";
 
   $: active = $blockGj.features.length > 0;
@@ -12,19 +18,24 @@
 
   function findAll(sidewalks: boolean) {
     blockGj.set(JSON.parse($network!.findAllBlocks(sidewalks)));
+    showingBundles.set(sidewalks);
   }
 
-  let colors = {
+  let blockColors = {
     LandUseBlock: "grey",
     RoadAndSidewalk: "green",
     RoadAndCycleLane: "orange",
     CycleLaneAndSidewalk: "yellow",
     DualCarriageway: "purple",
-    // Can reuse colors because we won't display blocks and bundles at the same time
-    RoadBundle: "green",
-    IntersectionBundle: "orange",
     Unknown: "blue",
   };
+  let bundleColors = {
+    LandUseBlock: "grey",
+    RoadBundle: "green",
+    IntersectionBundle: "orange",
+  };
+
+  $: colors = $showingBundles ? bundleColors : blockColors;
 </script>
 
 <GeoJSON data={$blockGj} generateId>

--- a/web/src/street-explorer/RenderBlock.svelte
+++ b/web/src/street-explorer/RenderBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { caseHelper, layerId, emptyGeojson } from "../common/utils";
-  import { Popup, LineLayer, FillLayer, GeoJSON } from "svelte-maplibre";
+  import { hoverStateFilter, Popup, LineLayer, FillLayer, GeoJSON } from "svelte-maplibre";
   import { blockGj } from "./stores";
   import { network, Legend } from "../common";
 
@@ -15,6 +15,7 @@
   }
 
   let colors = {
+    LandUseBlock: "grey",
     RoadAndSidewalk: "green",
     RoadAndCycleLane: "orange",
     CycleLaneAndSidewalk: "yellow",
@@ -26,13 +27,14 @@
   };
 </script>
 
-<GeoJSON data={$blockGj}>
+<GeoJSON data={$blockGj} generateId>
   <FillLayer
     {...layerId("block")}
     filter={["==", ["get", "type"], "block"]}
+    manageHoverState
     paint={{
       "fill-color": caseHelper("kind", colors, "red"),
-      "fill-opacity": 0.8,
+      "fill-opacity": hoverStateFilter(0.8, 0.4),
     }}
   >
     <Popup openOn="hover" let:data>

--- a/web/src/street-explorer/stores.ts
+++ b/web/src/street-explorer/stores.ts
@@ -4,6 +4,8 @@ import { emptyGeojson } from "../common/utils";
 import { network } from "../common";
 
 export const blockGj: Writable<FeatureCollection> = writable(emptyGeojson());
+// Does blockGj currently represent blocks or bundles?
+export const showingBundles = writable(false);
 
 // TODO Need to unsubscribe
 // Unset when the network changes


### PR DESCRIPTION
#248. A "block" is just the space between roads and intersections; there shouldn't be other roads and intersections in there. This PR firms up the idea of a "bundle" -- either a road and its sidepaths or a junction, or just the land-use space in between roads. The classification is wrong in many cases, but it's starting to chop up things into junctions and road-bundles nicely in some cases:

(Ignore the misclassified parking lot)
![image](https://github.com/a-b-street/osm2streets/assets/1664407/6e087f1e-4670-42a5-ae5f-f11938fee51b)

Two adjacent road bundles is interesting -- that's how the dog-leg intersection shows up. All of this logic is very dependent on where the crossings are -- if they aren't everywhere, some of these ideas start to break down.
![image](https://github.com/a-b-street/osm2streets/assets/1664407/9e36754b-2bd6-4a1a-965a-2a13b0eae626)