### PR TITLE
Enable manual snapshot testing for blocks

### DIFF
--- a/tests/src/.gitignore
+++ b/tests/src/.gitignore
@@ -1,1 +1,2 @@
 */*.orig.*
+*/blocks.json


### PR DESCRIPTION
@BudgieInWA, I want to quickly detect which test cases have different output for the new block-tracing logic, so this is how I'm doing it. I'm gitignoring the files and disabling the new test for now, because I don't want to bloat the git history with a bunch of new files this early in development. But this general approach could be an example for more things, like lane markings