### PR TITLE
Improve block detection

### DIFF
--- a/osm2streets-js/src/lib.rs
+++ b/osm2streets-js/src/lib.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use osm2streets::{
-    osm, DebugStreets, Filter, IntersectionID, LaneID, MapConfig, Placement, RoadID, Sidepath,
-    StreetNetwork, Transformation,
+    osm, DebugStreets, Filter, IntersectionID, LaneID, MapConfig, Placement, RoadID, RoadSideID,
+    SideOfRoad, Sidepath, StreetNetwork, Transformation,
 };
 
 static SETUP_LOGGER: Once = Once::new();
@@ -252,7 +252,17 @@ impl JsStreetNetwork {
     #[wasm_bindgen(js_name = findBlock)]
     pub fn find_block(&self, road: usize, left: bool, sidewalks: bool) -> Result<String, JsValue> {
         self.inner
-            .find_block(RoadID(road), left, sidewalks)
+            .find_block(
+                RoadSideID {
+                    road: RoadID(road),
+                    side: if left {
+                        SideOfRoad::Left
+                    } else {
+                        SideOfRoad::Right
+                    },
+                },
+                sidewalks,
+            )
             .map_err(err_to_js)?
             .render_polygon(&self.inner)
             .map_err(err_to_js)

--- a/osm2streets/src/block.rs
+++ b/osm2streets/src/block.rs
@@ -272,15 +272,12 @@ fn classify_block(streets: &StreetNetwork, boundary: &Vec<RoadSideID>) -> BlockK
     let mut has_sidewalk = false;
 
     for road_side in boundary {
-        // TODO All of this logic is wrong. Look at the outermost lane, not the whole road.
-        let road = &streets.roads[&road_side.road];
-        if road.is_driveable() {
-            // TODO Or bus lanes?
+        let lt = road_side.get_outermost_lane(streets).lt;
+        if lt == LaneType::Driving || lt == LaneType::Bus {
             has_road = true;
-        } else if road.lane_specs_ltr.len() == 1 && road.lane_specs_ltr[0].lt == LaneType::Biking {
+        } else if lt == LaneType::Biking {
             has_cycle_lane = true;
-        } else if road.lane_specs_ltr.len() == 1 && road.lane_specs_ltr[0].lt == LaneType::Sidewalk
-        {
+        } else if lt == LaneType::Sidewalk {
             has_sidewalk = true;
         }
     }

--- a/osm2streets/src/lib.rs
+++ b/osm2streets/src/lib.rs
@@ -13,7 +13,7 @@ use self::utils::{deserialize_btreemap, serialize_btreemap};
 
 pub use self::geometry::{intersection_polygon, InputRoad};
 pub(crate) use self::ids::RoadWithEndpoints;
-pub use self::ids::{CommonEndpoint, IntersectionID, LaneID, RoadID};
+pub use self::ids::{CommonEndpoint, IntersectionID, LaneID, RoadID, RoadSideID, SideOfRoad};
 pub use self::intersection::{
     Crossing, CrossingKind, Intersection, IntersectionControl, IntersectionKind, Movement,
     TrafficConflict,

--- a/osm2streets/src/road.rs
+++ b/osm2streets/src/road.rs
@@ -562,6 +562,7 @@ pub(crate) struct RoadEdge {
     pub lane: LaneSpec,
     /// Which edge of a road? Note this is an abuse of DrivingSide; this just means the left or
     /// right side
+    // TODO Use SideofRoad
     pub _side: DrivingSide,
 }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
         }
 
         // Manually enable to do diff-testing on blocks.
-        if true {
+        if false {
             let prior_blocks = std::fs::read_to_string(format!("{path}/blocks.json"))
                 .unwrap_or_else(|_| String::new());
             std::fs::write(

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
         }
 
         // Manually enable to do diff-testing on blocks.
-        if false {
+        if true {
             let prior_blocks = std::fs::read_to_string(format!("{path}/blocks.json"))
                 .unwrap_or_else(|_| String::new());
             std::fs::write(


### PR DESCRIPTION
Some more steps towards #248. Individual blocks involving dead-end roads now mostly work, thanks to bringing in code from https://github.com/a-b-street/abstreet/blob/main/blockfinding/src/lib.rs. (Why solve problems twice?)

And then improve block classification by looking only at the lane closest to the block, not the whole road. Many cases improve.

I looked at loads of before/afters through this, but didn't take any screenshots this time.