### PR TITLE
Replace `country-geocoder` with `country-boundaries`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,14 +267,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "country-geocoder"
-version = "0.1.0"
-source = "git+https://github.com/a-b-street/country-geocoder#4a9b736340f7824f24f4e35cede1ffbceac2ec84"
-dependencies = [
- "geo",
- "geojson",
- "serde",
-]
+name = "country-boundaries"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a949524fd9d83cd48e5046cd6212c1e533477d376b82570b6c0bcc4c6775625"
 
 [[package]]
 name = "cpufeatures"
@@ -1538,9 +1534,10 @@ version = "0.1.0"
 dependencies = [
  "abstutil",
  "anyhow",
- "country-geocoder",
+ "country-boundaries",
  "geom",
  "log",
+ "muv-osm",
  "osm-reader",
  "osm2streets",
 ]

--- a/streets_reader/Cargo.toml
+++ b/streets_reader/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 [dependencies]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 anyhow = { workspace = true }
-country-geocoder = { git = "https://github.com/a-b-street/country-geocoder" }
+country-boundaries = "1.2.0"
 geom = { workspace = true }
 log = "0.4.14"
+muv-osm = { git = "https://gitlab.com/LeLuxNet/Muv", features = ["lanes"] }
 osm-reader = { git = "https://github.com/a-b-street/osm-reader" }
 osm2streets = { path = "../osm2streets" }

--- a/tests/src/frederiksted/geometry.json
+++ b/tests/src/frederiksted/geometry.json
@@ -1,5 +1,5 @@
 {
-  "country_code": "",
+  "country_code": "VI",
   "features": [
     {
       "geometry": {
@@ -4815,7 +4815,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 3,
-        "intersection_kind": "Fork",
+        "intersection_kind": "Intersection",
         "movements": [
           "Road #13 -> Road #1",
           "Road #0 -> Road #1",
@@ -4860,7 +4860,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 4,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Connection",
         "movements": [
           "Road #57 -> Road #18",
           "Road #18 -> Road #57"
@@ -4908,7 +4908,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 5,
-        "intersection_kind": "Fork",
+        "intersection_kind": "Intersection",
         "movements": [
           "Road #19 -> Road #2",
           "Road #1 -> Road #2",
@@ -5009,7 +5009,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 7,
-        "intersection_kind": "Fork",
+        "intersection_kind": "Intersection",
         "movements": [
           "Road #24 -> Road #3",
           "Road #2 -> Road #3",
@@ -5564,7 +5564,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 16,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Connection",
         "movements": [
           "Road #68 -> Road #35",
           "Road #35 -> Road #68"
@@ -7724,7 +7724,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 54,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Connection",
         "movements": [
           "Road #92 -> Road #91",
           "Road #91 -> Road #92"
@@ -7858,7 +7858,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 57,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Fork",
         "movements": [
           "Road #5 -> Road #6",
           "Road #5 -> Road #87",
@@ -7907,7 +7907,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 58,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Connection",
         "movements": [
           "Road #87 -> Road #88",
           "Road #88 -> Road #87"
@@ -7996,7 +7996,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 60,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Fork",
         "movements": [
           "Road #3 -> Road #4",
           "Road #3 -> Road #90",
@@ -8045,7 +8045,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 61,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Connection",
         "movements": [
           "Road #90 -> Road #91",
           "Road #91 -> Road #90"
@@ -8227,7 +8227,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 65,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Connection",
         "movements": [
           "Road #42 -> Road #41",
           "Road #41 -> Road #42"
@@ -8335,7 +8335,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 67,
-        "intersection_kind": "Fork",
+        "intersection_kind": "Intersection",
         "movements": [
           "Road #96 -> Road #7",
           "Road #6 -> Road #7",
@@ -8384,7 +8384,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 68,
-        "intersection_kind": "Fork",
+        "intersection_kind": "Intersection",
         "movements": [
           "Road #97 -> Road #5",
           "Road #4 -> Road #5",

--- a/tests/src/fremantle_placement/geometry.json
+++ b/tests/src/fremantle_placement/geometry.json
@@ -1,5 +1,5 @@
 {
-  "country_code": "",
+  "country_code": "AU",
   "features": [
     {
       "geometry": {
@@ -3194,7 +3194,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 8,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Fork",
         "movements": [
           "Road #12 -> Road #5",
           "Road #12 -> Road #13",
@@ -4287,7 +4287,7 @@
         "control": "Signed",
         "crossing": null,
         "id": 32,
-        "intersection_kind": "Intersection",
+        "intersection_kind": "Fork",
         "movements": [
           "Road #31 -> Road #63",
           "Road #31 -> Road #32",


### PR DESCRIPTION
Instead of relying on [`country-geocoder`](https://github.com/a-b-street/country-geocoder) to find a country code, we now use
[`country-boundaries`](https://github.com/westnordost/country-boundaries-rust/). This makes the lookup faster, but more importantly it also returns correct results for regions and countries which are not `admin_level=0`, such as Hong Kong or Macau.

`country-boundaries` does not include data on whether a country drives on the left or right, however thankfully `muv-osm` does, so we use its data instead (which is generated from `wikidata.org`).

Fixes #267 

Example: https://a-b-street.github.io/osm2streets/#18.47/22.3022565/114.0112691

Before
![image](https://github.com/user-attachments/assets/ae5b8625-75e1-4baa-bf66-72f6dca846f7)

After
![image](https://github.com/user-attachments/assets/dff5a8fc-e593-4809-b550-4ec81f19c4d0)
